### PR TITLE
Add integration test for PROTEUS

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: 'true'
+          submodules: 'false'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -53,6 +53,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libnetcdff-dev netcdf-bin
+
+      - name: Get SOCRATES
+        uses: actions/checkout@v4
+        with:
+          repository: 'FormingWorlds/SOCRATES'
+          path: 'SOCRATES'
 
       - uses: actions/cache@v3
         id: cache-socrates

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,56 +54,33 @@ jobs:
           python -m pip install git+https://github.com/FormingWorlds/MORS
           python -m pip install git+https://github.com/FormingWorlds/JANUS
 
-      - name: Setup system for SOCRATES/SPIDER
+      - name: Setup system for SOCRATES
         run: |
           sudo apt-get update
-          sudo apt-get install libnetcdff-dev netcdf-bin petsc-dev
+          sudo apt-get install libnetcdff-dev netcdf-bin
 
-      # - name: Get SOCRATES
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: 'FormingWorlds/SOCRATES'
-      #     path: 'SOCRATES'
-
-      # - uses: actions/cache@v3
-      #   id: cache-socrates
-      #   with:
-      #     path: |
-      #       SOCRATES/bin
-      #       SOCRATES/sbin
-      #       SOCRATES/set_rad_env
-      #     key: socrates-${{ hashFiles('SOCRATES/version') }}
-
-      # - name: Build SOCRATES
-      #   if: steps.cache-socrates.outputs.cache-hit != 'true'
-      #   run: |
-      #     export LD_LIBRARY_PATH=""
-      #     cd SOCRATES
-      #     ./configure
-      #     ./build_code
-      #     cd ..
-
-      - name: Get SPIDER
+      - name: Get SOCRATES
         uses: actions/checkout@v4
         with:
-          repository: 'djbower/SPIDER'
-          path: 'SPIDER'
+          repository: 'FormingWorlds/SOCRATES'
+          path: 'SOCRATES'
 
-      # - uses: actions/cache@v3
-      #   id: cache-spider
-      #   with:
-      #     path: |
-      #       ...
-      #     key: spider-${{ hashFiles('SPIDER/version') }}
+      - uses: actions/cache@v3
+        id: cache-socrates
+        with:
+          path: |
+            SOCRATES/bin
+            SOCRATES/sbin
+            SOCRATES/set_rad_env
+          key: socrates-${{ hashFiles('SOCRATES/version') }}
 
-      - name: Build SPIDER
-        # if: steps.cache-spider.outputs.cache-hit != 'true'
+      - name: Build SOCRATES
+        if: steps.cache-socrates.outputs.cache-hit != 'true'
         run: |
-          cd SPIDER
-          sed -i 's/clean ::/clean :/g' Makefile
-          export PETSC_DIR="/usr/lib/petsc"
-          export PETSC_ARCH="arch-linux-c-opt"
-          make -j
+          export LD_LIBRARY_PATH=""
+          cd SOCRATES
+          ./configure
+          ./build_code
           cd ..
 
       - uses: actions/cache@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,17 +86,16 @@ jobs:
 
       - name: Test with pytest
         run: |
-          source PROTEUS.env
           export FWL_DATA="/home/runner/work/fwl_data"
+
+          mors download all
+          janus download stellar
+          janus download spectral
+          janus download spectral -n Frostflow -b 48
+
           export RAD_DIR="./SOCRATES"
           export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
-
-          python -m mors download all
-          python -m janus download stellar
-          python -m janus download spectral
-          python -m janus download spectral -n Frostflow -b 48
-
-          ls $FWL_DATA
+          source PROTEUS.env
 
           coverage run -m pytest
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,10 +91,10 @@ jobs:
           export RAD_DIR="./SOCRATES"
           export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
 
