### PR TITLE
Fix banner in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Documentation Status](https://readthedocs.org/projects/fwl-proteus/badge/?version=latest)](https://fwl-proteus.readthedocs.io/en/latest/?badge=latest) 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-![PROTEUS banner](https://raw.githubusercontent.com/FormingWorlds/PROTEUS/mkdocs/docs/images/PROTEUS_white.png#gh-light-mode-only)
-![PROTEUS banner](https://raw.githubusercontent.com/FormingWorlds/PROTEUS/mkdocs/docs/images/PROTEUS_black.png#gh-dark-mode-only)
+![PROTEUS banner](https://raw.githubusercontent.com/FormingWorlds/PROTEUS/master/docs/images/PROTEUS_white.png#gh-light-mode-only)
+![PROTEUS banner](https://raw.githubusercontent.com/FormingWorlds/PROTEUS/master/docs/images/PROTEUS_black.png#gh-dark-mode-only)
 
 # PROTEUS Framework for Planetary Evolution
 


### PR DESCRIPTION
This PR fixes the banner in the readme, it was still pointing to the (no longer existing) mkdocs branch.

Preview: https://github.com/FormingWorlds/PROTEUS/blob/27099c09d4873753b40dc37a2152d939a63cc097/README.md