### PR TITLE
Adding melting curves as a key on toml file

### DIFF
--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -1,4 +1,22 @@
 # PROTEUS configuration file (version 2.0)
+
+# Root tables should be physical, with the exception of "params"
+# Software related options should go within the appropriate physical table
+
+# The general structure is:
+#   [root]     metadata
+#   [params]   parameters for code execution, output files, time-stepping, convergence
+#   [star]     stellar parameters, model selection
+#   [orbit]    planetary orbital parameters
+#   [struct]   planetary structure (mass, radius)
+#   [atmos]    atmosphere parameters, model selection
+#   [escape]   escape parameters, model selection
+#   [interior] magma ocean model selection and parameters
+#   [outgas]   outgassing parameters (fO2) and included volatiles
+#   [delivery] initial volatile inventory, and delivery model selection
+
+# ----------------------------------------------------
+# Metadata
 version = "2.0"
 author  = "Harrison Nicholls, Tim Lichtenberg"
 
@@ -8,7 +26,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     # output files
     [params.out]
         path        = "dummy_aragog"
-        logging     = "DEBUG"
+        logging     = "INFO"
         plot_mod    = 1      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended
         write_mod   = 5      # Write CSV frequency, 0: wait until completion | n: every n iterations
@@ -24,16 +42,24 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
         # solidification
         [params.stop.solid]
-            enabled  = false
+            enabled  = true
             phi_crit = 0.005  # non-dim., model will terminate when global melt fraction < phi_crit
-
 
 # ----------------------------------------------------
 # Star
 [star]
+
+    # Physical parameters
     mass    = 1.0       # M_sun
     age_ini = 0.100     # Gyr, model initialisation/start age
-    module  = "dummy"
+
+    module  = "mors"
+    [star.mors]
+        rot_pcntle = 50.0    # rotation percentile
+        tracks  = "spada" # evolution tracks: spada | baraffe
+        age_now = 4.567     # Gyr, current age of star used for scaling
+        spec    = "stellar_spectra/Named/sun.txt" # stellar spectrum
+
     [star.dummy]
         radius  = 1.0       # R_sun
         Teff    = 5772.0    # K
@@ -45,24 +71,43 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     zenith_angle    = 48.19     # degrees
     s0_factor       = 0.375     # dimensionless
 
+    module  = "none"
+
+    [orbit.dummy]
+        H_tide  = 1e-7  # Fixed tidal power density [W kg-1]
+        Phi_tide = "<0.3"   # Tidal heating applied when inequality locally satisfied
+
+    [orbit.lovepy]
+        visc_thresh = 1e9   # Minimum viscosity required for heating [Pa s]
+
 # Planetary structure - physics table
 [struct]
-    radius_int  = 0.9       # R_earth
-    corefrac    = 0.55      # non-dim., radius fraction
+    set_by      = 'mass_tot' # Variable to set interior structure: 'radius_int' or 'mass_tot'
+    mass_tot    = 1.0       # M_earth
+    corefrac    = 0.65      # non-dim., radius fraction
+    core_density = 10738.33      # Core density [kg m-3]
+    core_heatcap = 880.0         # Core specific heat capacity [J K-1 kg-1]
 
 # Atmosphere - physics table
 [atmos_clim]
+    prevent_warming = true      # do not allow the planet to heat up
     surface_d       = 0.01      # m, conductive skin thickness
     surface_k       = 2.0       # W m-1 K-1, conductive skin thermal conductivity
+    cloud_enabled   = false     # enable water cloud radiative effects
+    cloud_alpha     = 0.0       # condensate retention fraction (1 -> fully retained)
     surf_state      = "fixed"   # surface scheme: "mixed_layer" | "fixed" | "skin"
+    surf_greyalbedo  = 0.1      # surface grey albedo
+    albedo_pl       = 0.0   	# Bond albedo (scattering)
     rayleigh        = false      # enable rayleigh scattering
+    tmp_minimum     = 0.5           # temperature floor on solver
+    tmp_maximum     = 5000.0        # temperature ceiling on solver
 
     module  = "agni"           # Which atmosphere module to use
 
     [atmos_clim.agni]
         p_top           = 1.0e-7        # bar, top of atmosphere grid pressure
-        spectral_group  = "Dayspring"   # which gas opacities to include
-        spectral_bands  = "16"          # how many spectral bands?
+        spectral_group  = "Honeyside"   # which gas opacities to include
+        spectral_bands  = "48"          # how many spectral bands?
         num_levels      = 40            # Number of atmospheric grid levels
         chemistry       = "none"        # "none" | "eq"
         surf_material   = "greybody"    # surface material file for scattering
