### PR TITLE
Generalised outgassing wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ ARAGOG
 atmodeller
 ATMODELLER
 Atmodeller
+zephyrus
+ZEPHYRUS
+Zephyrus
 
 # misc
 ######

--- a/input/default.toml
+++ b/input/default.toml
@@ -210,7 +210,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # [Settings here for accretion rate, etc.]
 
     # Which initial inventory to use?
-    initial = 'elements'        # "elements" | "volatiles"
+    initial = 'volatiles'        # "elements" | "volatiles"
 
     # No module for accretion as of yet
     module = "none"

--- a/input/dummy.toml
+++ b/input/dummy.toml
@@ -26,7 +26,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # output files
     [params.out]
         path        = "dummy"
-        logging     = "DEBUG"
+        logging     = "ERROR"
         plot_mod    = 0      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended
 

--- a/input/dummy.toml
+++ b/input/dummy.toml
@@ -26,7 +26,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # output files
     [params.out]
         path        = "dummy"
-        logging     = "ERROR"
+        logging     = "DEBUG"
         plot_mod    = 0      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended
 

--- a/src/proteus/config/_delivery.py
+++ b/src/proteus/config/_delivery.py
@@ -28,7 +28,7 @@ class Volatiles:
 @define
 class Delivery:
     """Initial volatile inventory, and delivery model selection"""
-    initial: str = field(validator=validators.in_(('elements', 'volatile')))
+    initial: str = field(validator=validators.in_(('elements', 'volatiles')))
 
     module: str | None = field(validator=validators.in_((None,)), converter=none_if_none)
 

--- a/src/proteus/escape/wrapper.py
+++ b/src/proteus/escape/wrapper.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import mors
 import numpy as np
@@ -10,7 +11,6 @@ from zephyrus.escape import EL_escape
 from proteus.utils.constants import AU, element_list, ergcm2stoWm2, secs_per_year
 from proteus.utils.helper import PrintHalfSeparator
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from proteus.config import Config
 

--- a/src/proteus/escape/wrapper.py
+++ b/src/proteus/escape/wrapper.py
@@ -10,16 +10,19 @@ from zephyrus.escape import EL_escape
 from proteus.utils.constants import AU, element_list, ergcm2stoWm2, secs_per_year
 from proteus.utils.helper import PrintHalfSeparator
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from proteus.config import Config
+
 log = logging.getLogger("fwl."+__name__)
 
 # Define global variables
 star = None
 
-def RunEscape(config, hf_row, dt):
+def RunEscape(config:Config, hf_row:dict, dt:float):
     """Run Escape submodule.
 
     Generic function to run escape calculation using ZEPHYRUS or dummy.
-    Writes into the hf_row generic and solvevol_target variable passed as an arguement.
 
     Parameters
     ----------
@@ -29,11 +32,6 @@ def RunEscape(config, hf_row, dt):
             Dictionary of helpfile variables, at this iteration only
         dt : float
             Time interval over which escape is occuring [yr]
-
-    Output
-    ------
-        solvevol_target : dict
-            Dictionary of elemental mass inventories [kg]
     """
 
     PrintHalfSeparator()
@@ -55,7 +53,11 @@ def RunEscape(config, hf_row, dt):
 
     solvevol_target = SpeciesEscapeFromTotalEscape(hf_row, dt)
 
