### PR TITLE
Enable/disable real gas EOS in AGNI

### DIFF
--- a/input/default.toml
+++ b/input/default.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method    = "ee"          # gas overlap method
         condensation    = true          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-7        # bar, top of atmosphere grid pressure

--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = false          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-6        # bar, top of atmosphere grid pressure

--- a/input/demos/dummy.toml
+++ b/input/demos/dummy.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method    = "ee"          # gas overlap method
         condensation    = true         # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-6        # bar, top of atmosphere grid pressure

--- a/input/demos/escape.toml
+++ b/input/demos/escape.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = true         # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-7        # bar, top of atmosphere grid pressure

--- a/input/demos/speedy.toml
+++ b/input/demos/speedy.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = false          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-6        # bar, top of atmosphere grid pressure

--- a/input/demos/speedy.toml
+++ b/input/demos/speedy.toml
@@ -25,19 +25,19 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 [params]
     # output files
     [params.out]
-        path        = "trappist1c"
+        path        = "speedy"
         logging     = "INFO"
-        plot_mod    = 10      # Plotting frequency, 0: wait until completion | n: every n iterations
+        plot_mod    = 2      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended
         write_mod   = 1      # Write CSV frequency, 0: wait until completion | n: every n iterations
 
     # time-stepping
     [params.dt]
-        minimum      = 3e2    # yr, minimum time-step
+        minimum      = 3e1    # yr, minimum time-step
         maximum      = 1e7    # yr, maximum time-step
-        initial      = 1e3    # yr, inital step size
-        starspec     = 3e6    # yr, interval to re-calculate the stellar spectrum
-        starinst     = 1e2    # yr, interval to re-calculate the instellation
+        initial      = 3e1    # yr, inital step size
+        starspec     = 1e9    # yr, interval to re-calculate the stellar spectrum
+        starinst     = 1e1    # yr, interval to re-calculate the instellation
         method       = "adaptive"  # proportional | adaptive | maximum
 
         [params.dt.proportional]
@@ -45,7 +45,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
         [params.dt.adaptive]
             atol         = 0.02   # Step size atol
-            rtol         = 0.07   # Step size rtol
+            rtol         = 0.09   # Step size rtol
 
     # Termination criteria
     #     Set enabled=true/false in each section to enable/disable that termination criterion
@@ -64,7 +64,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         [params.stop.time]
             enabled = true
             minimum = 1.0e3     # yr, model will certainly run to t > minimum
-            maximum = 7.6e+9     # yr, model will terminate when t > maximum
+            maximum = 4.567e+9     # yr, model will terminate when t > maximum
 
         # solidification
         [params.stop.solid]
@@ -73,8 +73,8 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
         # radiative equilibrium
         [params.stop.radeqm]
-            enabled = false
-            atol    = 0.1     # absolute tolerance [W m-2]
+            enabled = true
+            atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
         [params.stop.escape]
@@ -87,15 +87,15 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 [star]
 
     # Physical parameters
-    mass    = 0.1      # M_sun
+    mass    = 1.0       # M_sun
     age_ini = 0.100     # Gyr, model initialisation/start age
 
-    module  = "mors"
+    module  = "dummy"
     [star.mors]
         rot_pctle = 50.0    # rotation percentile
-        tracks  = "spada" # evolution tracks: spada | baraffe
-        age_now = 7.6     # Gyr, current age of star used for scaling
-        spec    = "stellar_spectra/Named/trappist-1.txt" # stellar spectrum
+        tracks  = "baraffe" # evolution tracks: spada | baraffe
+        age_now = 4.567     # Gyr, current age of star used for scaling
+        spec    = "stellar_spectra/Named/sun.txt" # stellar spectrum
 
     [star.dummy]
         radius  = 1.0       # R_sun
@@ -103,15 +103,15 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
 # Orbital system
 [orbit]
-    semimajoraxis   = 0.01580    # AU
-    eccentricity    = 0.00654      # dimensionless
-    zenith_angle    = 54.74     # degrees
-    s0_factor       = 0.25      # dimensionless
+    semimajoraxis   = 1.0       # AU
+    eccentricity    = 0.0       # dimensionless
+    zenith_angle    = 48.19     # degrees
+    s0_factor       = 0.375     # dimensionless
 
     module  = "none"
 
     [orbit.dummy]