@@ -73,17 +118,33 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         condensation    = false          # volatile condensation
         real_gas        = true          # use real-gas equations of state
 
-    [atmos_clim.dummy]
-        gamma           = 0.8           # atmosphere opacity between 0 and 1
+    [atmos_clim.janus]
+        p_top           = 1.0e-6        # bar, top of atmosphere grid pressure
+        p_obs           = 1.0e-3        # bar, observed pressure level
+        spectral_group  = "Frostflow"   # which gas opacities to include
+        spectral_bands  = "16"          # how many spectral bands?
+        F_atm_bc        = 0             # measure outgoing flux at: (0) TOA | (1) Surface
+        num_levels      = 40           # Number of atmospheric grid levels
+        tropopause      = "none"        # none | skin | dynamic
+        overlap_method    = "ee"          # gas overlap method
 
+    [atmos_clim.dummy]
+        gamma           = 0.01           # atmosphere opacity between 0 and 1
+
+# Volatile escape - physics table
 [escape]
 
-    reservoir = "bulk"  # Escaping reservoir: "bulk", "outgas", "pxuv".
     module = "dummy"    # Which escape module to use
 
-    [escape.dummy]
-        rate        = 2.0e4         # Bulk unfractionated escape rate [kg s-1]
+    [escape.zephyrus]
+        Pxuv        = 1e-2          # Pressure at which XUV radiation become opaque in the planetary atmosphere [bar]
+        efficiency  = 1.0           # Escape efficiency factor
+        tidal       = false         # Tidal contribution enabled
 
+    [escape.dummy]
+        rate        = 0.5         # Bulk unfractionated escape rate [kg s-1]
+
+# Interior - physics table
 [interior]
     grain_size      = 0.1   # crystal settling grain size [m]
     F_initial       = 1e6   # Initial heat flux guess [W m-2]
@@ -92,11 +153,12 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_loc    = 0.4    # Centre of rheological transition
     rheo_phi_wid    = 0.15   # Width of rheological transition
     bulk_modulus    = 260e9   # Bulk modulus [Pa]
+    melting_dir     ="Monteaux-600"
 
     module = "aragog"   # Which interior module to use
 
     [interior.spider]
-        num_levels      = 220       # Number of SPIDER grid levels
+        num_levels      = 100       # Number of SPIDER grid levels
         mixing_length   = 2         # Mixing length parameterization
         tolerance       = 1.0e-10   # solver tolerance
         tsurf_atol      = 30.0      # tsurf_poststep_change
@@ -105,7 +167,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         ini_dsdr        = -4.698e-6 # Interior entropy gradient [J K-1 kg-1 m-1]
 
     [interior.aragog]
-        num_levels      = 100       # Number of Aragog grid levels
+        num_levels      = 40       # Number of Aragog grid levels
         tolerance       = 1.0e-7   # solver tolerance
         ini_tmagma      = 3300.0    # Initial magma surface temperature [K]
 
@@ -114,18 +176,27 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
 # Outgassing - physics table
 [outgas]
-    fO2_shift_IW    = 2         # log10(ΔIW), atmosphere/interior boundary oxidation state
+    fO2_shift_IW    = 4         # log10(ΔIW), atmosphere/interior boundary oxidation state
 
     module = "calliope"         # Which outgassing module to use
 
     [outgas.calliope]
-        include_SO2  = false     # Include SO2 compound
-        include_H2S  = false     # Include H2S compound
-        include_NH3  = false     # Include NH3 compound
-        include_H2   = false     # Include H2 compound
-        include_CH4  = false     # Include CH4 compound
-        include_CO   = false     # Include CO compound
+        include_H2O  = true     # Include H2O compound
+        include_CO2  = true     # Include CO2 compound
+        include_N2   = true     # Include N2 compound
+        include_S2   = true     # Include S2 compound
+        include_SO2  = true     # Include SO2 compound
+        include_H2S  = true     # Include H2S compound
+        include_NH3  = true     # Include NH3 compound
+        include_H2   = true     # Include H2 compound
+        include_CH4  = true     # Include CH4 compound
+        include_CO   = true     # Include CO compound
+        T_floor      = 700.0    # Temperature floor applied to outgassing calculation [K].
 
+    [outgas.atmodeller]
+        some_parameter = "some_value"
+
+# Volatile delivery - physics table
 [delivery]
 
     # Radionuclide parameters