-    return solvevol_target
+    # store in hf_row as elements
+    for e in element_list:
+        if e == "O":
+            continue
+        hf_row[e + "_kg_total"] = solvevol_target[e]
 
 def RunZEPHYRUS(config, hf_row):
     """Run energy-limited escape (for now) model.

--- a/src/proteus/outgas/__init__.py
+++ b/src/proteus/outgas/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .wrapper import run_outgas
+
+__all__ = [
+    'run_outgas',
+]

--- a/src/proteus/outgas/__init__.py
+++ b/src/proteus/outgas/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from .wrapper import run_outgas
+from .wrapper import run_outgassing
 
 __all__ = [
-    'run_outgas',
+    'run_outgassing',
 ]

--- a/src/proteus/outgas/atmodeller.py
+++ b/src/proteus/outgas/atmodeller.py
@@ -1,2 +1,10 @@
 # Wrapper functions for atmodeller
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+log = logging.getLogger("fwl."+__name__)

--- a/src/proteus/outgas/atmodeller.py
+++ b/src/proteus/outgas/atmodeller.py
@@ -1,0 +1,2 @@
+# Wrapper functions for atmodeller
+

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -7,4 +7,29 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from proteus.config import Config
 
+from proteus.utils.constants import volatile_species
+
 log = logging.getLogger("fwl."+__name__)
+
+def construct_options(config, hf_row):
+    """
+    Construct CALLIOPE options dictionary
+    """
+
+    solvevol_inp = {}
+    solvevol_inp["M_mantle"] = hf_row["M_mantle"]
+    solvevol_inp["T_magma"] = hf_row["T_magma"]
+    solvevol_inp["Phi_global"] = hf_row["Phi_global"]
+    solvevol_inp["gravity"] = hf_row["gravity"]
+    solvevol_inp["mass"] = hf_row["M_planet"]
+    solvevol_inp["radius"] = hf_row["R_planet"]
+    solvevol_inp['fO2_shift_IW'] = config.outgas.fO2_shift_IW
+    solvevol_inp['hydrogen_earth_oceans'] = config.delivery.elements.H_oceans
+    solvevol_inp['CH_ratio'] = config['CH_ratio']
+    solvevol_inp['nitrogen_ppmw'] = config['nitrogen_ppmw']
+    solvevol_inp['sulfur_ppmw'] = config['sulfur_ppmw']
+    for s in volatile_species:
+        solvevol_inp[f'{s}_initial_bar'] = config[f'{s}_initial_bar']
+        solvevol_inp[f'{s}_included'] = config[f'{s}_included']
+
+    return solvevol_inp

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -7,18 +7,18 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from proteus.config import Config
 
-from proteus.utils.constants import volatile_species, element_list
-from proteus.utils.helper import UpdateStatusfile
-
 from calliope.solve import (
+    equilibrium_atmosphere,
     get_target_from_params,
     get_target_from_pressures,
-    equilibrium_atmosphere
 )
+
+from proteus.utils.constants import element_list, volatile_species
+from proteus.utils.helper import UpdateStatusfile
 
 log = logging.getLogger("fwl."+__name__)
 
-def construct_options(config:Config, hf_row:dict):
+def construct_options(dirs:dict, config:Config, hf_row:dict):
     """
     Construct CALLIOPE options dictionary
     """
@@ -56,9 +56,9 @@ def construct_options(config:Config, hf_row:dict):
     return solvevol_inp
 
 
-def calc_target_masses(config:Config, hf_row:dict):
+def calc_target_masses(dirs:dict, config:Config, hf_row:dict):
     # make solvevol options
-    solvevol_inp = construct_options(config, hf_row)
+    solvevol_inp = construct_options(dirs, config, hf_row)
 
     # calculate target mass of atoms (except O, which is derived from fO2)
     if config.delivery.initial == 'elements':
@@ -78,9 +78,9 @@ def calc_target_masses(config:Config, hf_row:dict):
         hf_row[e + "_kg_total"] = solvevol_target[e]
 
 
-def calc_surface_pressures(config:Config, hf_row:dict):
+def calc_surface_pressures(dirs:dict, config:Config, hf_row:dict):
     # make solvevol options
-    solvevol_inp = construct_options(config, hf_row)
+    solvevol_inp = construct_options(dirs, config, hf_row)
 
     # convert masses to dict for calliope
     solvevol_target = {}

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from proteus.config import Config
 
-from proteus.utils.constants import volatile_species
+from proteus.utils.constants import volatile_species, element_list
 
 log = logging.getLogger("fwl."+__name__)
 
-def construct_options(config, hf_row):
+def construct_options(config:Config, hf_row:dict):
     """
     Construct CALLIOPE options dictionary
     """

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -17,19 +17,27 @@ def construct_options(config:Config, hf_row:dict):
     """
 
     solvevol_inp = {}
