### PR TITLE
New config keys on toml file from aragog interior model

### DIFF
--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -87,14 +87,14 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         rate        = 2.0e4         # Bulk unfractionated escape rate [kg s-1]
 
 [interior]
-    grain_size      = 0.1   # crystal settling grain size [m]
-    F_initial       = 1e6   # Initial heat flux guess [W m-2]
-    radiogenic_heat = false  # enable radiogenic heat production
-    tidal_heat      = false  # enable tidal heat production
-    rheo_phi_loc    = 0.4    # Centre of rheological transition
-    rheo_phi_wid    = 0.15   # Width of rheological transition
-    bulk_modulus    = 260e9   # Bulk modulus [Pa]
-    melting_dir     ="Monteux-600" #Liquidus from Monteux+2016 and solidus=liquidus-600
+    grain_size      = 0.1               # crystal settling grain size [m]
+    F_initial       = 1e6               # Initial heat flux guess [W m-2]
+    radiogenic_heat = false             # enable radiogenic heat production
+    tidal_heat      = false             # enable tidal heat production
+    rheo_phi_loc    = 0.4               # Centre of rheological transition
+    rheo_phi_wid    = 0.15              # Width of rheological transition
+    bulk_modulus    = 260e9             # Bulk modulus [Pa]
+    melting_dir     = "Monteux-600"     # Liquidus from Monteux+2016 and solidus=liquidus-600
 
     module = "aragog"   # Which interior module to use
 
@@ -113,10 +113,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         ini_tmagma                      = 3300.0   # Initial magma surface temperature [K]
         inner_boundary_condition        = 1        # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
         inner_boundary_value            = 4000     # core temperature [K], if inner_boundary_condition = 3. CMB heat flux [W/m^2], if if inner_boundary_condition = 2
-        conduction                      = true
-        convection                      = true
-        gravitational_separation        = false
-        mixing                          = false
+        conduction                      = true     # enable conductive heat transfer
+        convection                      = true     # enable convective heat transfer
+        gravitational_separation        = false    # enable gravitational separation
+        mixing                          = false    # enable mixing
 
     [interior.dummy]
         ini_tmagma      = 3500.0    # Initial magma surface temperature [K]

--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -63,8 +63,8 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
     [atmos_clim.agni]
         p_top           = 1.0e-7        # bar, top of atmosphere grid pressure
-        spectral_group  = "Dayspring"   # which gas opacities to include
-        spectral_bands  = "16"          # how many spectral bands?
+        spectral_group  = "Honeyside"   # which gas opacities to include
+        spectral_bands  = "48"          # how many spectral bands?
         num_levels      = 40            # Number of atmospheric grid levels
         chemistry       = "none"        # "none" | "eq"
         surf_material   = "greybody"    # surface material file for scattering
@@ -110,6 +110,12 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         num_levels      = 40       # Number of Aragog grid levels
         tolerance       = 1.0e-7   # solver tolerance
         ini_tmagma      = 3300.0    # Initial magma surface temperature [K]
+        inner_boundary_condition   = 1 # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
+        inner_boundary_value       = 4000# core temperature [K], if inner_boundary_condition = 3
+        conduction                 = true #How to manage this with SPIDER?
+        convection                 = true
+        gravitational_separation   = false
+        mixing                     = false
 
     [interior.dummy]
         ini_tmagma      = 3500.0    # Initial magma surface temperature [K]

--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -7,7 +7,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 [params]
     # output files
     [params.out]
-        path        = "dummy_0.1_heatflux0.1_monetux-600"
+        path        = "dummy_aragog"
         logging     = "INFO"
         plot_mod    = 1      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended

--- a/input/demos/aragog.toml
+++ b/input/demos/aragog.toml
@@ -7,7 +7,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 [params]
     # output files
     [params.out]
-        path        = "dummy_aragog"
+        path        = "dummy_0.1_heatflux0.1_monetux-600"
         logging     = "INFO"
         plot_mod    = 1      # Plotting frequency, 0: wait until completion | n: every n iterations
         plot_fmt    = "png"  # Plotting image file format, "png" or "pdf" recommended