@@ -135,10 +206,24 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     radio_Th   = 0.124  # ppmw of thorium (all isotopes)
 
     # Which initial inventory to use?
-    initial = 'volatiles'        # "elements" | "volatiles"
+    initial = 'elements'        # "elements" | "volatiles"
 
     # No module for accretion as of yet
     module = "none"
+
+    # Set initial volatile inventory by planetary element abundances
+    [delivery.elements]
+        H_oceans    = 1.0       # Hydrogen inventory in units of equivalent Earth oceans
+        #H_ppmw      = 109.0     # Hydrogen inventory in ppmw relative to mantle mass
+
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
+        # C_ppmw      = 0.0       # Carbon inventory in ppmw relative to mantle mass
+
+        # NH_ratio    = 0.0       # N/H mass ratio in mantle/atmosphere system
+        N_ppmw      = 1.0       # Nitrogen inventory in ppmw relative to mantle mass
+
+        #SH_ratio    = 2.0       # S/H mass ratio in mantle/atmosphere system
+        S_ppmw      = 1.0     # Sulfur inventory in ppmw relative to mantle mass
 
     # Set initial volatile inventory by partial pressures in atmosphere
     [delivery.volatiles]
@@ -153,5 +238,8 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         CH4  = 0.0
         CO   = 0.0
 
+# Calculate simulated observations
 [observe]
+
+    # Module with which to calculate the synthetic observables
     synthesis = "none"

--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -1,22 +1,4 @@
 # PROTEUS configuration file (version 2.0)
-
-# Root tables should be physical, with the exception of "params"
-# Software related options should go within the appropriate physical table
-
-# The general structure is:
-#   [root]     metadata
-#   [params]   parameters for code execution, output files, time-stepping, convergence
-#   [star]     stellar parameters, model selection
-#   [orbit]    planetary orbital parameters
-#   [struct]   planetary structure (mass, radius)
-#   [atmos]    atmosphere parameters, model selection
-#   [escape]   escape parameters, model selection
-#   [interior] magma ocean model selection and parameters
-#   [outgas]   outgassing parameters (fO2) and included volatiles
-#   [delivery] initial volatile inventory, and delivery model selection
-
-# ----------------------------------------------------
-# Metadata
 version = "2.0"
 author  = "Harrison Nicholls, Tim Lichtenberg"
 
@@ -42,24 +24,16 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
         # solidification
         [params.stop.solid]
-            enabled  = true
+            enabled  = false
             phi_crit = 0.005  # non-dim., model will terminate when global melt fraction < phi_crit
+
 
 # ----------------------------------------------------
 # Star
 [star]
-
-    # Physical parameters
     mass    = 1.0       # M_sun
     age_ini = 0.100     # Gyr, model initialisation/start age
-
-    module  = "mors"
-    [star.mors]
-        rot_pcntle = 50.0    # rotation percentile
-        tracks  = "spada" # evolution tracks: spada | baraffe
-        age_now = 4.567     # Gyr, current age of star used for scaling
-        spec    = "stellar_spectra/Named/sun.txt" # stellar spectrum
-
+    module  = "dummy"
     [star.dummy]
         radius  = 1.0       # R_sun
         Teff    = 5772.0    # K
@@ -71,43 +45,26 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     zenith_angle    = 48.19     # degrees
     s0_factor       = 0.375     # dimensionless
 
-    module  = "none"
-
-    [orbit.dummy]
-        H_tide  = 1e-7  # Fixed tidal power density [W kg-1]
-        Phi_tide = "<0.3"   # Tidal heating applied when inequality locally satisfied
-
-    [orbit.lovepy]
-        visc_thresh = 1e9   # Minimum viscosity required for heating [Pa s]
+    module          ="none"
 
 # Planetary structure - physics table
 [struct]
-    set_by      = 'mass_tot' # Variable to set interior structure: 'radius_int' or 'mass_tot'
-    mass_tot    = 1.0       # M_earth
+    radius_int  = 0.9       # R_earth
     corefrac    = 0.65      # non-dim., radius fraction
-    core_density = 10738.33      # Core density [kg m-3]
-    core_heatcap = 880.0         # Core specific heat capacity [J K-1 kg-1]
 
 # Atmosphere - physics table
 [atmos_clim]
-    prevent_warming = true      # do not allow the planet to heat up
     surface_d       = 0.01      # m, conductive skin thickness
     surface_k       = 2.0       # W m-1 K-1, conductive skin thermal conductivity
