### PR TITLE
MacOS tests and standalone setup

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    # if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     name: Run Coverage and Tests
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,9 +60,9 @@ jobs:
         if: steps.cache-fwl-data.cache-hit != 'true'
         run: |
           mors download all
-          janus download stellar
-          janus download spectral
-          janus download spectral -n Frostflow -b 48
+          proteus get stellar
+          proteus get spectral
+          proteus get spectral -n Frostflow -b 48
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install dependencies
-        if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+        # if: steps.cache-virtualenv.outputs.cache-hit != 'true'
         run: |
           python -m pip install -e .[develop]
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Pre-download fwl data
         if: steps.cache-fwl-data.cache-hit != 'true'
         run: |
-          mors download all
           proteus get stellar
           proteus get spectral
           proteus get spectral -n Frostflow -b 48

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
+    # if: github.event.pull_request.draft == false
     name: Run Coverage and Tests
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,35 +49,6 @@ jobs:
         run: |
           python -m pip install -e .[develop]
 
-      - name: Setup system for SOCRATES
-        run: |
-          sudo apt-get update
-          sudo apt-get install libnetcdff-dev netcdf-bin
-
-      - name: Get SOCRATES
-        uses: actions/checkout@v4
-        with:
-          repository: 'nichollsh/SOCRATES'
-          path: 'SOCRATES'
-
-      - uses: actions/cache@v4
-        id: cache-socrates
-        with:
-          path: |
-            SOCRATES/bin
-            SOCRATES/sbin
-            SOCRATES/set_rad_env
-          key: socrates-${{ hashFiles('SOCRATES/version') }}
-
-      - name: Build SOCRATES
-        if: steps.cache-socrates.outputs.cache-hit != 'true'
-        run: |
-          export LD_LIBRARY_PATH=""
-          cd SOCRATES
-          ./configure
-          ./build_code
-          cd ..
-
       - uses: actions/cache@v4
         id: cache-fwl-data
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,9 @@ jobs:
   test:
     if: github.event.pull_request.draft == false
     name: Run Coverage and Tests
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.10', '3.12']
 
     env:
@@ -28,8 +28,9 @@ jobs:
       RAD_DIR: ./SOCRATES
       SOCRATES: ./SOCRATES  # https://github.com/FormingWorlds/JANUS/issues/51
 
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'false'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: ['3.10', '3.12']
 
     env:
-      FWL_DATA: /home/runner/work/fwl_data
+      FWL_DATA: $HOME/work/fwl_data
       RAD_DIR: ./SOCRATES
       SOCRATES: ./SOCRATES  # https://github.com/FormingWorlds/JANUS/issues/51
 

--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -1,0 +1,48 @@
+# Common atmosphere climate model functions
+from __future__ import annotations
+
+import netCDF4 as nc
+import numpy as np
+import os
+
+def read_ncdf_profile(nc_fpath:str):
+    # open file
+    ds = nc.Dataset(nc_fpath)
+
+    p = np.array(ds.variables["p"][:])
+    pl = np.array(ds.variables["pl"][:])
+
+    t = np.array(ds.variables["tmp"][:])
+    tl = np.array(ds.variables["tmpl"][:])
+
+    z = np.array(ds.variables["z"][:])
+    zl = np.array(ds.variables["zl"][:])
+
+    nlev = len(p)
+
+    # read pressure, temperature, height data into dictionary values
+    out = {}
+    out["p"] = [pl[0]]
+    out["t"] = [tl[0]]
+    out["z"] = [zl[0]]
+    for i in range(nlev):
+        out["p"].append(p[i])
+        out["p"].append(pl[i+1])
+
+        out["t"].append(t[i])
+        out["t"].append(tl[i+1])
+
+        out["z"].append(z[i])
+        out["z"].append(zl[i+1])
+
+    # close file
+    ds.close()
+
+    # convert to np arrays
+    for k in out.keys():
+        out[k] = np.array(out[k], dtype=float)
+
+    return out
+
+def read_ncdfs(output_dir:str, times:list):
+    return [read_ncdf_profile(os.path.join(output_dir, "data", "%d_atm.nc"%t)) for t in times]

--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -1,9 +1,11 @@
 # Common atmosphere climate model functions
 from __future__ import annotations
 
+import os
+
 import netCDF4 as nc
 import numpy as np
-import os
+
 
 def read_ncdf_profile(nc_fpath:str):
     # open file