-        H_tide  = 1e-11  # Fixed tidal power density [W kg-1]
+        H_tide  = 1e-7  # Fixed tidal power density [W kg-1]
         Phi_tide = "<0.3"   # Tidal heating applied when inequality locally satisfied
 
     [orbit.lovepy]
@@ -119,9 +119,9 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
 # Planetary structure - physics table
 [struct]
-    set_by      = 'mass_tot' # Variable to set interior structure: 'radius_int' or 'mass_tot'
-    mass_tot    = 1.308       # M_earth
-    radius_int  = 1.0       # R_earth
+    set_by      = 'radius_int' # Variable to set interior structure: 'radius_int' or 'mass_tot'
+    mass_tot    = 1.0       # M_earth
+    radius_int  = 0.9       # R_earth
     corefrac    = 0.55      # non-dim., radius fraction
     core_density = 10738.33      # Core density [kg m-3]
     core_heatcap = 880.0         # Core specific heat capacity [J K-1 kg-1]
@@ -133,60 +133,59 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     surface_k       = 2.0       # W m-1 K-1, conductive skin thermal conductivity
     cloud_enabled   = false     # enable water cloud radiative effects
     cloud_alpha     = 0.0       # condensate retention fraction (1 -> fully retained)
-    surf_state      = "fixed"    # surface scheme: "mixed_layer" | "fixed" | "skin"
-    surf_greyalbedo = 0.2       # surface grey albedo
-    albedo_pl       = 0.0   	# Enforced Bond albedo (do not use with `rayleigh = true`)
-    rayleigh        = true      # Enable rayleigh scattering
+    surf_state      = "fixed"   # surface scheme: "mixed_layer" | "fixed" | "skin"
+    surf_greyalbedo  = 0.1      # surface grey albedo
+    albedo_pl       = 0.0   	# Bond albedo (scattering)
+    rayleigh        = false      # enable rayleigh scattering
     tmp_minimum     = 0.5           # temperature floor on solver
     tmp_maximum     = 5000.0        # temperature ceiling on solver
 
     module  = "agni"           # Which atmosphere module to use
 
     [atmos_clim.agni]
-        p_top           = 1.0e-5        # bar, top of atmosphere grid pressure
-        spectral_group  = "Honeyside"   # which gas opacities to include
-        spectral_bands  = "256"         # how many spectral bands?
-        num_levels      = 60            # Number of atmospheric grid levels
+        p_top           = 1.0e-7        # bar, top of atmosphere grid pressure
+        spectral_group  = "Dayspring"   # which gas opacities to include
+        spectral_bands  = "16"          # how many spectral bands?
+        num_levels      = 40            # Number of atmospheric grid levels
         chemistry       = "none"        # "none" | "eq"
         surf_material   = "greybody"    # surface material file for scattering
         solve_energy    = false         # solve for energy-conserving atmosphere profile
-        solution_atol   = 1e-2          # solver absolute tolerance
-        solution_rtol   = 5e-2          # solver relative tolerance
+        solution_atol   = 1e-3          # solver absolute tolerance
+        solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
-        condensation    = true          # volatile condensation
-        real_gas        = true          # use real-gas equations of state
+        condensation    = false          # volatile condensation
 
     [atmos_clim.janus]
-        p_top           = 1.0e-5        # bar, top of atmosphere grid pressure
+        p_top           = 1.0e-6        # bar, top of atmosphere grid pressure
         p_obs           = 1.0e-3        # bar, observed pressure level
-        spectral_group  = "Honeyside"   # which gas opacities to include
-        spectral_bands  = "256"         # how many spectral bands?
+        spectral_group  = "Frostflow"   # which gas opacities to include
+        spectral_bands  = "16"          # how many spectral bands?
         F_atm_bc        = 0             # measure outgoing flux at: (0) TOA | (1) Surface
-        num_levels      = 90            # Number of atmospheric grid levels
+        num_levels      = 40           # Number of atmospheric grid levels
         tropopause      = "none"        # none | skin | dynamic
         overlap_method    = "ee"          # gas overlap method
 
     [atmos_clim.dummy]
-        gamma           = 0.7           # atmosphere opacity between 0 and 1
+        gamma           = 0.8           # atmosphere opacity between 0 and 1
 
 # Volatile escape - physics table
 [escape]
 