-          mors download all
-          janus download stellar
-          janus download spectral
-          janus download spectral -n Frostflow -b 48
+          python -m mors download all
+          python -m janus download stellar
+          python -m janus download spectral
+          python -m janus download spectral -n Frostflow -b 48
 
           ls $FWL_DATA
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,11 @@ jobs:
           python -m pip install git+https://github.com/FormingWorlds/JANUS
           python -m pip install git+https://github.com/FormingWorlds/MORS
 
+      - name: Setup system for SOCRATES
+        run: |
+          sudo apt-get update
+          sudo apt-get install libnetcdff-dev netcdf-bin
+
       - uses: actions/cache@v3
         id: cache-socrates
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,11 @@ jobs:
       matrix:
         python-version: ['3.10']
 
+    env:
+      FWL_DATA: /home/runner/work/fwl_data
+      RAD_DIR: ./SOCRATES
+      SOCRATES: ./SOCRATES  # https://github.com/FormingWorlds/JANUS/issues/51
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -49,46 +54,44 @@ jobs:
           python -m pip install git+https://github.com/FormingWorlds/MORS
           python -m pip install git+https://github.com/FormingWorlds/JANUS
 
-      # - name: Setup system for SOCRATES
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install libnetcdff-dev netcdf-bin
+      - name: Setup system for SOCRATES
+        run: |
+          sudo apt-get update
+          sudo apt-get install libnetcdff-dev netcdf-bin
 
-      # - name: Get SOCRATES
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: 'FormingWorlds/SOCRATES'
-      #     path: 'SOCRATES'
+      - name: Get SOCRATES
+        uses: actions/checkout@v4
+        with:
+          repository: 'FormingWorlds/SOCRATES'
+          path: 'SOCRATES'
 
-      # - uses: actions/cache@v3
-      #   id: cache-socrates
-      #   with:
-      #     path: |
-      #       SOCRATES/bin
-      #       SOCRATES/sbin
-      #       SOCRATES/set_rad_env
-      #     key: socrates-${{ hashFiles('SOCRATES/version') }}
+      - uses: actions/cache@v3
+        id: cache-socrates
+        with:
+          path: |
+            SOCRATES/bin
+            SOCRATES/sbin
+            SOCRATES/set_rad_env
+          key: socrates-${{ hashFiles('SOCRATES/version') }}
 
-      # - name: Build SOCRATES
-      #   if: steps.cache-socrates.outputs.cache-hit != 'true'
-      #   run: |
-      #     export LD_LIBRARY_PATH=""
-      #     cd SOCRATES
-      #     ./configure
-      #     ./build_code
-      #     cd ..
+      - name: Build SOCRATES
+        if: steps.cache-socrates.outputs.cache-hit != 'true'
+        run: |
+          export LD_LIBRARY_PATH=""
+          cd SOCRATES
+          ./configure
+          ./build_code
+          cd ..
 
       - uses: actions/cache@v3
         id: cache-fwl-data
         with:
-          path: /home/runner/work/fwl_data
+          path: $FWL_DATA
           key: fwl-data-2
 
       - name: Install dependencies
         if: steps.cache-fwl-data.cache-hit != 'true'
         run: |
-          export FWL_DATA="/home/runner/work/fwl_data"
-
           mors download all
           janus download stellar
           janus download spectral
@@ -96,11 +99,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          export FWL_DATA="/home/runner/work/fwl_data"
-          export RAD_DIR="./SOCRATES"
-          export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
           source PROTEUS.env
-
           coverage run -m pytest
 
       - name: Report coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,29 @@ jobs:
         run: |
           python -m pip install -e .[develop]
 