@@ -59,7 +59,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     surf_state      = "fixed"   # surface scheme: "mixed_layer" | "fixed" | "skin"
     rayleigh        = false      # enable rayleigh scattering
 
-    module  = "agni"           # Which atmosphere module to use
+    module  = "dummy"           # Which atmosphere module to use
 
     [atmos_clim.agni]
         p_top           = 1.0e-7        # bar, top of atmosphere grid pressure
@@ -76,7 +76,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         real_gas        = true          # use real-gas equations of state
 
     [atmos_clim.dummy]
-        gamma           = 0.8           # atmosphere opacity between 0 and 1
+        gamma           = 0.01           # atmosphere opacity between 0 and 1
 
 [escape]
 
@@ -95,6 +95,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_wid    = 0.15   # Width of rheological transition
     bulk_modulus    = 260e9   # Bulk modulus [Pa]
     melting_dir     ="Monteux-600" #Liquidus from Monteux+2016 and solidus=liquidus-600
+
     module = "aragog"   # Which interior module to use
 
     [interior.spider]
@@ -107,15 +108,15 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         ini_dsdr        = -4.698e-6 # Interior entropy gradient [J K-1 kg-1 m-1]
 
     [interior.aragog]
-        num_levels      = 40       # Number of Aragog grid levels
-        tolerance       = 1.0e-7   # solver tolerance
-        ini_tmagma      = 3300.0    # Initial magma surface temperature [K]
-        inner_boundary_condition   = 1 # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
-        inner_boundary_value       = 4000# core temperature [K], if inner_boundary_condition = 3
-        conduction                 = true #How to manage this with SPIDER?
-        convection                 = true
-        gravitational_separation   = false
-        mixing                     = false
+        num_levels                      = 50       # Number of Aragog grid levels
+        tolerance                       = 1.0e-7   # solver tolerance
+        ini_tmagma                      = 3300.0   # Initial magma surface temperature [K]
+        inner_boundary_condition        = 1        # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
+        inner_boundary_value            = 4000     # core temperature [K], if inner_boundary_condition = 3. CMB heat flux [W/m^2], if if inner_boundary_condition = 2
+        conduction                      = true
+        convection                      = true
+        gravitational_separation        = false
+        mixing                          = false
 
     [interior.dummy]
         ini_tmagma      = 3500.0    # Initial magma surface temperature [K]

--- a/src/proteus/config/_interior.py
+++ b/src/proteus/config/_interior.py
@@ -68,6 +68,18 @@ class Aragog:
         Solver tolerance.
     ini_tmagma: float
         Initial magma surface temperature [K].
+    inner_boundary_condition: int
+        Type of inner boundary condition. Choices:  1 (core cooling), 2 (prescribed heat flux), 3 (prescribed temperature).
+    inner_boundary_value: float
+        Value of the inner boundary condition, either temperature or heat flux, depending on the chosen condition.
+    conduction: bool
+        Whether to include conductive heat transfer in the model. Default is True.
+    convection: bool
+        Whether to include convective heat transfer in the model. Default is True.
+    gravitational_separation: bool
+        Whether to include gravitational separation in the model. Default is False.
+    mixing: bool
+        Whether to include mixing in the model. Default is False.
     """
 
     logging: str                        = field(default='ERROR',validator=in_(('INFO', 'DEBUG', 'ERROR', 'WARNING')))
@@ -75,7 +87,7 @@ class Aragog:
     num_levels: int                     = field(default=100,    validator=ge(40))
     tolerance: float                    = field(default=1e-10,  validator=gt(0))
     inner_boundary_condition: int       = field(default=1, validator=ge(0))
-    inner_boundary_value:float          = field(default=4000, validator=ge(0))#what would be the minimum?
+    inner_boundary_value:float          = field(default=4000, validator=ge(0))
     conduction: bool                    = field(default=True)
     convection: bool                    = field(default=True)
     gravitational_separation: bool      = field(default=False)
@@ -135,6 +147,8 @@ class Interior:
         Parameters for running the aragog module.
     dummy: Dummy
         Parameters for running the dummy module.
+    melting_dir: str
+        Set of melting curves to use in the model.
     """
 
     module: str             = field(validator=in_(('spider', 'aragog', 'dummy')))