-    solvevol_inp["M_mantle"] = hf_row["M_mantle"]
-    solvevol_inp["T_magma"] = hf_row["T_magma"]
-    solvevol_inp["Phi_global"] = hf_row["Phi_global"]
-    solvevol_inp["gravity"] = hf_row["gravity"]
-    solvevol_inp["mass"] = hf_row["M_planet"]
-    solvevol_inp["radius"] = hf_row["R_planet"]
-    solvevol_inp['fO2_shift_IW'] = config.outgas.fO2_shift_IW
+
+    # Planet properties
+    solvevol_inp["M_mantle"]    =   hf_row["M_mantle"]
+    solvevol_inp["Phi_global"]  =   hf_row["Phi_global"]
+    solvevol_inp["gravity"]     =   hf_row["gravity"]
+    solvevol_inp["mass"]        =   hf_row["M_planet"]
+    solvevol_inp["radius"]      =   hf_row["R_planet"]
+
+    # Surface properties
+    solvevol_inp["T_magma"]     =   hf_row["T_magma"]
+    solvevol_inp['fO2_shift_IW'] =  config.outgas.fO2_shift_IW
+
+    # Elemental inventory
     solvevol_inp['hydrogen_earth_oceans'] = config.delivery.elements.H_oceans
-    solvevol_inp['CH_ratio'] = config['CH_ratio']
-    solvevol_inp['nitrogen_ppmw'] = config['nitrogen_ppmw']
-    solvevol_inp['sulfur_ppmw'] = config['sulfur_ppmw']
+    solvevol_inp['CH_ratio']    =           config.delivery.elements.CH_ratio
+    solvevol_inp['nitrogen_ppmw'] =         config.delivery.elements.N_ppmw
+    solvevol_inp['sulfur_ppmw'] =           config.delivery.elements.S_ppmw
+
+    # Volatile inventory
     for s in volatile_species:
-        solvevol_inp[f'{s}_initial_bar'] = config[f'{s}_initial_bar']
-        solvevol_inp[f'{s}_included'] = config[f'{s}_included']
+        solvevol_inp[f'{s}_initial_bar'] =  config[f'{s}_initial_bar']
+        solvevol_inp[f'{s}_included'] =     config[f'{s}_included']
 
     return solvevol_inp

--- a/src/proteus/outgas/wrapper.py
+++ b/src/proteus/outgas/wrapper.py
@@ -4,36 +4,32 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from proteus.utils.helper import PrintHalfSeparator
-from proteus.utils.constants import volatile_species, element_list
-from proteus.outgas.calliope import (
-    calc_surface_pressures,
-    calc_target_masses
-)
+from proteus.outgas.calliope import calc_surface_pressures, calc_target_masses
+from proteus.utils.constants import volatile_species
 
 if TYPE_CHECKING:
     from proteus.config import Config
 
 log = logging.getLogger("fwl."+__name__)
 
-def calc_target_elemental_inventories(config:Config, hf_row:dict):
+def calc_target_elemental_inventories(dirs:dict, config:Config, hf_row:dict):
     """
     Calculate total amount of volatile elements in the planet
     """
 
     if config.outgas.module == 'calliope':
-        calc_target_masses(config, hf_row)
+        calc_target_masses(dirs, config, hf_row)
     else:
         raise Exception("Unsupported outgassing module selected!")
 
 
-def run_outgassing(config:Config, hf_row:dict):
+def run_outgassing(dirs:dict, config:Config, hf_row:dict):
     '''
     Run outgassing model to get new volatile surface pressures
     '''
 
     if config.outgas.module == 'calliope':
-        calc_surface_pressures(config, hf_row)
+        calc_surface_pressures(dirs, config, hf_row)
     else:
         raise Exception("Unsupported outgassing module selected!")
 

--- a/src/proteus/outgas/wrapper.py
+++ b/src/proteus/outgas/wrapper.py
@@ -5,15 +5,49 @@ import logging
 from typing import TYPE_CHECKING
 
 from proteus.utils.helper import PrintHalfSeparator
+from proteus.utils.constants import volatile_species
+
+from calliope.solve import (
+    equilibrium_atmosphere,
+    get_target_from_params,
+    get_target_from_pressures,
+)
 
 if TYPE_CHECKING:
     from proteus.config import Config
 
 log = logging.getLogger("fwl."+__name__)
 
-def run_outgas():
+def get_target(config:Config, solvevol_inp:dict):
+    # calculate target mass of atoms (except O, which is derived from fO2)
+    if config.delivery.initial == 'elements':
+        solvevol_target = get_target_from_params(solvevol_inp)
+    else:
+        solvevol_target = get_target_from_pressures(solvevol_inp)
+
+    # prevent numerical issues
+    for key in solvevol_target.keys():
+        if solvevol_target[key] < 1.0e4:
+            solvevol_target[key] = 0.0
+
+    return solvevol_target
+
+
+def run_outgas(solvevol_target, solvevol_inp, hf_row):
     '''
     Run volatile outgassing model
     '''
 
     PrintHalfSeparator()