--- a/src/proteus/atmos_clim/janus.py
+++ b/src/proteus/atmos_clim/janus.py
@@ -7,7 +7,6 @@ import os
 import shutil
 
 import janus.set_socrates_env  # noqa
-import netCDF4 as nc
 import numpy as np
 import pandas as pd
 
@@ -15,48 +14,6 @@ from proteus.utils.constants import volatile_species
 from proteus.utils.helper import UpdateStatusfile, create_tmp_folder, find_nearest
 
 log = logging.getLogger("fwl."+__name__)
-
-def read_ncdf_profile(nc_fpath:str):
-    # open file
-    ds = nc.Dataset(nc_fpath)
-
-    p = np.array(ds.variables["p"][:])
-    pl = np.array(ds.variables["pl"][:])
-
-    t = np.array(ds.variables["tmp"][:])
-    tl = np.array(ds.variables["tmpl"][:])
-
-    z = np.array(ds.variables["z"][:])
-    zl = np.array(ds.variables["zl"][:])
-
-    nlev = len(p)
-
-    # read pressure, temperature, height data into dictionary values
-    out = {}
-    out["p"] = [pl[0]]
-    out["t"] = [tl[0]]
-    out["z"] = [zl[0]]
-    for i in range(nlev):
-        out["p"].append(p[i])
-        out["p"].append(pl[i+1])
-
-        out["t"].append(t[i])
-        out["t"].append(tl[i+1])
-
-        out["z"].append(z[i])
-        out["z"].append(zl[i+1])
-
-    # close file
-    ds.close()
-
-    # convert to np arrays
-    for k in out.keys():
-        out[k] = np.array(out[k], dtype=float)
-
-    return out
-
-def read_ncdfs(output_dir:str, times:list):
-    return [read_ncdf_profile(os.path.join(output_dir, "data", "%d_atm.nc"%t)) for t in times]
 
 def InitStellarSpectrum(dirs:dict, wl:list, fl:list, spectral_file_nostar):
 

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -6,6 +6,7 @@ import os
 
 import pandas as pd
 from scipy.integrate import solve_ivp
+
 from proteus.utils.helper import PrintHalfSeparator, UpdateStatusfile, safe_rm
 
 atm = None

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -6,16 +6,6 @@ import os
 
 import pandas as pd
 from scipy.integrate import solve_ivp
-
-from proteus.atmos_clim.agni import (
-    activate_julia,
-    deallocate_atmos,
-    init_agni_atmos,
-    run_agni,
-    update_agni_atmos,
-)
-from proteus.atmos_clim.dummy import RunDummyAtm
-from proteus.atmos_clim.janus import InitAtm, InitStellarSpectrum, RunJANUS
 from proteus.utils.helper import PrintHalfSeparator, UpdateStatusfile, safe_rm
 
 atm = None
