### PR TITLE
Minor update of escape.toml

### DIFF
--- a/input/demos/escape.toml
+++ b/input/demos/escape.toml
@@ -25,7 +25,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 [params]
     # output files
     [params.out]
-        path        = "default"
+        path        = "escape"
         logging     = "INFO"
         plot_mod    = 2      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "pdf"  # Plotting image file format, "png" or "pdf" recommended
@@ -89,7 +89,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     module  = "mors"
     [star.mors]
         rot_pctle = 50.0    # rotation percentile
-        tracks  = "baraffe"   # evolution tracks: spada | baraffe
+        tracks  = "spada"   # evolution tracks: spada | baraffe
         age_now = 4.567     # Gyr, current age of star used for scaling
         spec    = "stellar_spectra/Named/sun.txt" # stellar spectrum
 


### PR DESCRIPTION
Hi all, here is a very minor update in input/demos/escape.toml. I just changed the output folder name to 'escape' instead of 'default'. I also change the stellar tracks to 'spada' instead of 'baraffe' because this is required for the escape computation. Those 2 mistakes aredue to a bad use of copy/paste in a previous PR.