### PR TITLE
Update termination criteria

### DIFF
--- a/input/aragog.toml
+++ b/input/aragog.toml
@@ -53,7 +53,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         # required number of iterations
         [params.stop.iters]
             enabled = true
-            minimum = 3
+            minimum = 5
             maximum = 9000
 
         # required time constraints
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             enabled = true
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
-
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 0.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 1.0e-9     # Percentage change in melt fraction over time (dp/p)/dt*100
 
         [params.stop.escape]
             enabled   = true

--- a/input/default.toml
+++ b/input/default.toml
@@ -53,7 +53,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         # required number of iterations
         [params.stop.iters]
             enabled = true
-            minimum = 3
+            minimum = 5
             maximum = 9000
 
         # required time constraints
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             enabled = true
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
-
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 0.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 1.0e-9     # Percentage change in melt fraction over time (dp/p)/dt*100
 
         [params.stop.escape]
             enabled   = true

--- a/input/hd63433d.toml
+++ b/input/hd63433d.toml
@@ -53,7 +53,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         # required number of iterations
         [params.stop.iters]
             enabled = true
-            minimum = 3
+            minimum = 5
             maximum = 9000
 
         # required time constraints
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             enabled = true
             atol    = 0.1     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
-
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 1.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 3.0e-10     # Percentage change in melt fraction over time (dp/p)/dt*100
 
         [params.stop.escape]
             enabled   = true

--- a/input/k218b.toml
+++ b/input/k218b.toml
@@ -53,7 +53,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         # required number of iterations
         [params.stop.iters]
             enabled = true
-            minimum = 3
+            minimum = 5
             maximum = 9000
 
         # required time constraints
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             enabled = true
             atol    = 0.1     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
-
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 1.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 3.0e-10     # Percentage change in melt fraction over time (dp/p)/dt*100
 
         [params.stop.escape]
             enabled   = false

--- a/input/l9859d.toml
+++ b/input/l9859d.toml
@@ -27,7 +27,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     [params.out]
         path        = "l9859d"
         logging     = "INFO"
-        plot_mod    = 5      # Plotting frequency, 0: wait until completion | n: every n iterations
+        plot_mod    = 10      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended
 
     # time-stepping
@@ -60,7 +60,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         [params.stop.time]
             enabled = true
             minimum = 1.0e3     # yr, model will certainly run to t > minimum
-            maximum = 4.567e+9     # yr, model will terminate when t > maximum
+            maximum = 1e+9     # yr, model will terminate when t > maximum
 
         # solidification
         [params.stop.solid]
@@ -71,7 +71,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         [params.stop.radeqm]
             enabled = true
             atol    = 1e-2    # absolute tolerance [W m-2]
-            rtol    = 1e-2    # relative tolerance
+            rtol    = 2e-2    # relative tolerance
 
         # steady state
         [params.stop.steady]
@@ -140,7 +140,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     [atmos_clim.agni]
         p_top           = 1.0e-4        # bar, top of atmosphere grid pressure
-        spectral_group  = "Dayspring"   # which gas opacities to include
+        spectral_group  = "Honeyside"   # which gas opacities to include
         spectral_bands  = "256"         # how many spectral bands?
         num_levels      = 42            # Number of atmospheric grid levels
         chemistry       = "eq"        # "none" | "eq"

--- a/input/l9859d.toml
+++ b/input/l9859d.toml
@@ -53,7 +53,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         # required number of iterations
         [params.stop.iters]
             enabled = true
-            minimum = 3
+            minimum = 5
             maximum = 9000
 
         # required time constraints
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             enabled = true
             atol    = 1e-2    # absolute tolerance [W m-2]
             rtol    = 2e-2    # relative tolerance
-
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 1.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 3.0e-10     # Percentage change in melt fraction over time (dp/p)/dt*100
 
         [params.stop.escape]
             enabled   = true

--- a/input/trappist1c.toml
+++ b/input/trappist1c.toml
@@ -53,7 +53,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         # required number of iterations
         [params.stop.iters]
             enabled = true
-            minimum = 3
+            minimum = 5
             maximum = 9000
 
         # required time constraints
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             enabled = true
             atol    = 0.1     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