@@ -58,8 +48,10 @@ def RunAtmosphere(OPTIONS:dict, dirs:dict, loop_counter:dict,
         hf_row["T_surf"] = ShallowMixedOceanLayer(hf_all.iloc[-1].to_dict(), hf_row)
 
     if OPTIONS["atmosphere_model"] == 0:
-        # Run JANUS:
+        # Import
+        from proteus.atmos_clim.janus import InitAtm, InitStellarSpectrum, RunJANUS
 
+        # Run JANUS
         no_atm = bool(atm is None)
         #Enforce surface temperature at first iteration
         if no_atm:
@@ -77,8 +69,16 @@ def RunAtmosphere(OPTIONS:dict, dirs:dict, loop_counter:dict,
         atm_output = RunJANUS(atm, dirs, OPTIONS, hf_row, hf_all)
 
     elif OPTIONS["atmosphere_model"] == 1:
-        # Run AGNI
+        # Import
+        from proteus.atmos_clim.agni import (
+            activate_julia,
+            deallocate_atmos,
+            init_agni_atmos,
+            run_agni,
+            update_agni_atmos,
+        )
 
+        # Run AGNI
         # Initialise atmosphere struct
         spfile_path = os.path.join(dirs["output"] , "runtime.sf")
         no_atm = bool(atm is None)
@@ -114,6 +114,9 @@ def RunAtmosphere(OPTIONS:dict, dirs:dict, loop_counter:dict,
         atm, atm_output = run_agni(atm, loop_counter["total"], dirs, OPTIONS, hf_row)
 
     elif OPTIONS["atmosphere_model"] == 2:
+        # Import
+        from proteus.atmos_clim.dummy import RunDummyAtm
+
         # Run dummy atmosphere model
         atm_output = RunDummyAtm(dirs, OPTIONS, hf_row["T_magma"], hf_row["F_ins"],
                                     hf_row["R_planet"], hf_row["M_planet"])

--- a/src/proteus/cli.py
+++ b/src/proteus/cli.py
@@ -79,5 +79,64 @@ cli.add_command(plot)
 cli.add_command(start)
 
 
+@click.group()
+def get():
+    """Get data and modules"""
+    pass
+
+
+@click.command()
+@click.option('-n', '--name', 'fname', type=str, help='Name of the spectra')
+@click.option('-b', '--band', 'nband', type=int, help='Number of the band', default=256)
+def spectral(**kwargs):
+    """Get spectral files
+
+    By default, download all files.
+    """
+    from .utils.data import download_spectral_files
+    download_spectral_files(**kwargs)
+
+
+@click.command()
+def stellar():
+    """Get stellar spectra"""
+    from .utils.data import download_evolution_tracks, download_stellar_spectra
+
+    for track in ["Spada","Baraffe"]:
+        download_evolution_tracks(track)
+    download_stellar_spectra()
+
+@click.command()
+def surfaces():
+    """Get surface albedos"""
+    from .utils.data import download_surface_albedos
+    download_surface_albedos()
+
+
+@click.command()
+def socrates():
+    """Set up SOCRATES"""
+    from .utils.data import get_socrates
+    get_socrates()
+
+@click.command()
+def petsc():
+    """Set up PETSc"""
+    from .utils.data import get_petsc
+    get_petsc()
+
+@click.command()
+def spider():
+    """Set up SPIDER"""
+    from .utils.data import get_spider
+    get_spider()
+
+cli.add_command(get)
+get.add_command(spectral)
+get.add_command(stellar)
+get.add_command(socrates)
+get.add_command(petsc)
+get.add_command(spider)
+
 if __name__ == '__main__':
     cli()

--- a/src/proteus/plot/cpl_atmosphere.py
+++ b/src/proteus/plot/cpl_atmosphere.py
@@ -10,7 +10,7 @@ import numpy as np
 from cmcrameri import cm
 from matplotlib.ticker import LogLocator
 
-from proteus.atmos_clim.janus import read_ncdfs
+from proteus.atmos_clim.common import read_ncdfs
 from proteus.utils.plot import latex_float, sample_output
 
 if TYPE_CHECKING:

--- a/src/proteus/plot/cpl_atmosphere_cbar.py
+++ b/src/proteus/plot/cpl_atmosphere_cbar.py
@@ -12,7 +12,7 @@ from cmcrameri import cm
 from matplotlib.ticker import LogLocator, MultipleLocator
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from proteus.atmos_clim.janus import read_ncdf_profile
+from proteus.atmos_clim.common import read_ncdf_profile
 
 if TYPE_CHECKING:
     from proteus import Proteus

--- a/src/proteus/plot/cpl_stacked.py
+++ b/src/proteus/plot/cpl_stacked.py
@@ -11,7 +11,7 @@ import numpy as np
 from cmcrameri import cm
 from matplotlib.ticker import MultipleLocator
 
-from proteus.atmos_clim.janus import read_ncdfs
+from proteus.atmos_clim.common import read_ncdfs
 from proteus.interior.spider import read_jsons
 from proteus.utils.plot import dict_colors, latex_float, sample_times
 

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from proteus.atmos_clim.janus import read_ncdfs
+from proteus.atmos_clim.common import read_ncdfs
 from proteus.interior.spider import read_jsons
 from proteus.plot.cpl_atmosphere import plot_atmosphere
 from proteus.plot.cpl_elements import plot_elements

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -33,7 +33,7 @@ from proteus.utils.constants import (
     element_list,
     volatile_species,
 )
-from proteus.utils.helper import UpdateStatusfile, safe_rm
+from proteus.utils.helper import UpdateStatusfile, safe_rm, get_proteus_dir
 from proteus.utils.plot import sample_times
 
 log = logging.getLogger("fwl."+__name__)
@@ -387,9 +387,7 @@ def SetDirectories(OPTIONS: dict):
             Dictionary of paths to important directories
     """
 
-    if os.environ.get('PROTEUS_DIR') is None:
-        raise Exception("Environment variables not set! Have you sourced PROTEUS.env?")
-    proteus_dir = os.path.abspath(os.getenv('PROTEUS_DIR'))
+    proteus_dir = get_proteus_dir()
     proteus_src = os.path.join(proteus_dir,"src","proteus")
 
     # PROTEUS folders
@@ -401,7 +399,7 @@ def SetDirectories(OPTIONS: dict):
             "vulcan":   os.path.join(proteus_dir,"VULCAN"),
             "spider":   os.path.join(proteus_dir,"SPIDER"),
             "utils":    os.path.join(proteus_src,"utils"),
-            "tools":    os.path.join(proteus_src,"tools"),
+            "tools":    os.path.join(proteus_dir,"tools"),
             }
 
     # FWL data folder

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -33,7 +33,7 @@ from proteus.utils.constants import (
     element_list,
     volatile_species,
 )
-from proteus.utils.helper import UpdateStatusfile, safe_rm, get_proteus_dir
+from proteus.utils.helper import UpdateStatusfile, get_proteus_dir, safe_rm
 from proteus.utils.plot import sample_times
 
 log = logging.getLogger("fwl."+__name__)

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -41,18 +41,23 @@ def GetFWLData() -> Path:
     """
     return Path(FWL_DATA_DIR).absolute()
 
+def get_osf(id:str):
+    """
+    Generate an object to access OSF storage
+    """
+    osf = OSF()
+    project = osf.project(id)
+    return project.storage('osfstorage')
+
+
 def download_surface_albedos():
     """
     Download surface optical properties
     """
     log.debug("Get surface albedos")
-    project_id = '2gcd9'
+    storage = get_osf('2gcd9')
+
     folder_name = 'Hammond24'
-
-    osf = OSF()
-    project = osf.project(project_id)
-    storage = project.storage('osfstorage')
-
     data_dir = GetFWLData() / "surface_albedos"
     data_dir.mkdir(parents=True, exist_ok=True)
 
@@ -72,17 +77,13 @@ def download_spectral_files(fname: str="", nband: int=256):
     """
     log.debug("Get spectral files")
 
-    #project ID of the spectral files on OSF
-    project_id = 'vehxg'
 
     #Create spectral file data repository if not existing
     data_dir = GetFWLData() / "spectral_files"
     data_dir.mkdir(parents=True, exist_ok=True)
 
     #Link with OSF project repository
-    osf = OSF()
-    project = osf.project(project_id)
-    storage = project.storage('osfstorage')
+    storage = get_osf('vehxg')
 
     basic_list = (
         "Dayspring/48"
@@ -114,13 +115,8 @@ def download_stellar_spectra():
     """
     log.debug("Get stellar spectra")
 
-    #project ID of the stellar spectra on OSF
-    project_id = '8r2sw'
     folder_name = 'Named'
-
-    osf = OSF()
-    project = osf.project(project_id)
-    storage = project.storage('osfstorage')
+    storage = get_osf('8r2sw')
 
     data_dir = GetFWLData() / "stellar_spectra"
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -60,21 +60,75 @@ def download_surface_albedos():
         log.info(f"Downloading surface albedos to {data_dir}")
         download_folder(storage=storage, folders=[folder_name], data_dir=data_dir)
 
-def download_spectral_files():
+def download_spectral_files(fname: str="", nband: int=256):
     """
-    Download spectral files
+    Download spectral files data
+
+    Inputs :
+        - fname (optional) :    folder name, i.e. "/Dayspring"
+                                if not provided download all the basic list
+        - nband (optional) :    number of band = 16, 48, 256, 4096
+                                (only relevant for Dayspring, Frostflow and Honeyside)
     """
-    from janus.utils.data import DownloadSpectralFiles
     log.debug("Get spectral files")
-    DownloadSpectralFiles()
+
+    #project ID of the spectral files on OSF
+    project_id = 'vehxg'
+
+    #Create spectral file data repository if not existing
+    data_dir = GetFWLData() / "spectral_files"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    #Link with OSF project repository
+    osf = OSF()
+    project = osf.project(project_id)
+    storage = project.storage('osfstorage')
+
+    basic_list = (
+        "Dayspring/48"
+        "Dayspring/256",
+        "Frostflow/256",
+        "Honeyside/4096"
+        )
+
+    #If no folder specified download all basic list
+    if not fname:
+        folder_list = basic_list
+    elif fname in ("Dayspring", "Frostflow", "Honeyside"):
+        folder_list = [fname + "/" + str(nband)]
+    elif fname in ("Kynesgrove","Legacy","Mallard","Oak","Reach","stellar_spectra"):
+        folder_list = [fname]
+    else:
+        raise ValueError(f"Unrecognised folder name: {fname}")
+
+    folders = [folder for folder in folder_list if not (data_dir / folder).exists()]
+
+    if folders:
+        log.debug(f"    downloading spectral files to {data_dir}")
+        download_folder(storage=storage, folders=folders, data_dir=data_dir)
+
 
 def download_stellar_spectra():
     """
     Download stellar spectra
     """
-    from janus.utils.data import DownloadStellarSpectra
     log.debug("Get stellar spectra")
-    DownloadStellarSpectra()
+
+    #project ID of the stellar spectra on OSF
+    project_id = '8r2sw'
+    folder_name = 'Named'
+
+    osf = OSF()
+    project = osf.project(project_id)
+    storage = project.storage('osfstorage')
+
+    data_dir = GetFWLData() / "stellar_spectra"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    if not (data_dir / folder_name).exists():
+        print(f"Downloading stellar spectra to {data_dir}")
+        download_folder(storage=storage, folders=[folder_name], data_dir=data_dir)
+
 
 def download_evolution_tracks(track:str):
     """

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -153,12 +153,23 @@ def download_sufficient_data(OPTIONS:dict):
     if OPTIONS["atmosphere_model"] == 1:
         download_surface_albedos()
 
-def get_socrates(dirs:dict):
+def _none_dirs():
+    from proteus.utils.helper import get_proteus_dir
+
+    dirs = {"proteus":get_proteus_dir()}
+    dirs["tools"] = os.path.join(dirs["proteus"],"tools")
+    return dirs
+
+def get_socrates(dirs=None):
     """
     Download and install SOCRATES
     """
 
     log.info("Setting up SOCRATES")
+
+    # None dirs
+    if dirs is None:
+        dirs = _none_dirs()
 
     # Get path
     workpath = os.path.join(dirs["proteus"], "SOCRATES")
@@ -179,12 +190,15 @@ def get_socrates(dirs:dict):
     os.environ["RAD_DIR"] = workpath
     log.debug("    done")
 
-def get_petsc(dirs:dict):
+def get_petsc(dirs=None):
     """
     Download and install PETSc
     """
 
     log.info("Setting up PETSc")
+
+    if dirs is None:
+        dirs = _none_dirs()
 
     # Get path
     workpath = os.path.join(dirs["proteus"], "petsc")
@@ -204,10 +218,13 @@ def get_petsc(dirs:dict):
 
     log.debug("    done")
 
-def get_spider(dirs:dict):
+def get_spider(dirs=None):
     """
     Download and install SPIDER
     """
+
+    if dirs is None:
+        dirs = _none_dirs()
 
     # Need to install PETSc first
     get_petsc(dirs)

--- a/src/proteus/utils/helper.py
+++ b/src/proteus/utils/helper.py
@@ -12,6 +12,11 @@ import numpy as np
 
 log = logging.getLogger("fwl."+__name__)
 
+def get_proteus_dir():
+    if os.environ.get('PROTEUS_DIR') is None:
+        raise Exception("Environment variables not set! Have you sourced PROTEUS.env?")
+    return os.path.abspath(os.getenv('PROTEUS_DIR'))
+
 def PrintSeparator():
     log.info("===================================================")
     pass

--- a/tools/get_socrates.sh
+++ b/tools/get_socrates.sh
@@ -16,6 +16,7 @@ socpath="socrates"
 if [ -n "$1" ]; then
     socpath=$1
 fi
+rm -rf "$socpath"
 
 # Download (using SSH if possible)
 echo "Cloning from GitHub"
@@ -26,7 +27,6 @@ else
 fi
 echo "    $uri -> $socpath"
 git clone "$uri" "$socpath"
-rm -rf "$socpath"
 
 # Configure and build SOCRATES
 olddir=$(pwd)


### PR DESCRIPTION
- Removed SOCRATES from tests, since we use dummy atmosphere for this. SOCRATES has its own workflow for testing its compilation.
- Rework download functions and CLI so that PROTEUS doesn't depend on JANUS to do this
- Moved some of the atmos_clim imports into the functions in which they are used. This avoids performing redundant imports when only using the CLI, or when only using a specific climate model.
- Added MacOS to test matrix. Closes #172.