+
+    solvevol_result = equilibrium_atmosphere(solvevol_target, solvevol_inp)
+
+    #    store results
+    for k in solvevol_result.keys():
+        if k in hf_row.keys():
+            hf_row[k] = solvevol_result[k]
+
+    #    calculate total atmosphere mass
+    hf_row["M_atm"] = 0.0
+    for s in volatile_species:
+        hf_row["M_atm"] += hf_row[s + "_kg_atm"]

--- a/src/proteus/outgas/wrapper.py
+++ b/src/proteus/outgas/wrapper.py
@@ -1,10 +1,19 @@
-# Function and classes used to run CALLIOPE
+# Generic interior wrapper
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
 
+from proteus.utils.helper import PrintHalfSeparator
+
 if TYPE_CHECKING:
     from proteus.config import Config
 
 log = logging.getLogger("fwl."+__name__)
+
+def run_outgas():
+    '''
+    Run volatile outgassing model
+    '''
+
+    PrintHalfSeparator()

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -10,12 +10,9 @@ from pathlib import Path
 import numpy as np
 import toml
 from attrs import asdict
-from calliope.solve import (
-    equilibrium_atmosphere,
-    get_target_from_params,
-    get_target_from_pressures,
-)
 from calliope.structure import calculate_mantle_mass
+from proteus.outgas.calliope import construct_options
+from proteus.outgas.wrapper import get_target, run_outgas
 
 import proteus.utils.constants
 from proteus.atmos_clim import RunAtmosphere
@@ -418,55 +415,23 @@ class Proteus:
             ############### / STELLAR FLUX MANAGEMENT
 
             ############### ESCAPE
-
             if (loop_counter["total"] >= loop_counter["init_loops"]):
                 solvevol_target = RunEscape(self.config, hf_row, dt)
             ############### / ESCAPE
 
             ############### OUTGASSING
             PrintHalfSeparator()
-            solvevol_inp = {}
-            solvevol_inp["M_mantle"] = hf_row["M_mantle"]
-            solvevol_inp["T_magma"] = hf_row["T_magma"]
-            solvevol_inp["Phi_global"] = hf_row["Phi_global"]
-            solvevol_inp["gravity"] = hf_row["gravity"]
-            solvevol_inp["mass"] = hf_row["M_planet"]
-            solvevol_inp["radius"] = hf_row["R_planet"]
-            solvevol_inp['fO2_shift_IW'] = self.config.outgas.fO2_shift_IW
-            solvevol_inp['hydrogen_earth_oceans'] = self.config.delivery.elements.H_oceans
-            solvevol_inp['CH_ratio'] = self.config['CH_ratio']
-            solvevol_inp['nitrogen_ppmw'] = self.config['nitrogen_ppmw']
-            solvevol_inp['sulfur_ppmw'] = self.config['sulfur_ppmw']
-            for s in ('H2O', 'CO2', 'N2', 'S2', 'SO2', 'H2', 'CH4', 'CO'):
-                solvevol_inp[f'{s}_initial_bar'] = self.config[f'{s}_initial_bar']
-                solvevol_inp[f'{s}_included'] = self.config[f'{s}_included']
+
+            solvevol_inp = construct_options(self.config, hf_row)
 
             #    recalculate mass targets during init phase, since these will be adjusted
             #    depending on the true melt fraction and T_magma found by SPIDER at runtime.
             if loop_counter["init"] < loop_counter["init_loops"]:
-                # calculate target mass of atoms (except O, which is derived from fO2)
-                if self.config.delivery.initial == 'elements':
-                    solvevol_target = get_target_from_params(solvevol_inp)
-                else:
-                    solvevol_target = get_target_from_pressures(solvevol_inp)
-
-                # prevent numerical issues
-                for key in solvevol_target.keys():
-                    if solvevol_target[key] < 1.0e4:
-                        solvevol_target[key] = 0.0
+                solvevol_target = get_target(self.config, solvevol_inp)
 
             # solve for atmosphere composition