+      - name: Install JANUS+MORS
+        run: |
+          python -m pip install git+https://github.com/FormingWorlds/JANUS
+          python -m pip install git+https://github.com/FormingWorlds/MORS
+
+      - uses: actions/cache@v3
+        id: cache-socrates
+        with:
+          path: |
+            SOCRATES/bin
+            SOCRATES/sbin
+            SOCRATES/set_rad_env
+          key: socrates-${{ hashFiles('SOCRATES/version') }}
+
+      - name: Build SOCRATES
+        if: steps.cache-socrates.outputs.cache-hit != 'true'
+        run: |
+          export LD_LIBRARY_PATH=""
+          cd SOCRATES
+          ./configure
+          ./build_code
+          cd ..
+
       - uses: actions/cache@v3
         id: cache-fwl-data
         with:
@@ -55,6 +78,7 @@ jobs:
           source PROTEUS.env
           export FWL_DATA="/home/runner/work/fwl_data"
           export RAD_DIR="./SOCRATES"
+          export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
           coverage run -m pytest
 
       - name: Report coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Install JANUS+MORS
         run: |
-          python -m pip install git+https://github.com/FormingWorlds/JANUS
           python -m pip install git+https://github.com/FormingWorlds/MORS
+          python -m pip install git+https://github.com/FormingWorlds/JANUS
 
       # - name: Setup system for SOCRATES
       #   run: |
@@ -78,14 +78,11 @@ jobs:
       #     ./build_code
       #     cd ..
 
-      - name: Sanity check
-        run: which mors
-
       - uses: actions/cache@v3
         id: cache-fwl-data
         with:
           path: /home/runner/work/fwl_data
-          key: fwl-data-1
+          key: fwl-data-2
 
       - name: Install dependencies
         if: steps.cache-fwl-data.cache-hit != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,6 +84,8 @@ jobs:
           export FWL_DATA="/home/runner/work/fwl_data"
           export RAD_DIR="./SOCRATES"
           export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
+
+          janus download spectral -n Frostflow -b 48
           coverage run -m pytest
 
       - name: Report coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,6 +100,7 @@ jobs:
         # if: steps.cache-spider.outputs.cache-hit != 'true'
         run: |
           cd SPIDER
+          sed -i 's/clean ::/clean :/g' Makefile
           export PETSC_DIR="/usr/lib/petsc"
           export PETSC_ARCH="arch-linux-c-opt"
           make -j

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,10 +86,10 @@ jobs:
       - uses: actions/cache@v3
         id: cache-fwl-data
         with:
-          path: $FWL_DATA
+          path: ${{ env.FWL_DATA }}
           key: fwl-data-2
 
-      - name: Install dependencies
+      - name: Pre-download fwl data
         if: steps.cache-fwl-data.cache-hit != 'true'
         run: |
           mors download all

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,34 +49,37 @@ jobs:
           python -m pip install git+https://github.com/FormingWorlds/JANUS
           python -m pip install git+https://github.com/FormingWorlds/MORS
 
-      - name: Setup system for SOCRATES
-        run: |
-          sudo apt-get update
-          sudo apt-get install libnetcdff-dev netcdf-bin
+      # - name: Setup system for SOCRATES
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install libnetcdff-dev netcdf-bin
 
-      - name: Get SOCRATES
-        uses: actions/checkout@v4
-        with:
-          repository: 'FormingWorlds/SOCRATES'
-          path: 'SOCRATES'
+      # - name: Get SOCRATES
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: 'FormingWorlds/SOCRATES'
+      #     path: 'SOCRATES'
 
-      - uses: actions/cache@v3
-        id: cache-socrates
-        with:
-          path: |
-            SOCRATES/bin
-            SOCRATES/sbin
-            SOCRATES/set_rad_env
-          key: socrates-${{ hashFiles('SOCRATES/version') }}
+      # - uses: actions/cache@v3
+      #   id: cache-socrates
+      #   with:
+      #     path: |
+      #       SOCRATES/bin
+      #       SOCRATES/sbin
+      #       SOCRATES/set_rad_env
+      #     key: socrates-${{ hashFiles('SOCRATES/version') }}
 
