### PR TITLE
Change project slug in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ mkdocs serve
 You can find the documentation source in the [docs](https://github.com/FormingWorlds/PROTEUS/tree/master/docs) directory.
 If you are adding new pages, make sure to update the listing in the [`mkdocs.yml`](https://github.com/FormingWorlds/PROTEUS/blob/master/mkdocs.yml) under the `nav` entry.
 
-The documentation is hosted on [readthedocs](https://readthedocs.io/projects/proteus-code).
+The documentation is hosted on [readthedocs](https://readthedocs.io/projects/fwl-proteus).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status](https://readthedocs.org/projects/proteus-code/badge/?version=latest)](https://proteus-code.readthedocs.io/en/latest/?badge=latest) 
+[![Documentation Status](https://readthedocs.org/projects/fwl-proteus/badge/?version=latest)](https://fwl-proteus.readthedocs.io/en/latest/?badge=latest) 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ![PROTEUS banner](https://raw.githubusercontent.com/FormingWorlds/PROTEUS/mkdocs/docs/images/PROTEUS_white.png#gh-light-mode-only)
@@ -11,7 +11,7 @@ of the atmospheres and interiors of rocky planets.
 
 ## Installation instructions   
 
-Click [here](https://proteus-code.readthedocs.io/en/latest/installation.html) for steps and troubleshooting advice.
+Click [here](https://fwl-proteus.readthedocs.io/en/latest/installation.html) for steps and troubleshooting advice.
 
 ## Run instructions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ nav:
   - Installation: installation.md
   - Usage: usage.md
   - Troubleshooting: troubleshooting.md
+  - MORS: https://fwl-proteus.readthedocs.io/projects/mors/
+  - JANUS: https://fwl-proteus.readthedocs.io/projects/janus/
   - Contact: contact.md
   - Contributing: CONTRIBUTING.md
   - Code of Conduct: CODE_OF_CONDUCT.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: PROTEUS
-site_url: https://proteus-code.readthedocs.io
+site_url: https://fwl-proteus.readthedocs.io
 repo_url: https://github.com/FormingWorlds/PROTEUS
 repo_name: GitHub
 


### PR DESCRIPTION
This PR changes the project slug from `proteus-code` to `fwl-proteus` in the documentation.

Addresses #122 