-    module = "zephyrus"    # Which escape module to use
+    module = "dummy"    # Which escape module to use
 
     [escape.zephyrus]
         Pxuv        = 1e-2          # Pressure at which XUV radiation become opaque in the planetary atmosphere [bar]
-        efficiency  = 0.1           # Escape efficiency factor
+        efficiency  = 1.0           # Escape efficiency factor
         tidal       = false         # Tidal contribution enabled
 
     [escape.dummy]
-        rate        = 0.0           # Bulk unfractionated escape rate [kg s-1]
+        rate        = 2.0e4         # Bulk unfractionated escape rate [kg s-1]
 
 # Interior - physics table
 [interior]
     grain_size      = 0.1   # crystal settling grain size [m]
-    F_initial       = 1e5   # Initial heat flux guess [W m-2]
-    radiogenic_heat = true  # enable radiogenic heat production
+    F_initial       = 1e6   # Initial heat flux guess [W m-2]
+    radiogenic_heat = false  # enable radiogenic heat production
     tidal_heat      = false  # enable tidal heat production
     rheo_phi_loc    = 0.4    # Centre of rheological transition
     rheo_phi_wid    = 0.15   # Width of rheological transition
@@ -195,25 +194,25 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     module = "spider"   # Which interior module to use
 
     [interior.spider]
-        num_levels      = 100       # Number of SPIDER grid levels
+        num_levels      = 220       # Number of SPIDER grid levels
         mixing_length   = 2         # Mixing length parameterization
-        tolerance       = 1.0e-7   # solver tolerance
-        tsurf_atol      = 20.0      # tsurf_poststep_change
-        tsurf_rtol      = 0.01      # tsurf_poststep_change_frac
-        ini_entropy     = 3000.0    # Surface entropy conditions [J K-1 kg-1]
+        tolerance       = 1.0e-10   # solver tolerance
+        tsurf_atol      = 30.0      # tsurf_poststep_change
+        tsurf_rtol      = 0.02      # tsurf_poststep_change_frac
+        ini_entropy     = 2700.0    # Surface entropy conditions [J K-1 kg-1]
         ini_dsdr        = -4.698e-6 # Interior entropy gradient [J K-1 kg-1 m-1]
 
     [interior.aragog]
-        num_levels      = 220       # Number of Aragog grid levels
-        tolerance       = 1.0e-10   # solver tolerance
-        ini_tmagma      = 3200.0    # Initial magma surface temperature [K]
+        num_levels      = 100       # Number of Aragog grid levels
+        tolerance       = 1.0e-7   # solver tolerance
+        ini_tmagma      = 3300.0    # Initial magma surface temperature [K]
 
     [interior.dummy]
         ini_tmagma      = 3500.0    # Initial magma surface temperature [K]
 
 # Outgassing - physics table
 [outgas]
-    fO2_shift_IW    = 4         # log10(ΔIW), atmosphere/interior boundary oxidation state
+    fO2_shift_IW    = 2         # log10(ΔIW), atmosphere/interior boundary oxidation state
 
     module = "calliope"         # Which outgassing module to use
 
@@ -222,10 +221,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         include_CO2  = true     # Include CO2 compound
         include_N2   = true     # Include N2 compound
         include_S2   = true     # Include S2 compound
-        include_SO2  = true     # Include SO2 compound
-        include_H2   = true     # Include H2 compound
-        include_CH4  = true     # Include CH4 compound
-        include_CO   = true     # Include CO compound
+        include_SO2  = false     # Include SO2 compound
+        include_H2   = false     # Include H2 compound
+        include_CH4  = false     # Include CH4 compound
+        include_CO   = false     # Include CO compound
         T_floor      = 700.0    # Temperature floor applied to outgassing calculation [K].
 
     [outgas.atmodeller]
@@ -241,29 +240,29 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     radio_Th   = 0.124  # ppmw of thorium (all isotopes)
 
     # Which initial inventory to use?
-    initial = 'elements'        # "elements" | "volatiles"
+    initial = 'volatiles'        # "elements" | "volatiles"
 
     # No module for accretion as of yet
     module = "none"
 
     # Set initial volatile inventory by planetary element abundances
     [delivery.elements]
