### PR TITLE
Allow setting Hydrogen inventory relative to mantle mass

### DIFF
--- a/input/aragog.toml
+++ b/input/aragog.toml
@@ -239,9 +239,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
-        H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
-        N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass, by mass
-        S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mass of melt
+        H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
+        N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass
+        S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mantle mass
 
     # Set initial volatile inventory by partial pressures in atmosphere
     [delivery.volatiles]

--- a/input/aragog.toml
+++ b/input/aragog.toml
@@ -238,7 +238,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
         H_oceans    = 0.0       # Hydrogen inventory in units of equivalent Earth oceans
         H_ppmw      = 109.0     # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass

--- a/input/aragog.toml
+++ b/input/aragog.toml
@@ -239,8 +239,8 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
-        H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans
-        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
+        H_oceans    = 0.0       # Hydrogen inventory in units of equivalent Earth oceans
+        H_ppmw      = 109.0     # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass
         S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mantle mass
 

--- a/input/default.toml
+++ b/input/default.toml
@@ -239,9 +239,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
-        H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
-        N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass, by mass
-        S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mass of melt
+        H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
+        N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass
+        S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mantle mass
 
     # Set initial volatile inventory by partial pressures in atmosphere
     [delivery.volatiles]

--- a/input/default.toml
+++ b/input/default.toml
@@ -238,7 +238,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
         H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans
         H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass

--- a/input/hd63433d.toml
+++ b/input/hd63433d.toml
@@ -238,7 +238,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
         H_oceans    = 8.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
         H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass

--- a/input/hd63433d.toml
+++ b/input/hd63433d.toml
@@ -240,6 +240,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
         H_oceans    = 8.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass
         S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mass of melt
 

--- a/input/k218b.toml
+++ b/input/k218b.toml
@@ -238,7 +238,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        CH_ratio    = 0.1       # C/H ratio in mantle/atmosphere system
+        CH_ratio    = 0.1       # C/H mass ratio in mantle/atmosphere system
         H_oceans    = 60.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
         H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass

--- a/input/k218b.toml
+++ b/input/k218b.toml
@@ -240,6 +240,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [delivery.elements]
         CH_ratio    = 0.1       # C/H ratio in mantle/atmosphere system
         H_oceans    = 60.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass
         S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mass of melt
 

--- a/input/l9859d.toml
+++ b/input/l9859d.toml
@@ -239,6 +239,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
         H_oceans    = 8.0      # Hydrogen inventory in units of equivalent Earth oceans, by mass
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass
         S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mass of melt
 

--- a/input/l9859d.toml
+++ b/input/l9859d.toml
@@ -237,7 +237,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
         H_oceans    = 8.0      # Hydrogen inventory in units of equivalent Earth oceans, by mass
         H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass

--- a/input/trappist1c.toml
+++ b/input/trappist1c.toml
@@ -238,7 +238,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
         H_oceans    = 8.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
         H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass

--- a/input/trappist1c.toml
+++ b/input/trappist1c.toml
@@ -240,6 +240,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
         H_oceans    = 8.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass, by mass
         S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mass of melt
 

--- a/src/proteus/config/_delivery.py
+++ b/src/proteus/config/_delivery.py
@@ -13,7 +13,7 @@ class Elements:
     Attributes
     ----------
     CH_ratio: float
-        Volatile C/H nass ratio in combined mantle+atmosphere system.
+        Volatile C/H mass ratio in combined mantle+atmosphere system.
     H_oceans: float
         Absolute hydrogen inventory, units of equivalent Earth oceans.
     H_ppmw: float

--- a/src/proteus/config/_delivery.py
+++ b/src/proteus/config/_delivery.py
@@ -15,14 +15,17 @@ class Elements:
     CH_ratio: float
         Volatile C/H nass ratio in combined mantle+atmosphere system.
     H_oceans: float
-        Bulk hydrogen inventory in units of equivalent Earth oceans.
+        Absolute hydrogen inventory, units of equivalent Earth oceans.
+    H_ppmw: float
+        Relative hydrogen inventory, ppmw relative to mantle mass.
     N_ppmw: float
-        Bulk nitrogen inventory in ppmw relative to mantle mass.
+        Relative nitrogen inventory, ppmw relative to mantle mass.
     S_ppmw: float