-            solvevol_result = equilibrium_atmosphere(solvevol_target, solvevol_inp)
+            run_outgas(solvevol_target, solvevol_inp, hf_row)
 
-            #    store results
-            for k in solvevol_result.keys():
-                if k in hf_row.keys():
-                    hf_row[k] = solvevol_result[k]
-
-            #    calculate total atmosphere mass
-            hf_row["M_atm"] = 0.0
-            for s in volatile_species:
-                hf_row["M_atm"] += hf_row[s + "_kg_atm"]
             ############### / OUTGASSING
 
             ############### ATMOSPHERE SUB-LOOP

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -12,7 +12,7 @@ import toml
 from attrs import asdict
 from calliope.structure import calculate_mantle_mass
 from proteus.outgas.calliope import construct_options
-from proteus.outgas.wrapper import get_target, run_outgas
+from proteus.outgas.wrapper import calc_target_elemental_inventories, run_outgas
 
 import proteus.utils.constants
 from proteus.atmos_clim import RunAtmosphere
@@ -416,7 +416,7 @@ class Proteus:
 
             ############### ESCAPE
             if (loop_counter["total"] >= loop_counter["init_loops"]):
-                solvevol_target = RunEscape(self.config, hf_row, dt)
+                RunEscape(self.config, hf_row, dt)
             ############### / ESCAPE
 
             ############### OUTGASSING
@@ -427,10 +427,10 @@ class Proteus:
             #    recalculate mass targets during init phase, since these will be adjusted
             #    depending on the true melt fraction and T_magma found by SPIDER at runtime.
             if loop_counter["init"] < loop_counter["init_loops"]:
-                solvevol_target = get_target(self.config, solvevol_inp)
+                calc_target_elemental_inventories(self.config, solvevol_inp, hf_row)
 
             # solve for atmosphere composition
-            run_outgas(solvevol_target, solvevol_inp, hf_row)
+            run_outgas(solvevol_inp, hf_row)
 
             ############### / OUTGASSING
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -11,14 +11,13 @@ import numpy as np
 import toml
 from attrs import asdict
 from calliope.structure import calculate_mantle_mass
-from proteus.outgas.calliope import construct_options
-from proteus.outgas.wrapper import calc_target_elemental_inventories, run_outgassing
 
 import proteus.utils.constants
 from proteus.atmos_clim import RunAtmosphere
 from proteus.config import read_config_object
 from proteus.escape.wrapper import RunEscape
 from proteus.interior import run_interior