-      - name: Build SOCRATES
-        if: steps.cache-socrates.outputs.cache-hit != 'true'
-        run: |
-          export LD_LIBRARY_PATH=""
-          cd SOCRATES
-          ./configure
-          ./build_code
-          cd ..
+      # - name: Build SOCRATES
+      #   if: steps.cache-socrates.outputs.cache-hit != 'true'
+      #   run: |
+      #     export LD_LIBRARY_PATH=""
+      #     cd SOCRATES
+      #     ./configure
+      #     ./build_code
+      #     cd ..
+
+      - name: Sanity check
+        run: which mors
 
       - uses: actions/cache@v3
         id: cache-fwl-data
@@ -84,7 +87,8 @@ jobs:
           path: /home/runner/work/fwl_data
           key: fwl-data-1
 
-      - name: Test with pytest
+      - name: Install dependencies
+        if: steps.cache-fwl-data.cache-hit != 'true'
         run: |
           export FWL_DATA="/home/runner/work/fwl_data"
 
@@ -93,6 +97,9 @@ jobs:
           janus download spectral
           janus download spectral -n Frostflow -b 48
 
+      - name: Test with pytest
+        run: |
+          export FWL_DATA="/home/runner/work/fwl_data"
           export RAD_DIR="./SOCRATES"
           export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
           source PROTEUS.env

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,7 +100,7 @@ jobs:
         # if: steps.cache-spider.outputs.cache-hit != 'true'
         run: |
           cd SPIDER
-          export PETSC_DIR="/usr/lib/petscdir"
+          export PETSC_DIR="/usr/lib/petsc"
           export PETSC_ARCH="arch-linux-c-opt"
           make -j
           cd ..

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,13 @@ jobs:
           export RAD_DIR="./SOCRATES"
           export SOCRATES="./SOCRATES"  # https://github.com/FormingWorlds/JANUS/issues/51
 
+          mors download all
+          janus download stellar
+          janus download spectral
           janus download spectral -n Frostflow -b 48
+
+          ls $FWL_DATA
+
           coverage run -m pytest
 
       - name: Report coverage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,40 +54,54 @@ jobs:
           python -m pip install git+https://github.com/FormingWorlds/MORS
           python -m pip install git+https://github.com/FormingWorlds/JANUS
 
-      - name: Setup system for SOCRATES
+      - name: Setup system for SOCRATES/SPIDER
         run: |
           sudo apt-get update
-          sudo apt-get install libnetcdff-dev netcdf-bin
+          sudo apt-get install libnetcdff-dev netcdf-bin petsc-dev
 
-      - name: Get SOCRATES
-        uses: actions/checkout@v4
-        with:
-          repository: 'FormingWorlds/SOCRATES'
-          path: 'SOCRATES'
+      # - name: Get SOCRATES
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: 'FormingWorlds/SOCRATES'
+      #     path: 'SOCRATES'
 
-      - uses: actions/cache@v3
-        id: cache-socrates
-        with:
-          path: |
-            SOCRATES/bin
-            SOCRATES/sbin
-            SOCRATES/set_rad_env
-          key: socrates-${{ hashFiles('SOCRATES/version') }}
+      # - uses: actions/cache@v3
+      #   id: cache-socrates
+      #   with:
+      #     path: |
+      #       SOCRATES/bin
+      #       SOCRATES/sbin
+      #       SOCRATES/set_rad_env
+      #     key: socrates-${{ hashFiles('SOCRATES/version') }}
 
-      - name: Build SOCRATES
-        if: steps.cache-socrates.outputs.cache-hit != 'true'
-        run: |
-          export LD_LIBRARY_PATH=""
-          cd SOCRATES
-          ./configure
-          ./build_code
-          cd ..
+      # - name: Build SOCRATES
+      #   if: steps.cache-socrates.outputs.cache-hit != 'true'
+      #   run: |
+      #     export LD_LIBRARY_PATH=""
+      #     cd SOCRATES
+      #     ./configure
+      #     ./build_code
+      #     cd ..
 
       - name: Get SPIDER
         uses: actions/checkout@v4
         with:
           repository: 'djbower/SPIDER'
           path: 'SPIDER'