--- a/src/proteus/config/_interior.py
+++ b/src/proteus/config/_interior.py
@@ -70,11 +70,18 @@ class Aragog:
         Initial magma surface temperature [K].
     """
 
-    logging: str        = field(default='ERROR',
-                                validator=in_(('INFO', 'DEBUG', 'ERROR', 'WARNING')))
-    ini_tmagma: float   = field(default=None)
-    num_levels: int     = field(default=100,    validator=ge(40))
-    tolerance: float    = field(default=1e-10,  validator=gt(0))
+    logging: str                        = field(default='ERROR',validator=in_(('INFO', 'DEBUG', 'ERROR', 'WARNING')))
+    ini_tmagma: float                   = field(default=None)
+    num_levels: int                     = field(default=100,    validator=ge(40))
+    tolerance: float                    = field(default=1e-10,  validator=gt(0))
+    inner_boundary_condition: int       = field(default=1, validator=ge(0))
+    inner_boundary_value:float          = field(default=4000, validator=ge(0))#what would be the minimum?
+    conduction: bool                    = field(default=True)
+    convection: bool                    = field(default=True)
+    gravitational_separation: bool      = field(default=False)
+    mixing: bool                        = field(default=False)
+
+
 
 def valid_interiordummy(instance, attribute, value):
     if instance.module != "dummy":

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -102,7 +102,7 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
     boundary_conditions = _BoundaryConditionsParameters(
             outer_boundary_condition = 4, # 4 = prescribed heat flux
             outer_boundary_value = hf_row["F_atm"], # first guess surface heat flux [W/m2]
-            inner_boundary_condition =  config.interior.aragog.inner_boundary_condition,
+            inner_boundary_condition =  config.interior.aragog.inner_boundary_condition,# 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
             inner_boundary_value = config.interior.aragog.inner_boundary_value, # core temperature [K], if inner_boundary_condition = 3
             emissivity = 1, # only used in gray body BC, outer_boundary_condition = 1
             equilibrium_temperature = hf_row["T_eqm"], # only used in gray body BC, outer_boundary_condition = 1

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -102,8 +102,8 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
     boundary_conditions = _BoundaryConditionsParameters(
             outer_boundary_condition = 4, # 4 = prescribed heat flux
             outer_boundary_value = hf_row["F_atm"], # first guess surface heat flux [W/m2]
-            inner_boundary_condition = 1, # 1 = core cooling model, 3 = prescribed temperature
-            inner_boundary_value = 4000, # core temperature [K], if inner_boundary_condition = 3
+            inner_boundary_condition =  config.interior.aragog.inner_boundary_condition,
+            inner_boundary_value = config.interior.aragog.inner_boundary_value, # core temperature [K], if inner_boundary_condition = 3
             emissivity = 1, # only used in gray body BC, outer_boundary_condition = 1
             equilibrium_temperature = hf_row["T_eqm"], # only used in gray body BC, outer_boundary_condition = 1
             core_density = config.struct.core_density, # used if inner_boundary_condition = 1
@@ -121,10 +121,10 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
             )
 
     energy = _EnergyParameters(
-            conduction = True,
-            convection = True,
-            gravitational_separation = False,
-            mixing = False,
+            conduction = config.interior.aragog.conduction,
+            convection = config.interior.aragog.convection,
+            gravitational_separation = config.interior.aragog.gravitational_separation,
+            mixing = config.interior.aragog.mixing,
             radionuclides = config.interior.radiogenic_heat,
             tidal = config.interior.tidal_heat,
             tidal_array = interior_o.tides

--- a/tests/integration/dummy.toml
+++ b/tests/integration/dummy.toml
@@ -139,7 +139,7 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_loc    = 0.4    # Centre of rheological transition
     rheo_phi_wid    = 0.15   # Width of rheological transition
     bulk_modulus    = 260e9   # Bulk modulus [Pa]
-    melting_dir     ="Monteux-600"
+    melting_dir     = "Monteux-600"
 
     module = "dummy"   # Which interior module to use
 

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -188,7 +188,8 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
     rheo_phi_loc    = 0.4           # Centre of rheological transition
     rheo_phi_wid    = 0.15          # Width of rheological transition
     bulk_modulus    = 260e9         # Bulk modulus [Pa]
-    melting_dir     ="Monteux-600"
+    melting_dir     = "Monteux-600" # Liquidus from Monteux+2016 and solidus=liquidus-600
+
     module = "aragog"               # Which interior module to use
 
     [interior.spider]
@@ -207,10 +208,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         ini_tmagma                    = 3000.0   # Initial magma surface temperature [K]
         inner_boundary_condition      = 1        # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
         inner_boundary_value          = 4000     # core temperature [K], if inner_boundary_condition = 3. CMB heat flux [W/m^2], if if inner_boundary_condition = 2
-        conduction                    = true
-        convection                    = true
-        gravitational_separation      = false
-        mixing                        = false
+        conduction                    = true     # enable conductive heat transfer
+        convection                    = true     # enable convective heat transfer
+        gravitational_separation      = false    # enable gravitational separation
+        mixing                        = false    # enable mixing
 
 
     [interior.dummy]

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -181,15 +181,15 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
 
 # Interior - physics table
 [interior]
-    grain_size      = 0.1   # crystal settling grain size [m]
-    F_initial       = 1e6   # Initial heat flux guess [W m-2]
-    radiogenic_heat = true  # enable radiogenic heat production
-    tidal_heat      = false  # enable tidal heat production
-    rheo_phi_loc    = 0.4    # Centre of rheological transition
-    rheo_phi_wid    = 0.15   # Width of rheological transition
-    bulk_modulus    = 260e9   # Bulk modulus [Pa]
+    grain_size      = 0.1           # crystal settling grain size [m]
+    F_initial       = 1e6           # Initial heat flux guess [W m-2]
+    radiogenic_heat = true          # enable radiogenic heat production
+    tidal_heat      = false         # enable tidal heat production
+    rheo_phi_loc    = 0.4           # Centre of rheological transition
+    rheo_phi_wid    = 0.15          # Width of rheological transition
+    bulk_modulus    = 260e9         # Bulk modulus [Pa]
     melting_dir     ="Monteux-600"
-    module = "aragog"   # Which interior module to use
+    module = "aragog"               # Which interior module to use
 
     [interior.spider]
         num_levels      = 220       # Number of SPIDER grid levels
@@ -204,10 +204,10 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         logging                       = "ERROR"
         num_levels                    = 90       # Number of Aragog grid levels
         tolerance                     = 1.0e-7   # solver tolerance
-        ini_tmagma                    = 3000.0    # Initial magma surface temperature [K]
-        inner_boundary_condition      = 1 # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
-        inner_boundary_value          = 4000 # core temperature [K], if inner_boundary_condition = 3
-        conduction                    = true #How to manage this with SPIDER?
+        ini_tmagma                    = 3000.0   # Initial magma surface temperature [K]
+        inner_boundary_condition      = 1        # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
+        inner_boundary_value          = 4000     # core temperature [K], if inner_boundary_condition = 3. CMB heat flux [W/m^2], if if inner_boundary_condition = 2
+        conduction                    = true
         convection                    = true
         gravitational_separation      = false
         mixing                        = false

--- a/tests/integration/physical.toml
+++ b/tests/integration/physical.toml
@@ -201,10 +201,17 @@ author  = "Harrison Nicholls, Tim Lichtenberg"
         ini_dsdr        = -4.698e-6 # Interior entropy gradient [J K-1 kg-1 m-1]
 
     [interior.aragog]
-        logging         = "ERROR"
-        num_levels      = 90       # Number of Aragog grid levels
-        tolerance       = 1.0e-7   # solver tolerance
-        ini_tmagma      = 3000.0    # Initial magma surface temperature [K]
+        logging                       = "ERROR"
+        num_levels                    = 90       # Number of Aragog grid levels
+        tolerance                     = 1.0e-7   # solver tolerance
+        ini_tmagma                    = 3000.0    # Initial magma surface temperature [K]
+        inner_boundary_condition      = 1 # 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
+        inner_boundary_value          = 4000 # core temperature [K], if inner_boundary_condition = 3
+        conduction                    = true #How to manage this with SPIDER?
+        convection                    = true
+        gravitational_separation      = false
+        mixing                        = false
+
 
     [interior.dummy]
         ini_tmagma      = 3500.0    # Initial magma surface temperature [K]

--- a/tools/grid_proteus.py
+++ b/tools/grid_proteus.py
@@ -446,8 +446,8 @@ if __name__=='__main__':
     # Define parameter grid
     # -----
 
-    config = "demos/aragog.toml"
-    folder = "dummy_vs_agni"
+    config = "planets/l9859d.toml"
+    folder = "l98d_escape12"
 
     cfg_base = os.path.join(PROTEUS_DIR,"input",config)
     # symlink = "/network/group/aopp/planetary/RTP035_NICHOLLS_PROTEUS/outputs/"+folder
@@ -457,6 +457,11 @@ if __name__=='__main__':
     pg.add_dimension("Redox state", "outgas.fO2_shift_IW")
     pg.set_dimension_direct("Redox state", [-5, -4, -3, -2, -1])
 
+    pg.add_dimension("Hydrogen", "delivery.elements.H_ppmw")
+    pg.set_dimension_direct("Hydrogen", [1e3, 8e3, 1e4])
+
+    pg.add_dimension("Sulfur", "delivery.elements.SH_ratio")
+    pg.set_dimension_direct("Sulfur", [6.0, 9.0, 12.0])
 
     # pg.add_dimension("Mass", "struct.mass_tot")
     # pg.set_dime nsion_direct("Mass", [1.85, 2.14, 2.39])
@@ -471,7 +476,7 @@ if __name__=='__main__':
     # -----
     # Start PROTEUS processes
     # -----
-    pg.run(5, test_run=False)
+    pg.run(100, test_run=False)
 
     # When this script ends, it means that all processes ARE complete or they
     # have been killed or crashed.

--- a/tools/grid_proteus.py
+++ b/tools/grid_proteus.py
@@ -446,8 +446,8 @@ if __name__=='__main__':
     # Define parameter grid
     # -----
 
-    config = "planets/l9859d.toml"
-    folder = "l98d_escape12"
+    config = "demos/aragog.toml"
+    folder = "dummy_vs_agni"
 
     cfg_base = os.path.join(PROTEUS_DIR,"input",config)
     # symlink = "/network/group/aopp/planetary/RTP035_NICHOLLS_PROTEUS/outputs/"+folder
@@ -457,11 +457,6 @@ if __name__=='__main__':
     pg.add_dimension("Redox state", "outgas.fO2_shift_IW")
     pg.set_dimension_direct("Redox state", [-5, -4, -3, -2, -1])
 
-    pg.add_dimension("Hydrogen", "delivery.elements.H_ppmw")
-    pg.set_dimension_direct("Hydrogen", [1e3, 8e3, 1e4])
-
-    pg.add_dimension("Sulfur", "delivery.elements.SH_ratio")
-    pg.set_dimension_direct("Sulfur", [6.0, 9.0, 12.0])
 
     # pg.add_dimension("Mass", "struct.mass_tot")
     # pg.set_dime nsion_direct("Mass", [1.85, 2.14, 2.39])
@@ -476,7 +471,7 @@ if __name__=='__main__':
     # -----
     # Start PROTEUS processes
     # -----
-    pg.run(100, test_run=False)
+    pg.run(5, test_run=False)
 
     # When this script ends, it means that all processes ARE complete or they
     # have been killed or crashed.


### PR DESCRIPTION
Adding new keys on toml file from aragog interior model, as described in [#358](https://github.com/FormingWorlds/PROTEUS/issues/358) . This includes:

- Inner boundary condition (1 = core cooling model, 2=prescribed heat flux, 3 = prescribed temperature)
- Inner boundary value (core temperature [K], if inner_boundary_condition = 3. CMB heat flux [W/m^2], if inner_boundary_condition = 2)
- conduction, convection, gravitational separation and mixing (whether to include or ignore each of them)

Therefore, the user can choose the different configurations on the .toml file