-        Bulk sulfur inventory in ppmw relative to mantle mass.
+        Absolute sulfur inventory, ppmw relative to mantle mass.
     """
     CH_ratio: float = field(validator=gt(0))
-    H_oceans: float = field(validator=gt(0))
+    H_oceans: float = field(validator=ge(0))
+    H_ppmw: float = field(validator=ge(0))
     N_ppmw: float = field(validator=ge(0))
     S_ppmw: float = field(validator=ge(0))
 

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -79,6 +79,11 @@ def calc_target_masses(dirs:dict, config:Config, hf_row:dict):
     # make solvevol options
     solvevol_inp = construct_options(dirs, config, hf_row)
 
+    # warn
+    if (config.delivery.elements.H_ppmw > 1e-10) \
+        and (config.delivery.elements.H_oceans > 1e-10):
+        log.warning("Hydrogen inventory set by summing `H_ppmw` and `H_oceans`")
+
     # calculate target mass of atoms (except O, which is derived from fO2)
     if config.delivery.initial == 'elements':
         solvevol_target = get_target_from_params(solvevol_inp)

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from proteus.config import Config
 
+from calliope.constants import molar_mass, ocean_moles
 from calliope.solve import (
     equilibrium_atmosphere,
     get_target_from_params,
     get_target_from_pressures,
 )
-from calliope.constants import ocean_moles, molar_mass
 
 from proteus.utils.constants import element_list, vol_list
 from proteus.utils.helper import UpdateStatusfile

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -12,6 +12,7 @@ from calliope.solve import (
     get_target_from_params,
     get_target_from_pressures,
 )
+from calliope.constants import ocean_moles, molar_mass
 
 from proteus.utils.constants import element_list, vol_list
 from proteus.utils.helper import UpdateStatusfile
@@ -35,8 +36,21 @@ def construct_options(dirs:dict, config:Config, hf_row:dict):
     solvevol_inp["T_magma"]     =  hf_row["T_magma"]
     solvevol_inp['fO2_shift_IW'] = config.outgas.fO2_shift_IW
 
+    # Sum hydrogen absolute and relative amounts...
+
+    #    absolute part
+    #         internally, calliope will convert this to mass in kg as:
+    #         H_kg = H_oceans * number_ocean_moles * molar_mass['H2']
+    H_abs = float(config.delivery.elements.H_oceans)
+
+    #    relative part
+    #        H_kg = H_rel * 1e-6 * M_mantle
+    #        then converted to units of earth oceans, and summed with absolute part
+    H_rel = config.delivery.elements.H_ppmw * 1e-6 * hf_row["M_mantle"]
+    H_rel /= ocean_moles * molar_mass['H2']
+
     # Elemental inventory
-    solvevol_inp['hydrogen_earth_oceans'] = config.delivery.elements.H_oceans
+    solvevol_inp['hydrogen_earth_oceans'] = H_abs + H_rel
     solvevol_inp['CH_ratio']    =           config.delivery.elements.CH_ratio
     solvevol_inp['nitrogen_ppmw'] =         config.delivery.elements.N_ppmw
     solvevol_inp['sulfur_ppmw'] =           config.delivery.elements.S_ppmw

--- a/src/proteus/outgas/calliope.py
+++ b/src/proteus/outgas/calliope.py
@@ -49,6 +49,12 @@ def construct_options(dirs:dict, config:Config, hf_row:dict):
     H_rel = config.delivery.elements.H_ppmw * 1e-6 * hf_row["M_mantle"]
     H_rel /= ocean_moles * molar_mass['H2']
 
+    #    avoid floating point errors here
+    if H_abs < 1e-10:
+        H_abs = 0.0
+    if H_rel < 1e-10:
+        H_rel < 0.0
+
     # Elemental inventory
     solvevol_inp['hydrogen_earth_oceans'] = H_abs + H_rel
     solvevol_inp['CH_ratio']    =           config.delivery.elements.CH_ratio

--- a/src/proteus/utils/constants.py
+++ b/src/proteus/utils/constants.py
@@ -17,7 +17,6 @@ R_earth         = 6.335439e6            # m
 R_core_earth    = 3485000.0             # m
 M_core_earth    = 1.94E24               # kg
 mol             = 6.02214076e+23        # mol definition
-ocean_moles     = 7.68894973907177e+22  # moles of H2 (or H2O) in one present-day Earth ocean
 
 # Earth heat flux, globally averaged [W m-2]
 # https://se.copernicus.org/articles/1/5/2010/

--- a/tests/integration/dummy.toml
+++ b/tests/integration/dummy.toml
@@ -238,6 +238,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
         H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass, by mass
         S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mass of melt
 

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -239,6 +239,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [delivery.elements]
         CH_ratio    = 1.0       # C/H ratio in mantle/atmosphere system
         H_oceans    = 6.0       # Hydrogen inventory in units of equivalent Earth oceans, by mass
+        H_ppmw      = 0.0       # Hydrogen inventory in ppmw relative to mantle mass
         N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass, by mass
         S_ppmw      = 200.0     # Sulfur inventory in ppmw relative to mass of melt
 


### PR DESCRIPTION
Currently, the user can only set the hydrogen inventory in absolute terms (`H_oceans`). This becomes somewhat annoying when varying planet mass -- such as when comparing different planets in the same star system -- since it means that the relative amount of hydrogen is implicitly changing. 

This PR makes it possible to set the hydrogen inventory in relative terms (`H_ppmw`) in the same way as we do with nitrogen and sulfur. This is then summed with the absolute amount, although I can imagine that  the user will probably only set one of these parameters to be >0 at any one time.