+
+      # - uses: actions/cache@v3
+      #   id: cache-spider
+      #   with:
+      #     path: |
+      #       ...
+      #     key: spider-${{ hashFiles('SPIDER/version') }}
+
+      - name: Build SPIDER
+        # if: steps.cache-spider.outputs.cache-hit != 'true'
+        run: |
+          cd SPIDER
+          make -j
+          cd ..
 
       - uses: actions/cache@v3
         id: cache-fwl-data

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,6 +100,8 @@ jobs:
         # if: steps.cache-spider.outputs.cache-hit != 'true'
         run: |
           cd SPIDER
+          export PETSC_DIR="/usr/lib/petscdir"
+          export PETSC_ARCH="arch-linux-c-opt"
           make -j
           cd ..
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,6 +83,12 @@ jobs:
           ./build_code
           cd ..
 
+      - name: Get SPIDER
+        uses: actions/checkout@v4
+        with:
+          repository: 'djbower/SPIDER'
+          path: 'SPIDER'
+
       - uses: actions/cache@v3
         id: cache-fwl-data
         with:

--- a/src/proteus/utils/plot.py
+++ b/src/proteus/utils/plot.py
@@ -302,7 +302,7 @@ class FigureData( object ):
         # Set main font properties
         font_d = {
             'size': 10.0,
-            'family': ['Arial','sans-serif']
+            'family': ['sans-serif']
             }
 
         # fonts  = fm.findSystemFonts(fontpaths=None, fontext='ttf')

--- a/tests/integration/test_proteus_start.py
+++ b/tests/integration/test_proteus_start.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from helpers import PROTEUS_ROOT
+
+from proteus import Proteus
+
+
+def test_dummy_run():
+    config_path = PROTEUS_ROOT / 'input' / 'dummy.toml'
+
+    runner = Proteus(config_path=config_path)
+
+    runner.config['log_level'] = 'WARNING'
+    runner.config['plot_iterfreq'] = 0
+    runner.config['iter_max'] = 0
+
+    runner.start()
+
+    output = Path(runner.directories['output'])
+
+    assert 'Completed' in (output / 'status').read_text()

--- a/tests/integration/test_proteus_start.py
+++ b/tests/integration/test_proteus_start.py
@@ -9,7 +9,7 @@ from helpers import PROTEUS_ROOT
 from proteus import Proteus
 
 if os.getenv('CI'):
-    pytest.skip(reason='No way of currently testing this on the CI.')
+    pytest.skip(reason='No way of currently testing this on the CI.', allow_module_level=True)
 
 
 def test_dummy_run():

--- a/tests/integration/test_proteus_start.py
+++ b/tests/integration/test_proteus_start.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
+import pytest
 from helpers import PROTEUS_ROOT
 
 from proteus import Proteus
+
+if os.getenv('CI'):
+    pytest.skip(reason='No way of currently testing this on the CI.')
 
 
 def test_dummy_run():

--- a/tests/integration/test_proteus_start.py
+++ b/tests/integration/test_proteus_start.py
@@ -9,6 +9,7 @@ from helpers import PROTEUS_ROOT
 from proteus import Proteus
 
 if os.getenv('CI'):
+    # https://github.com/FormingWorlds/PROTEUS/pull/149
     pytest.skip(reason='No way of currently testing this on the CI.', allow_module_level=True)
 
 


### PR DESCRIPTION
This PR adds an integration test for PROTEUS using the dummy config. This bumps the coverage to about 60%. It takes about 40 seconds on my PC.

I tried the default config (with JANUS), but this is extremely slow (over 6 min) even with `max_iter=0`. I think it would be better to test this module and others separately, or once we have a better way to control the number of iterations.

### TODO
- [x] Fix CI workflow