### PR TITLE
Fix for volatile pressure and element conservation issues

### DIFF
--- a/utils/cpl_global.py
+++ b/utils/cpl_global.py
@@ -300,7 +300,7 @@ def plot_global( output_dir ):
     ax3.yaxis.set_label_position("right")
     ax3.yaxis.set_label_coords(xcoord_r,ycoord_r)
     handles, labels = ax3.get_legend_handles_labels()
-    ax3.legend(handles, labels, ncol=2, frameon=1, fancybox=True, framealpha=0.9, fontsize=fs_legend, loc='lower right') 
+    ax3.legend(handles, labels, ncol=2, frameon=1, fancybox=True, framealpha=0.9, fontsize=fs_legend, loc='upper left') 
     ax3.set_title(title_ax3, fontname=title_font, fontsize=title_fs, x=title_x, y=title_y, ha=title_ha, va=title_va, bbox=dict(fc='white', ec="white", alpha=txt_alpha, pad=txt_pad))
     ##########
     # figure e

--- a/utils/utils_coupler.py
+++ b/utils/utils_coupler.py
@@ -838,6 +838,12 @@ def RunSPIDER( time_dict, dirs, COUPLER_options, loop_counter, runtime_helpfile 
     for vol in volatile_species:
         if COUPLER_options[vol+"_included"]:
 
+            # Set atmospheric pressure based on helpfile output
+            if loop_counter["total"] > loop_counter["init_loops"]:
+                key = vol+"_initial_atmos_pressure"
+                val = float(runtime_helpfile[vol+"_mr"].iloc[-1]) * float(runtime_helpfile["P_surf"].iloc[-1]) * 1.0e5   # convert bar to Pa
+                COUPLER_options[key] = val
+
             # Load volatiles
             if COUPLER_options["IC_ATMOSPHERE"] == 1:
                 call_sequence.extend(["-"+vol+"_initial_total_abundance", str(COUPLER_options[vol+"_initial_total_abundance"])])


### PR DESCRIPTION
Previously, the partial pressures of volatiles were being passed to SPIDER at runtime, but the values being passed were not updated based on the previous iteration. This was found to be causing issues with element conservation, and not allowing partial pressures to evolve appropriately over time.

This patch resolves #37 by updating the values of `*_init_atmos_pressure` from the most recent helpfile entry just before SPIDER is called in `RunSPIDER()`.

I have run PROTEUS with and without this patch in order to validate the changes (discussed on Discord).

This pull request also includes a very minor change to the plotting code.