-
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 1.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 3.0e-10     # Percentage change in melt fraction over time (dp/p)/dt*100
 
         [params.stop.escape]
             enabled   = true

--- a/src/proteus/config/_params.py
+++ b/src/proteus/config/_params.py
@@ -128,8 +128,6 @@ class StopParams:
         Parameters for solidification criteria.
     radeqm: StopRadeqm
         Parameters for radiative equilibrium criteria.
-    steady: StopSteady
-        Parameters for steady state criteria.
     escape: StopEscape
         Parameters for escape criteria.
     """
@@ -137,7 +135,6 @@ class StopParams:
     time: StopTime
     solid: StopSolid
     radeqm: StopRadeqm
-    steady: StopSteady
     escape: StopEscape
 
 
@@ -208,24 +205,6 @@ class StopRadeqm:
     enabled: bool
     atol: float = field(validator=gt(0))
     rtol: float = field(validator=ge(0))
-
-
-@define
-class StopSteady:
-    """Parameters for steady state stopping criteria.
-
-    Attributes
-    ----------
-    enabled: bool
-        Enable criteria if True
-    F_crit: float
-        Necessary (not sufficient) condition on maximum absolute net outgoing flux [W m-2].
-    dprel: float
-        Necessary (not sufficient) condition maximum change in melt fraction over time `(dp/p)/dt*100` [yr-1].
-    """
-    enabled: bool
-    F_crit: float = field(validator=gt(0))
-    dprel: float = field(validator=gt(0))
 
 
 @define

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -427,6 +427,18 @@ class Proteus:
                     log.info("")
                     self.finished = True
 
+            # Stop simulation when wants to warm up but cannot do so
+            if self.config.atmos_clim.prevent_warming and (self.loops["total"] > self.loops["init_loops"] + 1):
+
+                F_eps = self.hf_row["F_atm"] - self.hf_row["F_tidal"] - self.hf_row["F_radio"]
+
+                if F_eps < 0:
+                    UpdateStatusfile(self.directories, 14)
+                    log.info("")
+                    log.info("===> Planet is no longer cooling! <===")
+                    log.info("")
+                    self.finished = True
+
             # Determine when the simulation enters a steady state
             if (
                 self.config.params.stop.steady.enabled

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -152,8 +152,8 @@ class Proteus:
         # Count iterations
         self.loops = {
             "total": 0,  # Total number of iters performed
-            "total_min": 5,  # Minimum number of total loops
-            "total_loops": self.config.params.stop.iters.maximum,  # Maximum number of total loops
+            "total_min": self.config.params.stop.iters.minimum,
+            "total_loops": self.config.params.stop.iters.maximum, 
             "init": 0,  # Number of init iters performed
             "init_loops": 3,  # Maximum number of init iters
         }

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -53,7 +53,7 @@ from proteus.utils.logs import (
     GetLogfilePath,
     setup_logger,
 )
-from proteus.utils.terminate import check_termination
+from proteus.utils.terminate import check_termination, print_termination_criteria
 
 
 class Proteus:
@@ -143,6 +143,10 @@ class Proteus:
 
         # Print module configuration
         print_module_configuration(self.directories, self.config, self.config_path)
+
+        # Print termination criteria
+        print_termination_criteria(self.config)
+
         PrintHalfSeparator()
 
         # Count iterations
@@ -152,9 +156,6 @@ class Proteus:
             "total_loops": self.config.params.stop.iters.maximum,  # Maximum number of total loops
             "init": 0,  # Number of init iters performed
             "init_loops": 3,  # Maximum number of init iters
-            "steady": -1,  # Number of iterations passed since steady-state declared
-            "steady_loops": 3,  # Number of iterations to perform post-steady state
-            "steady_check": 15,  # Number of iterations to look backwards when checking steady state
         }
 
         # Write config to output directory, for future reference
@@ -251,16 +252,14 @@ class Proteus:
             log.info(" ")
             PrintSeparator()
             log.info("Loop counters")
-            log.info("init    total     steady")
+            log.info("init      total")
             log.info(
-                "%1d/%1d   %04d/%04d   %1d/%1d"
+                "%1d/%1d     %04d/%04d "
                 % (
                     self.loops["init"],
                     self.loops["init_loops"],
                     self.loops["total"],
                     self.loops["total_loops"],
-                    self.loops["steady"],
-                    self.loops["steady_loops"],
                 )
             )
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -53,6 +53,7 @@ from proteus.utils.logs import (
     GetLogfilePath,
     setup_logger,
 )
+from proteus.utils.terminate import check_termination
 
 
 class Proteus:
@@ -400,147 +401,21 @@ class Proteus:
             # Print info to terminal and log file
             PrintCurrentState(self.hf_row)
 
-            log.info("Check convergence criteria")
+            # Check for convergence
+            if self.loops["total"] >= self.loops["init_loops"]:
+                log.info("Check convergence criteria")
+                self.finished = check_termination(self)
 
-            # Stop simulation when planet is completely solidified
-            if self.config.params.stop.solid.enabled and (self.hf_row["Phi_global"] <= self.config.params.stop.solid.phi_crit):
-                UpdateStatusfile(self.directories, 10)
-                log.info("")
-                log.info("===> Planet solidified! <===")
-                log.info("")
-                self.finished = True
-
-            # Stop simulation when at radiative equilibrium
-            if self.config.params.stop.radeqm.enabled and (self.loops["total"] > self.loops["init_loops"] + 1):
-
-                # Radiative equilibrium nominally occurs when F_atm is zero.
-                # However, with tidal heating included, this is offset by the interior
-                #   heat production of the planet. Energy balance is instead achieved
-                #   when F_atm and F_tidal are equal.
-                F_eps = abs(self.hf_row["F_atm"] - self.hf_row["F_tidal"] - self.hf_row["F_radio"])
-                F_ref = abs(self.hf_row["F_atm"]) * self.config.params.stop.radeqm.rtol + self.config.params.stop.radeqm.atol
-
-                if F_eps <= F_ref:
-                    UpdateStatusfile(self.directories, 14)
-                    log.info("")
-                    log.info("===> Planet has reached global energy balance! <===")
-                    log.info("")
-                    self.finished = True
-
-            # Stop simulation when wants to warm up but cannot do so
-            if self.config.atmos_clim.prevent_warming and (self.loops["total"] > self.loops["init_loops"] + 1):
-
-                F_eps = self.hf_row["F_atm"] - self.hf_row["F_tidal"] - self.hf_row["F_radio"]
-
-                if F_eps < 0:
-                    UpdateStatusfile(self.directories, 14)
-                    log.info("")
-                    log.info("===> Planet is no longer cooling! <===")
-                    log.info("")
-                    self.finished = True
-
-            # Determine when the simulation enters a steady state
-            if (
-                self.config.params.stop.steady.enabled
-                and (self.loops["total"] > self.loops["steady_check"] * 2 + 5)
-                and (self.loops["steady"] < 0)
-            ):
-                # How many iterations to look backwards
-                lb1 = -int(self.loops["steady_check"])
-                lb2 = -1
-
-                # Get data
-                arr_t = np.array(self.hf_all["Time"])
-                arr_f = np.array(self.hf_all["F_atm"])
-                arr_p = np.array(self.hf_all["Phi_global"])
-
-                # Time samples
-                t1 = arr_t[lb1]
-                t2 = arr_t[lb2]
-
-                # Flux samples
-                flx_m = max(abs(arr_f[lb1]), abs(arr_f[lb2]))
-
-                # Check melt fraction rate
-                phi_1 = arr_p[lb1]
-                phi_2 = arr_p[lb2]
-                phi_r = abs(phi_2 - phi_1) / (t2 - t1)
-
-                # Stop when flux is small and melt fraction is unchanging
-                if (flx_m < self.config.params.stop.steady.F_crit) \
-                    and (phi_r < self.config.params.stop.steady.dprel):
-                    log.debug("Steady state declared")
-                    self.loops["steady"] = 0
-
-            # Steady-state handling
-            if self.loops["steady"] >= 0:
-                # Force the model to do N=steady_loops more iterations before stopping
-                # This is to make absolutely sure that it has reached a steady state.
-                self.loops["steady"] += 1
-
-                # Stop now?
-                if self.loops["steady"] >= self.loops["steady_loops"]:
-                    UpdateStatusfile(self.directories, 11)
-                    log.info("")
-                    log.info("===> Planet entered a steady state! <===")
-                    log.info("")
-                    self.finished = True
-
-            # Atmosphere has escaped
-            if self.has_escaped \
-                or (self.hf_row["M_atm"] <= self.config.params.stop.escape.mass_frac * \
-                                                self.hf_all.iloc[0]["M_atm"]):
-
-                UpdateStatusfile(self.directories, 15)
-                log.info("")
-                log.info("===> Atmosphere has escaped! <===")
-                log.info("")
-                self.finished = True
-
-            # Maximum time reached
-            if self.hf_row["Time"] >= self.config.params.stop.time.maximum:
-                UpdateStatusfile(self.directories, 13)
-                log.info("")
-                log.info("===> Target time reached! <===")
-                log.info("")
-                self.finished = True
-
-            # Maximum loops reached
-            if self.loops["total"] > self.loops["total_loops"]:
-                UpdateStatusfile(self.directories, 12)
-                log.info("")
-                log.info("===> Maximum number of iterations reached! <===")
-                log.info("")
-                self.finished = True
-
-            # Check if the minimum number of loops have been performed
-            if self.finished and (self.loops["total"] < self.loops["total_min"]):
-                log.info("Minimum number of iterations not yet attained; continuing...")
-                self.finished = False
-                UpdateStatusfile(self.directories, 1)
-
-            # Check if keepalive file has been removed - this means that the model should exit ASAP
-            if not os.path.exists(self.lockfile):
-                UpdateStatusfile(self.directories, 25)
-                log.info("")
-                log.info("===> Model exit was requested! <===")
-                log.info("")
-                self.finished = True
-
-            # Make plots if required and go to next iteration
-            if (
-                (self.config.params.out.plot_mod > 0)
-                and (self.loops["total"] % self.config.params.out.plot_mod == 0)
-                and (not self.finished)
-            ):
-                PrintHalfSeparator()
-                log.info("Making plots")
-                UpdatePlots(self.hf_all, self.directories, self.config)
+            # Make plots
+            if self.config.params.out.plot_mod > 0 and not self.finished:
+                if self.loops["total"] % self.config.params.out.plot_mod == 0:
+                    log.info("Making plots")
+                    UpdatePlots(self.hf_all, self.directories, self.config)
 
             ############### / HOUSEKEEPING AND CONVERGENCE CHECK
 
         # FINAL THINGS BEFORE EXIT
-        PrintHalfSeparator()
+        PrintSeparator()
 
         # Clean up files
         safe_rm(self.lockfile)

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -153,7 +153,7 @@ class Proteus:
         self.loops = {
             "total": 0,  # Total number of iters performed
             "total_min": self.config.params.stop.iters.minimum,
-            "total_loops": self.config.params.stop.iters.maximum, 
+            "total_loops": self.config.params.stop.iters.maximum,
             "init": 0,  # Number of init iters performed
             "init_loops": 3,  # Maximum number of init iters
         }

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -1,0 +1,158 @@
+# Contains routines for model termination and convergence
+
+# Import utils-specific modules
+from __future__ import annotations
+
+import os
+import logging
+from typing import TYPE_CHECKING
+
+from proteus.utils.helper import UpdateStatusfile
+
+if TYPE_CHECKING:
+    from proteus import Proteus
+
+log = logging.getLogger("fwl."+__name__)
+
+# Print message in common format
+def _msg_termination(msg:str):
+    log.info("")
+    log.info(f"===> {msg}! <===")
+    log.info("")
+
+# Solidified condition
+def _check_solid(handler: Proteus) -> bool:
+    log.debug("Check solidification")
+    if handler.hf_row["Phi_global"] <= handler.handler.config.params.stop.solid.phi_crit:
+        UpdateStatusfile(handler.directories, 10)
+        _msg_termination("Planet solidified!")
+        return True
+    return False
+
+# Energy balance condition
+def _check_radeqm(handler: Proteus) -> bool:
+    log.debug("Check energy balance / radeqm")
+
+    # Radiative equilibrium nominally occurs when F_atm is zero.
+    # However, with tidal heating included, this is offset by the interior
+    #   heat production of the planet. Energy balance is instead achieved
+    #   when F_atm and F_tidal are equal.
+
+    F_eps = handler.hf_row["F_atm"] - handler.hf_row["F_tidal"] - handler.hf_row["F_radio"]
+    F_ref = abs(handler.hf_row["F_atm"]) * handler.config.params.stop.radeqm.rtol + handler.config.params.stop.radeqm.atol
+
+    if abs(F_eps) <= F_ref:
+        UpdateStatusfile(handler.directories, 14)
+        _msg_termination("Planet has reached global energy balance")
+        return True
+
+     # Simulation when wants to warm up but cannot do so
+    if handler.config.atmos_clim.prevent_warming and (F_eps < 0):
+        UpdateStatusfile(handler.directories, 14)
+        _msg_termination("Planet is no longer cooling")
+        return True
+
+    return False
+
+# Volatiles have escaped
+def _check_escape(handler: Proteus) -> bool:
+    log.debug("Check escape")
+
+    if handler.has_escaped \
+        or (handler.hf_row["M_atm"] <= handler.config.params.stop.escape.mass_frac * handler.hf_all.iloc[0]["M_atm"]):
+
+        UpdateStatusfile(handler.directories, 15)
+        _msg_termination("Atmosphere has escaped")
+        return True
+    return False
+
+# Maximum time
+def _check_time(handler: Proteus) -> bool:
+    log.debug("Check maximum time")
+
+    if handler.hf_row["Time"] >= handler.config.params.stop.time.maximum:
+        UpdateStatusfile(handler.directories, 13)
+        _msg_termination("Target time reached")
+        return True
+    return False
+
+# Maximum iterations
+def _check_maxiter(handler: Proteus) -> bool:
+    log.debug("Check maximum iterations")
+
+    if handler.loops["total"] > handler.loops["total_loops"]:
+        UpdateStatusfile(handler.directories, 12)
+        _msg_termination("Maximum number of iterations reached")
+        return True
+    return False
+
+# Minimum iterations
+def _check_miniter(handler: Proteus) -> bool:
+    log.debug("Check minimum iterations")
+
+    if handler.loops["total"] > handler.loops["total_min"]:
+        UpdateStatusfile(handler.directories, 1)
+        return False
+    return True
+
+def _check_keepalive(handler: Proteus) -> bool:
+    log.debug("Check keepalive file")
+
+    if not os.path.exists(handler.lockfile):
+        UpdateStatusfile(handler.directories, 25)
+        _msg_termination("Model exit was requested")
+        return True
+    return False
+
+def check_termination(handler: Proteus) -> bool:
+    """
+    Decide if the model should stop or not.
+
+    Updates the status file. Does not modify any variables in the handler.
+
+    Parameters:
+    --------------
+        handler: Proteus
+            Proteus instance
+
+    Returns:
+    --------------
+        fininshed: bool
+            Should the model terminate now?
+    """
+
+    # Quantify model state
+    finished = False
+
+    # Stop simulation when planet is completely solidified
+    if handler.config.params.stop.solid.enabled:
+        finished = finished or _check_solid(handler)
+
+    # Stop simulation when at global energy balance
+    if handler.config.params.stop.radeqm.enabled:
+        finished = finished or _check_radeqm(handler)
+
+    # Atmosphere has escaped
+    if handler.config.params.stop.escape.enabled:
+        finished = finished or _check_escape(handler)
+
+    # Maximum time reached
+    if handler.config.params.stop.time.enabled:
+        finished = finished or _check_time(handler)
+
+    # Maximum loops reached
+    if handler.config.params.stop.iters.enabled:
+        finished = finished or _check_maxiter(handler)
+
+    # Minimum loops reached
+    if handler.config.params.stop.iters.enabled:
+        miniter = _check_miniter(handler)
+        if miniter and finished:
+            log.warning("Minimum number of iterations not yet attained; continuing...")
+            finished = False
+
+    # Check if keepalive file has been removed - this means that the model should exit ASAP
+    finished = finished or _check_keepalive(handler)
+
+    # Set state
+    return finished

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -20,7 +20,7 @@ def print_termination_criteria(config:Config):
     log.info("Active termination criteria")
 
     def _print_criterion(state, msg):
-        log.info(f"    {msg:16} {"✔" if state else "✗"}  ")
+        log.info(f"    {msg:16} {'✔' if state else '✗'}  ")
 
     # Optionally enabled:
     _print_criterion(config.params.stop.solid.enabled,  "Solidification")

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -11,8 +11,26 @@ from proteus.utils.helper import UpdateStatusfile
 
 if TYPE_CHECKING:
     from proteus import Proteus
+    from proteus.config import config
 
 log = logging.getLogger("fwl."+__name__)
+
+# Summarise convergence criteria
+def print_termination_criteria(config:Config):
+    log.info("Active termination criteria:")
+
+    def _print_criterion(state, msg):
+        log.info(f" {"✔" if state else "✗"}  {msg}")
+
+    # Optionally enabled:
+    _print_criterion(config.params.stop.solid.enabled,  "solidification")
+    _print_criterion(config.params.stop.radeqm.enabled, "energy balance / radiative equilibrium")
+    _print_criterion(config.params.stop.escape.enabled, "volatile inventory escaped")
+    _print_criterion(config.params.stop.time.enabled,   "maximum time reached")
+    _print_criterion(config.params.stop.iters.enabled,  "maximum loops reached")
+
+    # Always enabled:
+    _print_criterion(True, "keepalive file removed")
 
 # Print message in common format
 def _msg_termination(msg:str):

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -3,15 +3,15 @@
 # Import utils-specific modules
 from __future__ import annotations
 
-import os
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from proteus.utils.helper import UpdateStatusfile
 
 if TYPE_CHECKING:
     from proteus import Proteus
-    from proteus.config import config
+    from proteus.config import Config
 
 log = logging.getLogger("fwl."+__name__)
 

--- a/tests/integration/dummy.toml
+++ b/tests/integration/dummy.toml
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 0.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 1.0e-9     # Percentage change in melt fraction over time (dp/p)/dt*100
-
         [params.stop.escape]
             enabled   = true
             mass_frac = 3e-4      # Stop when atm_mass < this frac of initial mass

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -72,12 +72,6 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
-        # steady state
-        [params.stop.steady]
-            enabled  = false
-            F_crit   = 0.8        # Maximum absolute value of F_atm allowed for convergence
-            dprel    = 1.0e-9     # Percentage change in melt fraction over time (dp/p)/dt*100
-
         [params.stop.escape]
             enabled   = false
             mass_frac = 3e-4      # Stop when atm_mass < this frac of initial mass

--- a/tools/grid_proteus.py
+++ b/tools/grid_proteus.py
@@ -444,7 +444,7 @@ if __name__=='__main__':
     # -----
 
     config = "l9859d.toml"
-    folder = "l9859d_grid3"
+    folder = "l9859d_grid4"
 
     cfg_base = os.path.join(PROTEUS_DIR,"input",config)
     symlink = "/network/group/aopp/planetary/RTP035_NICHOLLS_PROTEUS/outputs/"+folder
@@ -461,13 +461,16 @@ if __name__=='__main__':
     # pg.set_dimension_direct("Model", ["janus", "agni"])
 
     pg.add_dimension("Redox state", "outgas.fO2_shift_IW")
-    pg.set_dimension_direct("Redox state", [-2, 0, 2, 4])
+    pg.set_dimension_direct("Redox state", [-2, 2, 6])
 
     pg.add_dimension("Tidal", "orbit.dummy.H_tide")
-    pg.set_dimension_direct("Tidal", [0.0, 1e-9, 1e-8, 1e-7, 1e-6])
+    pg.set_dimension_direct("Tidal", [0.0, 3e-8, 3e-7, 3e-6])
 
     pg.add_dimension("Mass", "struct.mass_tot")
-    pg.set_dimension_direct("Mass", [1.94, 2.14, 2.31])
+    pg.set_dimension_direct("Mass", [1.94, 2.31])
+
+    pg.add_dimension("Hydrogen", "delivery.elements.H_ppmw")
+    pg.set_dimension_direct("Hydrogen", [1e2, 3e2, 1e3])
 
     # -----
     # Print state of parameter grid


### PR DESCRIPTION
Removes old steady state check and improves radiative equilibrium / energy balance condition. Closes #295.

Tidies up this code significantly, and also prints information to log regarding which criteria are enabled.

Fixes bug where `config.params.stop.iter.minimum` wasn't actually being used.