-    cloud_enabled   = false     # enable water cloud radiative effects
-    cloud_alpha     = 0.0       # condensate retention fraction (1 -> fully retained)
     surf_state      = "fixed"   # surface scheme: "mixed_layer" | "fixed" | "skin"
-    surf_greyalbedo  = 0.1      # surface grey albedo
-    albedo_pl       = 0.0   	# Bond albedo (scattering)
     rayleigh        = false      # enable rayleigh scattering
-    tmp_minimum     = 0.5           # temperature floor on solver
-    tmp_maximum     = 5000.0        # temperature ceiling on solver
 
     module  = "agni"           # Which atmosphere module to use
 
     [atmos_clim.agni]
         p_top           = 1.0e-7        # bar, top of atmosphere grid pressure
-        spectral_group  = "Honeyside"   # which gas opacities to include
-        spectral_bands  = "48"          # how many spectral bands?
+        spectral_group  = "Dayspring"   # which gas opacities to include
+        spectral_bands  = "16"          # how many spectral bands?
         num_levels      = 40            # Number of atmospheric grid levels
         chemistry       = "none"        # "none" | "eq"
         surf_material   = "greybody"    # surface material file for scattering
@@ -118,33 +75,17 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         condensation    = false          # volatile condensation
         real_gas        = true          # use real-gas equations of state
 
-    [atmos_clim.janus]
-        p_top           = 1.0e-6        # bar, top of atmosphere grid pressure
-        p_obs           = 1.0e-3        # bar, observed pressure level
-        spectral_group  = "Frostflow"   # which gas opacities to include
-        spectral_bands  = "16"          # how many spectral bands?
-        F_atm_bc        = 0             # measure outgoing flux at: (0) TOA | (1) Surface
-        num_levels      = 40           # Number of atmospheric grid levels
-        tropopause      = "none"        # none | skin | dynamic
-        overlap_method    = "ee"          # gas overlap method
-
     [atmos_clim.dummy]
-        gamma           = 0.01           # atmosphere opacity between 0 and 1
+        gamma           = 0.8           # atmosphere opacity between 0 and 1
 
-# Volatile escape - physics table
 [escape]
 
+    reservoir = "bulk"  # Escaping reservoir: "bulk", "outgas", "pxuv".
     module = "dummy"    # Which escape module to use
 
-    [escape.zephyrus]
-        Pxuv        = 1e-2          # Pressure at which XUV radiation become opaque in the planetary atmosphere [bar]
-        efficiency  = 1.0           # Escape efficiency factor
-        tidal       = false         # Tidal contribution enabled
-
     [escape.dummy]
-        rate        = 0.5         # Bulk unfractionated escape rate [kg s-1]
+        rate        = 2.0e4         # Bulk unfractionated escape rate [kg s-1]
 
-# Interior - physics table
 [interior]
     grain_size      = 0.1   # crystal settling grain size [m]
     F_initial       = 1e6   # Initial heat flux guess [W m-2]
@@ -154,11 +95,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_wid    = 0.15   # Width of rheological transition
     bulk_modulus    = 260e9   # Bulk modulus [Pa]
     melting_dir     ="Monteaux-600"
-
     module = "aragog"   # Which interior module to use
 
     [interior.spider]
-        num_levels      = 100       # Number of SPIDER grid levels
+        num_levels      = 220       # Number of SPIDER grid levels
         mixing_length   = 2         # Mixing length parameterization
         tolerance       = 1.0e-10   # solver tolerance
         tsurf_atol      = 30.0      # tsurf_poststep_change
@@ -176,27 +116,18 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
 # Outgassing - physics table
 [outgas]
-    fO2_shift_IW    = 4         # log10(ΔIW), atmosphere/interior boundary oxidation state
+    fO2_shift_IW    = 2         # log10(ΔIW), atmosphere/interior boundary oxidation state
 
     module = "calliope"         # Which outgassing module to use
 
     [outgas.calliope]
-        include_H2O  = true     # Include H2O compound
-        include_CO2  = true     # Include CO2 compound
-        include_N2   = true     # Include N2 compound
-        include_S2   = true     # Include S2 compound
-        include_SO2  = true     # Include SO2 compound
-        include_H2S  = true     # Include H2S compound
-        include_NH3  = true     # Include NH3 compound
-        include_H2   = true     # Include H2 compound
-        include_CH4  = true     # Include CH4 compound
-        include_CO   = true     # Include CO compound
-        T_floor      = 700.0    # Temperature floor applied to outgassing calculation [K].
+        include_SO2  = false     # Include SO2 compound
+        include_H2S  = false     # Include H2S compound
+        include_NH3  = false     # Include NH3 compound
+        include_H2   = false     # Include H2 compound
+        include_CH4  = false     # Include CH4 compound
+        include_CO   = false     # Include CO compound
 
