### PR TITLE
Fix os.cpu_count() function in grid_proteus.py for users with Python<3.13

### DIFF
--- a/tools/grid_proteus.py
+++ b/tools/grid_proteus.py
@@ -265,7 +265,7 @@ class Grid():
         num_threads = min(num_threads, self.size)
 
         # do not use more threads than are available
-        num_threads = min(num_threads, os.process_cpu_count())
+        num_threads = min(num_threads, os.cpu_count())
 
         # Print warning
         if not test_run:


### PR DESCRIPTION
Hi all, this is related to this https://github.com/FormingWorlds/PROTEUS/pull/329#issuecomment-2634093669 

I updated the grid_proteus.py file to be able to run a grid without having the error about os library while using Pyhton 3.12.2 with my proteus environment as suggested by @nichollsh here https://github.com/FormingWorlds/PROTEUS/pull/329#issuecomment-2634129762