+from proteus.outgas.wrapper import calc_target_elemental_inventories, run_outgassing
 from proteus.utils.constants import (
     AU,
     L_sun,
@@ -421,10 +420,10 @@ class Proteus:
             #    recalculate mass targets during init phase, since these will be adjusted
             #    depending on the true melt fraction and T_magma found by SPIDER at runtime.
             if loop_counter["init"] < loop_counter["init_loops"]:
-                calc_target_elemental_inventories(self.config, hf_row)
+                calc_target_elemental_inventories(self.directories, self.config, hf_row)
 
             # solve for atmosphere composition
-            run_outgassing(self.config, hf_row)
+            run_outgassing(self.directories, self.config, hf_row)
 
             ############### / OUTGASSING
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -12,7 +12,7 @@ import toml
 from attrs import asdict
 from calliope.structure import calculate_mantle_mass
 from proteus.outgas.calliope import construct_options
-from proteus.outgas.wrapper import calc_target_elemental_inventories, run_outgas
+from proteus.outgas.wrapper import calc_target_elemental_inventories, run_outgassing
 
 import proteus.utils.constants
 from proteus.atmos_clim import RunAtmosphere
@@ -422,15 +422,13 @@ class Proteus:
             ############### OUTGASSING
             PrintHalfSeparator()
 
-            solvevol_inp = construct_options(self.config, hf_row)
-
             #    recalculate mass targets during init phase, since these will be adjusted
             #    depending on the true melt fraction and T_magma found by SPIDER at runtime.
             if loop_counter["init"] < loop_counter["init_loops"]:
-                calc_target_elemental_inventories(self.config, solvevol_inp, hf_row)
+                calc_target_elemental_inventories(self.config, hf_row)
 
             # solve for atmosphere composition
-            run_outgas(solvevol_inp, hf_row)
+            run_outgassing(self.config, hf_row)
 
             ############### / OUTGASSING
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -38,7 +38,6 @@ from proteus.utils.coupler import (
     ReadHelpfileFromCSV,
     SetDirectories,
     UpdatePlots,
-    ValidateInitFile,
     WriteHelpfileToCSV,
     ZeroHelpfileRow,
 )
@@ -84,9 +83,6 @@ class Proteus:
         import mors
 
         UpdateStatusfile(self.directories, 0)
-
-        # Validate options
-        ValidateInitFile(self.directories, self.config)
 
         # Clean output directory
         if not resume:

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -233,28 +233,6 @@ def ReadHelpfileFromCSV(output_dir:str):
         raise Exception("Cannot find helpfile at '%s'"%fpath)
     return pd.read_csv(fpath, sep=r"\s+")
 
-
-def ValidateInitFile(dirs:dict, config: Config):
-    '''
-    Validate configuration file, checking for invalid options
-    '''
-    # Ensure that all volatiles are all tracked
-    for s in volatile_species:
-        key_pp = str(s+"_initial_bar")
-        key_in = str(s+"_included")
-
-        if (config[key_pp] > 0.0) and (config[key_in] == 0):
-            UpdateStatusfile(dirs, 20)
-            raise RuntimeError(f"Volatile {s} has non-zero pressure but is disabled in cfg")
-
-    # Required vols
-    for s in ["H2O","CO2","N2","S2"]:
-        if config[s+"_included"] == 0:
-            UpdateStatusfile(dirs, 20)
-            raise RuntimeError(f"Missing required volatile {s}")
-
-    return True
-
 def UpdatePlots( hf_all:pd.DataFrame, output_dir:str, config:Config, end=False, num_snapshots=7):
     """Update plots during runtime for analysis
 

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -79,8 +79,7 @@ def download_spectral_files(fname: str="", nband: int=256):
         - nband (optional) :    number of band = 16, 48, 256, 4096
                                 (only relevant for Dayspring, Frostflow and Honeyside)
     """
-    log.debug("Get spectral files")
-
+    log.debug("Get spectral files?")
 
     #Create spectral file data repository if not existing
     data_dir = GetFWLData() / "spectral_files"
@@ -90,26 +89,23 @@ def download_spectral_files(fname: str="", nband: int=256):
     storage = get_osf('vehxg')
 
     basic_list = (
-        "Dayspring/48"
+        "Dayspring/48",
         "Dayspring/256",
         "Frostflow/256",
-        "Honeyside/4096"
+        "Honeyside/4096",
         )
 
     #If no folder specified download all basic list
     if not fname:
         folder_list = basic_list
-    elif fname in ("Dayspring", "Frostflow", "Honeyside"):
-        folder_list = [fname + "/" + str(nband)]
-    elif fname in ("Kynesgrove","Legacy","Mallard","Oak","Reach","stellar_spectra"):
-        folder_list = [fname]
     else:
-        raise ValueError(f"Unrecognised folder name: {fname}")
+        folder_list = [fname + "/" + str(nband)]
 
     folders = [folder for folder in folder_list if not (data_dir / folder).exists()]
 
     if folders:
-        log.info(f"    downloading spectral files to {data_dir}")
+        log.info(f"Downloading spectral files to {data_dir}")
+        log.debug("\t"+str(folders))
         download_folder(storage=storage, folders=folders, data_dir=data_dir)
 
 

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -58,7 +58,7 @@ def download_surface_albedos():
     """
     Download surface optical properties
     """
-    log.debug("Get surface albedos")
+    log.debug("Get surface albedos?")
     storage = get_osf('2gcd9')
 
     folder_name = 'Hammond24'
@@ -113,7 +113,7 @@ def download_stellar_spectra():
     """
     Download stellar spectra
     """
-    log.debug("Get stellar spectra")
+    log.debug("Get stellar spectra?")
 
     folder_name = 'Named'
     storage = get_osf('8r2sw')


### PR DESCRIPTION
This PR generalises access to the outgassing wrapper in a similar manner to the interior and atmosphere wrappers. This will make it possible to integrate atmodeller, for which there is now a stub file, and also potentially a dummy outgassing module. Closes #210.

Minor fixes:
* Typo in `data.py`
* Default configuration file
* Access config with attributes rather than keys.