-    [outgas.atmodeller]
-        some_parameter = "some_value"
-
-# Volatile delivery - physics table
 [delivery]
 
     # Radionuclide parameters
@@ -238,8 +169,5 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         CH4  = 0.0
         CO   = 0.0
 
-# Calculate simulated observations
 [observe]
-
-    # Module with which to calculate the synthetic observables
     synthesis = "none"

--- a/src/proteus/config/_interior.py
+++ b/src/proteus/config/_interior.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from attrs import define, field
 from attrs.validators import ge, gt, in_, lt
+import platformdirs
+import os
+from pathlib import Path
 
+FWL_DATA_DIR = Path(os.environ.get('FWL_DATA', platformdirs.user_data_dir('fwl_data')))
 
 def valid_spider(instance, attribute, value):
     if instance.module != "spider":
@@ -11,6 +15,12 @@ def valid_spider(instance, attribute, value):
     ini_entropy = instance.spider.ini_entropy
     if (not ini_entropy) or (ini_entropy <= 200.0) :
         raise ValueError("`interior.spider.ini_entropy` must be >200")
+
+def path_exists(instance, attribute, value):
+    """Validator to check if the full directory path exists."""
+    full_path = FWL_DATA_DIR / "interior_lookup_tables/Melting_curves" / value
+    if not os.path.isdir(full_path):
+        raise ValueError(f"Directory '{full_path}' does not exist.")
 
 @define
 class Spider:
@@ -127,7 +137,7 @@ class Interior:
     """
 
     module: str             = field(validator=in_(('spider', 'aragog', 'dummy')))
-
+    melting_dir: str        = field(validator=path_exists)
     radiogenic_heat: bool   = field(default=True)
     tidal_heat: bool        = field(default=True)
 
@@ -140,3 +150,4 @@ class Interior:
     rheo_phi_loc: float     = field(default=0.3,    validator=(gt(0),lt(1)))
     rheo_phi_wid: float     = field(default=0.15,   validator=(gt(0),lt(1)))
     bulk_modulus: float     = field(default=260e9,  validator=gt(0))
+

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -137,6 +137,7 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
 
     # Get look up data directory, will be configurable in the future
     LOOK_UP_DIR = FWL_DATA_DIR / "interior_lookup_tables/1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018/"
+    MELTING_DIR=  FWL_DATA_DIR / "interior_lookup_tables/Melting_curves/"
 
     phase_liquid = _PhaseParameters(
             density = LOOK_UP_DIR / "density_melt.dat",
@@ -162,8 +163,8 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
             latent_heat_of_fusion = 4e6,
             rheological_transition_melt_fraction = config.interior.rheo_phi_loc,
             rheological_transition_width = config.interior.rheo_phi_wid,
-            solidus = LOOK_UP_DIR / "solidus.dat",
-            liquidus = LOOK_UP_DIR / "liquidus.dat",
+            solidus = MELTING_DIR / config.interior.melting_dir / "solidus.dat",
+            liquidus= MELTING_DIR / config.interior.melting_dir / "liquidus.dat",
             phase = "mixed",
             phase_transition_width = 0.1,
             grain_size = config.interior.grain_size,

--- a/tests/integration/dummy.toml
+++ b/tests/integration/dummy.toml
@@ -139,6 +139,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_loc    = 0.4    # Centre of rheological transition
     rheo_phi_wid    = 0.15   # Width of rheological transition
     bulk_modulus    = 260e9   # Bulk modulus [Pa]
+    melting_dir     ="Monteaux-600"
 
     module = "dummy"   # Which interior module to use
 

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -188,7 +188,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_loc    = 0.4    # Centre of rheological transition
     rheo_phi_wid    = 0.15   # Width of rheological transition
     bulk_modulus    = 260e9   # Bulk modulus [Pa]
-
+    melting_dir     ="Monteaux-600"
     module = "aragog"   # Which interior module to use
 
     [interior.spider]


### PR DESCRIPTION
Adds the melting curves as a key, therefore add a config object. I created a new folder on the 1TPa-dK09-elec-free folder in the OSF repository with three different sets of melting curves: 

1) Wolf_Bower+2018
2)Monteaux+2016 (shifted +600 from solidus to test liquidus and shifted liquidus -600 to test solidus)

In that way, it's possible to run grids using different melting curves that the user can define. 