### PR TITLE
Font fix for headless linux systems

### DIFF
--- a/utils/cpl_atmosphere.py
+++ b/utils/cpl_atmosphere.py
@@ -178,8 +178,6 @@ title_ha   = "left"
 title_va   = "bottom"
 title_font = 'Arial'
 
-volatile_species = [ "H2O", "CO2", "H2", "CH4", "CO", "N2", "O2", "S", "He" ]
-
 def plot_current_mixing_ratio( output_dir, times, vulcan_setting ):
 
     fig, ax1 = plt.subplots()

--- a/utils/modules_plot.py
+++ b/utils/modules_plot.py
@@ -10,6 +10,7 @@ from natsort import natsorted # https://pypi.python.org/pypi/natsort
 
 # Define Crameri colormaps (+ recursive)
 from matplotlib.colors import LinearSegmentedColormap
+import matplotlib.font_manager as fm
 
 sci_colormaps = {}
 for name in [ 'acton', 'bamako', 'batlow', 'berlin', 'bilbao', 'broc', 'buda',
@@ -345,7 +346,7 @@ class FigureData( object ):
         times=None, units='kyr' ):
         dd = {}
         self.data_d = dd
-        if times:
+        if not (times == None):
             dd['time_l'] = times
             self.process_time_list()
         if units:
@@ -419,18 +420,23 @@ class FigureData( object ):
         dd['ncols'] = ncols
         dd['width'] = width # inches
         dd['height'] = height # inches
-        # TODO: breaks for MacOSX, since I don't think Mac comes
-        # with serif font.  But whatever it decides to switch to
-        # also looks OK and LaTeX-like.
-        font_d = {'family' : 'sans-serif',
-                  #'style': 'normal',
-                  #'weight' : 'bold'
-                  'serif': ['Arial'],
-                  'sans-serif': ['Arial'],
-                  'size'   : '10'}
+
+        # Set main font properties
+        font_d = {'size':10}
+        fonts  = fm.findSystemFonts(fontpaths=None, fontext='ttf')
+        # Has arial?
+        for f in fonts:
+            if 'Arial' in f:
+                font_d["family":'sans-serif']
+                font_d['serif': ['Arial']]
+                font_d['serif': ['Arial']]
+                break
         mpl.rc('font', **font_d)
+
         # Do NOT use TeX font for labels etc.
         plt.rc('text', usetex=False)
+
+        # Other params
         dd['dpi'] = 300
         dd['extension'] = 'png'
         dd['fontsize_legend'] = 8

--- a/utils/modules_plot.py
+++ b/utils/modules_plot.py
@@ -391,7 +391,10 @@ class FigureData( object ):
     def process_time_list( self ):
         dd = self.data_d
         time_l = dd['time_l']
-        time_l = [int(time) for time in time_l.split(',')]
+        try:
+            time_l = [int(time_l)]
+        except ValueError:
+            time_l = [int(time) for time in time_l.split(',')]
         self.time = time_l
 
     def make_figure( self ):

--- a/utils/modules_plot.py
+++ b/utils/modules_plot.py
@@ -346,9 +346,14 @@ class FigureData( object ):
         times=[], units='kyr' ):
         dd = {}
         self.data_d = dd
+
+        if (type(times) == float) or (type(times) == int):
+            times = np.array([times])
+
         if len(times) > 0:
             dd['time_l'] = times
-            self.process_time_list()
+            # self.process_time_list()
+
         if units:
             dd['time_units'] = units
             dd['time_decimal_places'] = 2 # hard-coded
@@ -386,10 +391,7 @@ class FigureData( object ):
     def process_time_list( self ):
         dd = self.data_d
         time_l = dd['time_l']
-        try:
-            time_l = [int(time_l)]
-        except ValueError:
-            time_l = [int(time) for time in time_l.split(',')]
+        time_l = [int(time) for time in time_l.split(',')]
         self.time = time_l
 
     def make_figure( self ):
@@ -422,15 +424,19 @@ class FigureData( object ):
         dd['height'] = height # inches
 
         # Set main font properties
-        font_d = {'size':10}
-        fonts  = fm.findSystemFonts(fontpaths=None, fontext='ttf')
+        font_d = {
+            'size': 10.0,
+            'family': ['Arial','sans-serif']
+            }
+
+        # fonts  = fm.findSystemFonts(fontpaths=None, fontext='ttf')
         # Has arial?
-        for f in fonts:
-            if 'Arial' in f:
-                font_d["family":'sans-serif']
-                font_d['serif': ['Arial']]
-                font_d['serif': ['Arial']]
-                break
+        # for f in fonts:
+        #     if 'Arial' in f:
+        #         font_d["family"]        = 'sans-serif'
+        #         font_d['serif']         = ['Arial']
+        #         font_d['sans-serif']    = ['Arial']
+        #         break
         mpl.rc('font', **font_d)
 
         # Do NOT use TeX font for labels etc.

--- a/utils/modules_plot.py
+++ b/utils/modules_plot.py
@@ -343,10 +343,10 @@ class MyFuncFormatter( object ):
 class FigureData( object ):
 
     def __init__( self, nrows, ncols, width, height, outname='fig',
-        times=None, units='kyr' ):
+        times=[], units='kyr' ):
         dd = {}
         self.data_d = dd
-        if not (times == None):
+        if len(times) > 0:
             dd['time_l'] = times
             self.process_time_list()
         if units:

--- a/utils/modules_utils.py
+++ b/utils/modules_utils.py
@@ -10,6 +10,8 @@ import logging
 import matplotlib as mpl
 mpl.use('Agg')
 
+logging.getLogger('matplotlib.font_manager').disabled = True  # Disable font fallback logging
+
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mtick
 import numpy as np

--- a/utils/utils_spider.py
+++ b/utils/utils_spider.py
@@ -13,7 +13,7 @@ from scipy.interpolate import RectBivariateSpline, interp1d
 from scipy.integrate import odeint
 from scipy.optimize import newton
 import numpy as np
-import logging, os, sys, json
+import os, sys, json
 
 from AEOLUS.utils import phys as phys
 


### PR DESCRIPTION
Previously, PROTEUS was set up to plot using Arial only. This caused problems when running the code on systems without Arial installed, including the AOPP cluster.

I also noticed a bug in the plotting functions where the 'times' array was compared using ==, which is always consistent. A minor change to the default value of 'times' fixed this.