### PR TITLE
Set up pyproject.toml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,11 +17,9 @@ mkdocs:
 
 # Optionally declare the Python requirements required to build your docs
 python:
-  install:
-  - requirements: docs/requirements.txt
-# python:
-#    install:
-#    - method: pip
-#      path: .
-#      extra_requirements:
-#       - docs
+python:
+   install:
+   - method: pip
+     path: .
+     extra_requirements:
+      - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,32 @@
 
 ## Development
 
+*PROTEUS* targets Python 3.10 or newer.
+
+Clone the repository into the `proteus` directory:
+
+```console
+git clone https://github.com/FormingWorlds/PROTEUS proteus
+```
+
+Install using `virtualenv`:
+
+```console
+cd gemdat
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -e .[develop]
+```
+
+Alternatively, install using Conda:
+
+```console
+cd proteus
+conda create -n proteus python=3.10
+conda activate proteus
+pip install -e .[develop]
+```
+
 ### Building the documentation
 
 The documentation is written in [markdown](https://www.markdownguide.org/basic-syntax/), and uses [mkdocs](https://www.mkdocs.org/) to generate the pages.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,11 +48,7 @@ sudo apt install libnetcdff-dev
 ```console
 conda create -n proteus python=3.12   
 conda activate proteus
-conda install matplotlib numpy pandas scipy sympy natsort ipykernel pip tomlkit
-conda install conda-forge::f90nml
-conda install conda-forge::netcdf4
-conda install conda-forge::cmcrameri 
-pip install juliacall
+pip install -e .
 ```
 
 ## Download the framework

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-markdown-include
-mkdocs
-mkdocs-material
-mkdocstrings[python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,13 @@ classifiers = [
 dependencies = [
     # "fwl-janus",
     # "fwl-mors",
+    "cmcrameri",
+    "juliacall",
     "matplotlib",
     "netCDF4",
     "numpy",
     "pandas",
+    "scipy",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,63 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=61.2"]
+build-backend = "setuptools.build_meta"
 
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
-name = "lumache"
-authors = [{name = "Graziella", email = "graziella@lumache"}]
-dynamic = ["version", "description"]
+name = "PROTEUS"
+version = "24.07.25"
+description = "Coupled atmosphere-interior framework to simulate the temporal evolution of rocky planets"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+	{name = "Tim Lichtenberg", email = "tim.lichtenberg@rug.nl"},
+]
+keywords = [
+    "Astronomy",
+    "Exoplanets",
+    "Model-coupling",
+]
+license = {text = "Apache 2.0 License"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Astronomy",
+]
+dependencies = [
+    # "fwl-janus",
+    # "fwl-mors",
+    "matplotlib",
+    "netCDF4",
+    "numpy",
+    "pandas",
+]
+
+[project.urls]
+homepage = "https://github.com/FormingWorlds/PROTEUS"
+issues = "https://github.com/FormingWorlds/PROTEUS/issues"
+documentation = "https://fwl-proteus.readthedocs.io"
+changelog = "https://github.com/FormingWorlds/PROTEUS/releases"
+
+[project.optional-dependencies]
+develop = [
+    "coverage[toml]",
+    "pytest >= 8.1",
+]
+
+docs = [
+    "markdown-include",
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocstrings[python]",
+]
+
+[tool.setuptools]
+package-dir = {"proteus" = "src/proteus" }
+include-package-data = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# fwl-janus
+# fwl-mors
+matplotlib
+netCDF4
+numpy
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # fwl-janus
 # fwl-mors
+cmcrameri,
+juliacall
 matplotlib
 netCDF4
 numpy
 pandas
+scipy


### PR DESCRIPTION
This PR sets up pyproject.toml for installing the code.

The code can be installed with `pip install -e .` For the moment this just installed the dependencies.

I was tentative to add MORS/JANUS to the dependencies, because it is not clear to me yet how they can be integrated. We can pick that up at a later stage.

I also set up the boilerplate for a Python package (`src/proteus`) where we can move shared code too.

Closes #106 