### PR TITLE
Fixed installation instructions : underscore in the step 4 command

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -81,7 +81,7 @@ Download the framework
 
         $   cd SOCRATES
         $   ./configure
-        $   ./build-code
+        $   ./build_code
         $   cd ..
 
 5. Setup atmosphere model (**JANUS**)


### PR DESCRIPTION
Hi all, I noticed a small thing in the online instructions at step 4 SOCRATES:

```$ ./build-code``` does not work but the correct command is 

```$ ./build_code```

The only difference is the underscore sign _ instead of the minus sign - between 'build' and 'code'. 

I just modified the docs>source>installation.rst file to correct this.