-        # H_oceans    = 8.0       # Hydrogen inventory in units of equivalent Earth oceans
+        # H_oceans    = 0.0       # Hydrogen inventory in units of equivalent Earth oceans
         H_ppmw      = 109.0     # Hydrogen inventory in ppmw relative to mantle mass
 
-        # CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
-        C_ppmw      = 109.0       # Carbon inventory in ppmw relative to mantle mass
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
+        # C_ppmw      = 0.0       # Carbon inventory in ppmw relative to mantle mass
 
         # NH_ratio    = 0.0       # N/H mass ratio in mantle/atmosphere system
-        N_ppmw      = 2.01      # Nitrogen inventory in ppmw relative to mantle mass
+        N_ppmw      = 2.0       # Nitrogen inventory in ppmw relative to mantle mass
 
-        # SH_ratio    = 0.0       # S/H mass ratio in mantle/atmosphere system
-        S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mantle mass
+        SH_ratio    = 2.0       # S/H mass ratio in mantle/atmosphere system
+        # S_ppmw      = 1.0     # Sulfur inventory in ppmw relative to mantle mass
 
     # Set initial volatile inventory by partial pressures in atmosphere
     [delivery.volatiles]
-        H2O  = 0.0           # partial pressure of H2O
-        CO2  = 0.0          # partial pressure of CO2
+        H2O  = 20.0          # partial pressure of H2O
+        CO2  = 30.0          # partial pressure of CO2
         N2   = 0.0          # etc
         S2   = 0.0
         SO2  = 0.0

--- a/input/planets/hd63433d.toml
+++ b/input/planets/hd63433d.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 5e-2          # solver relative tolerance
         overlap_method    = "ee"          # gas overlap method
         condensation    = true          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-5        # bar, top of atmosphere grid pressure

--- a/input/planets/k218b.toml
+++ b/input/planets/k218b.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 1e-1          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = true          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-5        # bar, top of atmosphere grid pressure

--- a/input/planets/l9859b.toml
+++ b/input/planets/l9859b.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 9e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = false         # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-5        # bar, top of atmosphere grid pressure

--- a/input/planets/l9859c.toml
+++ b/input/planets/l9859c.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 9e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = false         # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-5        # bar, top of atmosphere grid pressure

--- a/input/planets/l9859d.toml
+++ b/input/planets/l9859d.toml
@@ -154,6 +154,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 9e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = false         # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-5        # bar, top of atmosphere grid pressure

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -205,6 +205,7 @@ def init_agni_atmos(dirs:dict, config:Config, hf_row:dict):
                         condensates=condensates,
                         use_all_gases=include_all,
                         fastchem_work = fc_dir,
+                        real_gas = config.atmos_clim.agni.real_gas,
 
                         skin_d=config.atmos_clim.surface_d,
                         skin_k=config.atmos_clim.surface_k,
@@ -432,9 +433,14 @@ def _solve_once(atmos, condense:bool):
             Atmosphere struct
     """
 
+    log.info("    T_surf = %.3f K"%float(atmos.tmp_surf))
+
     # set temperature profile
     #    rainout volatiles
-    jl.AGNI.setpt.prevent_surfsupersat_b(atmos)
+    rained = jl.AGNI.setpt.prevent_surfsupersat_b(atmos)
+    rained = bool(rained)
+    if rained:
+        log.info("    gases are condensing at the surface")
     #    dry convection
     jl.AGNI.setpt.dry_adiabat_b(atmos)
     #    condensation above

--- a/tests/integration/dummy.toml
+++ b/tests/integration/dummy.toml
@@ -152,6 +152,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = true          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-6        # bar, top of atmosphere grid pressure

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -152,6 +152,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         solution_rtol   = 2e-2          # solver relative tolerance
         overlap_method  = "ee"          # gas overlap method
         condensation    = true          # volatile condensation
+        real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.janus]
         p_top           = 1.0e-6        # bar, top of atmosphere grid pressure


### PR DESCRIPTION
AGNI now supports real gas equations of state. It's useful to be able to toggle this via PROTEUS. Closes #335.

Also adds a config validator which disallows `surf_state=skin` when `solve_energy=false`. This combination is invalid, as it would completely decouple the atmosphere and interior temperatures.

This requires the user to update AGNI to version 1.1.0