### PR TITLE
Fix 353

### DIFF
--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import netCDF4 as nc
 import numpy as np
 import pandas as pd
+import hashlib
 import platformdirs
 from aragog import Output, Solver, aragog_file_logger
 from aragog.parser import (
@@ -35,26 +36,66 @@ if TYPE_CHECKING:
 FWL_DATA_DIR = Path(os.environ.get('FWL_DATA',
                                    platformdirs.user_data_dir('fwl_data')))
 
-class AragogRunner:
+def _summarize_for_hash(obj):
+    """Generate a fast, approximate hashable summary of an object."""
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    elif isinstance(obj, (list, tuple)):
+        return tuple(_summarize_for_hash(x) for x in obj)
+    elif isinstance(obj, dict):
+        return tuple(sorted((k, _summarize_for_hash(v)) for k, v in obj.items()))
+    elif isinstance(obj, np.ndarray):
+        if obj.size > 5000:  # Heuristic threshold
+            return (
+                obj.shape,
+                obj.dtype.str,
+                round(float(np.nanmean(obj)), 6),
+                round(float(np.nanstd(obj)), 6),
+                round(float(np.nanmin(obj)), 6),
+                round(float(np.nanmax(obj)), 6),
+            )
+        else:
+            return tuple(obj.ravel().tolist())
+    elif hasattr(obj, '__dict__'):
+        return _summarize_for_hash(vars(obj))
+    else:
+        return str(type(obj)) + repr(obj)
+
+
+class MultitonBase:
     _instances = {}
 
     def __new__(cls, *args, **kwargs):
-        # Build a cache key from the object identities of all args and kwargs
-        key = (
-            tuple(id(arg) for arg in args),
-            tuple(sorted((k, id(v)) for k, v in kwargs.items()))
-        )
-
-        if key in cls._instances:
-            return cls._instances[key]
+        try:
+            key = cls._build_key(args, kwargs)
+            if key in cls._instances:
+                return cls._instances[key]
+        except Exception as e:
+            print(("[Multiton warning] Falling back to uncached instance "
+                  f"due to: {e}"))
+            return super().__new__(cls)
 
         instance = super().__new__(cls)
-        instance._initialized = False
         cls._instances[key] = instance
         return instance
 
+    @classmethod
+    def _build_key(cls, args, kwargs):
+        summary = (
+            tuple(_summarize_for_hash(arg) for arg in args),
+            tuple(sorted((k, _summarize_for_hash(v)) for k, v
+                         in kwargs.items()))
+        )
+        return summary
+
+
+class AragogRunner(MultitonBase):
+
     def __init__(self, config: Config, dirs: dict, hf_row: dict, hf_all:
                  pd.DataFrame, interior_o: Interior_t):
+        if getattr(self, "_initialized", False):
+            return
+        self._initialized = True
         AragogRunner.setup_logger(config, dirs)
         dt = AragogRunner.compute_time_step(config, dirs, hf_row, hf_all,
                                             interior_o)

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 import netCDF4 as nc
 import numpy as np
 import pandas as pd
-import hashlib
 import platformdirs
 from aragog import Output, Solver, aragog_file_logger
 from aragog.parser import (

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -36,6 +36,22 @@ FWL_DATA_DIR = Path(os.environ.get('FWL_DATA',
                                    platformdirs.user_data_dir('fwl_data')))
 
 class AragogRunner:
+    _instances = {}
+
+    def __new__(cls, *args, **kwargs):
+        # Build a cache key from the object identities of all args and kwargs
+        key = (
+            tuple(id(arg) for arg in args),
+            tuple(sorted((k, id(v)) for k, v in kwargs.items()))
+        )
+
+        if key in cls._instances:
+            return cls._instances[key]
+
+        instance = super().__new__(cls)
+        cls._instances[key] = instance
+        return instance
+
     def __init__(self, config: Config, dirs: dict, hf_row: dict, hf_all:
                  pd.DataFrame, interior_o: Interior_t):
         self.aragog_solver = None

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -47,7 +47,6 @@ class AragogRunner():
         self.setup_or_update_solver(config, hf_row, interior_o, dt, dirs)
         interior_o.aragog_solver.initialize()
         self.aragog_solver = interior_o.aragog_solver
-        print("Aragog solver initialized")
 
     @staticmethod
     def setup_logger(config: Config, dirs: dict):
@@ -275,10 +274,8 @@ class AragogRunner():
             interior_o.aragog_solver.parameters.scalings.power_per_mass)
 
     def run_solver(self, hf_row, interior_o, dirs):
-        print(f"Initial sim time: {self.aragog_solver.parameters.solver.start_time}")
         # Run Aragog solver
         self.aragog_solver.solve()
-        print(f"Final sim time: {self.aragog_solver.parameters.solver.end_time}")
         # Get Aragog output
         output = self.get_output(hf_row, interior_o)
         sim_time = self.aragog_solver.parameters.solver.end_time

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -36,15 +36,13 @@ FWL_DATA_DIR = Path(os.environ.get('FWL_DATA',
                                    platformdirs.user_data_dir('fwl_data')))
 
 class AragogRunner:
-    def __init__(self):
+    def __init__(self, config: Config, dirs: dict, hf_row: dict, hf_all:
+                 pd.DataFrame, interior_o: Interior_t):
         self.aragog_solver = None
-
-    def run(self, config: Config, dirs: dict, hf_row: dict, hf_all:
-            pd.DataFrame, interior_o: Interior_t):
         AragogRunner.setup_logger(config, dirs)
         dt = self.compute_time_step(config, dirs, hf_row, hf_all, interior_o)
         self.setup_or_update_solver(config, hf_row, interior_o, dt, dirs)
-        return self.run_solver(hf_row, interior_o, dirs)
+        self.aragog_solver.initialize()
 
     @staticmethod
     def setup_logger(config: Config, dirs: dict):
@@ -266,7 +264,6 @@ class AragogRunner:
 
     def run_solver(self, hf_row, interior_o, dirs):
         # Run Aragog solver
-        self.aragog_solver.initialize()
         self.aragog_solver.solve()
 
         # Get Aragog output

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -32,114 +32,133 @@ from proteus.utils.constants import R_earth, radnuc_data, secs_per_year
 if TYPE_CHECKING:
     from proteus.config import Config
 
-aragog_solver = None
-log = logging.getLogger("fwl."+__name__)
+FWL_DATA_DIR = Path(os.environ.get('FWL_DATA',
+                                   platformdirs.user_data_dir('fwl_data')))
 
-FWL_DATA_DIR = Path(os.environ.get('FWL_DATA', platformdirs.user_data_dir('fwl_data')))
+class AragogRunner:
+    def __init__(self):
+        self.aragog_solver = None
 
-# Run the Aragog interior module
-def RunAragog(config:Config, dirs:dict,
-                hf_row:dict, hf_all:pd.DataFrame, interior_o:Interior_t):
+    def run(self, config: Config, dirs: dict, hf_row: dict, hf_all:
+            pd.DataFrame, interior_o: Interior_t):
+        AragogRunner.setup_logger(config, dirs)
+        dt = self.compute_time_step(config, dirs, hf_row, hf_all, interior_o)
+        self.setup_or_update_solver(config, hf_row, interior_o, dt, dirs)
+        return self.run_solver(hf_row, interior_o, dirs)
 
-    global aragog_solver
+    @staticmethod
+    def setup_logger(config: Config, dirs: dict):
+        file_level = logging.getLevelName(config.interior.aragog.logging)
+        aragog_file_logger(console_level=logging.WARNING, file_level=file_level,
+                           log_dir=dirs["output"])
 
-    # Setup Aragog logger
-    file_level = logging.getLevelName(config.interior.aragog.logging)
-    aragog_file_logger(console_level = logging.WARNING,
-                       file_level = file_level,
-                       log_dir = dirs["output"])
+    def compute_time_step(self, config: Config, dirs: dict, hf_row: dict,
+                          hf_all: pd.DataFrame, interior_o: Interior_t) -> (
+            float):
+        if interior_o.ic == 1:
+            self.aragog_solver = None
+            return 0.0
+        else:
+            step_sf = 1.0  # dt scale factor
+            return next_step(config, dirs, hf_row, hf_all, step_sf)
 
-    # Compute time step
-    if interior_o.ic==1:
-        dt = 0.0
-        aragog_solver = None
-    else:
-        step_sf = 1.0 # dt scale factor
-        dt = next_step(config, dirs, hf_row, hf_all, step_sf)
+    def setup_or_update_solver(self, config: Config, hf_row: dict,
+                               interior_o: Interior_t, dt: float, dirs: dict):
+        if self.aragog_solver is None:
+            self.setup_solver(config, hf_row, interior_o)
+            if config.params.resume:
+                self.update_solver(dt, hf_row, interior_o,
+                                   output_dir=dirs["output"])
+        else:
+            self.update_solver(dt, hf_row, interior_o)
 
-    # Setup Aragog parameters from options at first iteration
-    if (aragog_solver is None):
-        SetupAragogSolver(config, hf_row, interior_o)
-        # Update state from stored data if resuming a simulation
-        if config.params.resume:
-            UpdateAragogSolver(dt, hf_row, interior_o, output_dir=dirs["output"])
-    # Update varying parameters in ongoing simulation
-    else:
-        UpdateAragogSolver(dt, hf_row, interior_o)
+    def setup_solver(self, config:Config, hf_row:dict, interior_o:Interior_t):
 
-    # Run Aragog solver
-    aragog_solver.initialize()
-    aragog_solver.solve()
-
-    # Get Aragog output
-    output = GetAragogOutput(hf_row, interior_o)
-    sim_time = aragog_solver.parameters.solver.end_time
-
-    # Write output to a file
-    WriteAragogOutput(dirs["output"],sim_time)
-
-    return sim_time, output
-
-
-def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
-
-    global aragog_solver
-
-    scalings = _ScalingsParameters(
+        scalings = _ScalingsParameters(
             radius = R_earth, # scaling radius [m]
             temperature = 4000, # scaling temperature [K]
             density = 4000, # scaling density
             time = secs_per_year, # scaling time [sec]
             )
 
-    solver = _SolverParameters(
+        solver = _SolverParameters(
             start_time = 0,
             end_time = 0,
             atol = config.interior.aragog.tolerance,
             rtol = config.interior.aragog.tolerance,
             )
 
-    boundary_conditions = _BoundaryConditionsParameters(
-            outer_boundary_condition = 4, # 4 = prescribed heat flux
-            outer_boundary_value = hf_row["F_atm"], # first guess surface heat flux [W/m2]
-            inner_boundary_condition =  config.interior.aragog.inner_boundary_condition,# 1 = core cooling model, 2=prescribed heatflux, 3 = prescribed temperature
-            inner_boundary_value = config.interior.aragog.inner_boundary_value, # core temperature [K], if inner_boundary_condition = 3
-            emissivity = 1, # only used in gray body BC, outer_boundary_condition = 1
-            equilibrium_temperature = hf_row["T_eqm"], # only used in gray body BC, outer_boundary_condition = 1
-            core_density = config.struct.core_density, # used if inner_boundary_condition = 1
-            core_heat_capacity = 880, # used if inner_boundary_condition = 1
+        boundary_conditions = _BoundaryConditionsParameters(
+            # 4 = prescribed heat flux
+            outer_boundary_condition = 4,
+            # first guess surface heat flux [W/m2]
+            outer_boundary_value = hf_row["F_atm"],
+            # 1 = core cooling model
+            # 2 = prescribed heat flux
+            # 3 = prescribed temperature
+            inner_boundary_condition =  (
+                config.interior.aragog.inner_boundary_condition),
+            # core temperature [K], if inner_boundary_condition = 3
+            inner_boundary_value = (
+                config.interior.aragog.inner_boundary_value),
+            # only used in gray body BC, outer_boundary_condition = 1
+            emissivity = 1,
+            # only used in gray body BC, outer_boundary_condition = 1
+            equilibrium_temperature = hf_row["T_eqm"],
+            # used if inner_boundary_condition = 1
+            core_density = config.struct.core_density,
+            # used if inner_boundary_condition = 1
+            core_heat_capacity = 880,
             )
 
-    mesh = _MeshParameters(
-            outer_radius = hf_row["R_int"], # planet radius [m]
-            inner_radius = config.struct.corefrac * hf_row["R_int"], # core radius [m]
-            number_of_nodes = config.interior.aragog.num_levels, # basic nodes
+        mesh = _MeshParameters(
+            # planet radius [m]
+            outer_radius = hf_row["R_int"],
+            # core radius [m]
+            inner_radius = config.struct.corefrac * hf_row["R_int"],
+            # basic nodes
+            number_of_nodes = config.interior.aragog.num_levels,
             mixing_length_profile = "constant",
-            surface_density = 4090, # AdamsWilliamsonEOS parameter [kg/m3]
-            gravitational_acceleration = hf_row["gravity"], # [m/s-2]
-            adiabatic_bulk_modulus = config.interior.bulk_modulus, # AW-EOS parameter [Pa]
+            # AdamsWilliamsonEOS parameter [kg/m3]
+            surface_density = 4090,
+            # [m/s-2]
+            gravitational_acceleration = hf_row["gravity"],
+            # AW-EOS parameter [Pa]
+            adiabatic_bulk_modulus = config.interior.bulk_modulus,
             )
 
-    energy = _EnergyParameters(
+        energy = _EnergyParameters(
             conduction = config.interior.aragog.conduction,
             convection = config.interior.aragog.convection,
-            gravitational_separation = config.interior.aragog.gravitational_separation,
+            gravitational_separation = (
+                config.interior.aragog.gravitational_separation),
             mixing = config.interior.aragog.mixing,
             radionuclides = config.interior.radiogenic_heat,
             tidal = config.interior.tidal_heat,
             tidal_array = interior_o.tides
             )
 
-    initial_condition = _InitialConditionParameters(
-            initial_condition = 3, # 1 = linear profile, 2 = user-defined profile, 3 = adiabatic profile
-            surface_temperature = config.interior.aragog.ini_tmagma, # initial top temperature (K)
+        initial_condition = _InitialConditionParameters(
+            # 1 = linear profile
+            # 2 = user-defined profile
+            # 3 = adiabatic profile
+            initial_condition = 3,
+            # initial top temperature (K)
+            surface_temperature = config.interior.aragog.ini_tmagma,
             )
 
-    # Get look up data directory, will be configurable in the future
-    LOOK_UP_DIR = FWL_DATA_DIR / "interior_lookup_tables/1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018/"
-    MELTING_DIR=  FWL_DATA_DIR / "interior_lookup_tables/Melting_curves/"
+        # Get look up data directory, will be configurable in the future
+        LOOK_UP_DIR = (
+            FWL_DATA_DIR /
+            "interior_lookup_tables/1TPa-dK09-elec-free/"
+            "MgSiO3_Wolf_Bower_2018/"
+        )
+        MELTING_DIR = (
+            FWL_DATA_DIR /
+            "interior_lookup_tables/Melting_curves/"
+        )
 
-    phase_liquid = _PhaseParameters(
+        phase_liquid = _PhaseParameters(
             density = LOOK_UP_DIR / "density_melt.dat",
             viscosity = 1E2,
             heat_capacity = LOOK_UP_DIR / "heat_capacity_melt.dat",
@@ -149,7 +168,7 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
             thermal_expansivity = LOOK_UP_DIR / "thermal_exp_melt.dat",
             )
 
-    phase_solid = _PhaseParameters(
+        phase_solid = _PhaseParameters(
             density = LOOK_UP_DIR / "density_solid.dat",
             viscosity = 1E21,
             heat_capacity = LOOK_UP_DIR / "heat_capacity_solid.dat",
@@ -159,44 +178,47 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
             thermal_expansivity = LOOK_UP_DIR / "thermal_exp_solid.dat",
             )
 
-    phase_mixed = _PhaseMixedParameters(
+        phase_mixed = _PhaseMixedParameters(
             latent_heat_of_fusion = 4e6,
             rheological_transition_melt_fraction = config.interior.rheo_phi_loc,
             rheological_transition_width = config.interior.rheo_phi_wid,
             solidus = MELTING_DIR / config.interior.melting_dir / "solidus.dat",
-            liquidus= MELTING_DIR / config.interior.melting_dir / "liquidus.dat",
+            liquidus = (MELTING_DIR / config.interior.melting_dir /
+                       "liquidus.dat"),
             phase = "mixed",
             phase_transition_width = 0.1,
             grain_size = config.interior.grain_size,
             )
 
-    radionuclides = []
-    if config.interior.radiogenic_heat:
-        # offset by age_ini, which converts model simulation time to the actual age
-        radio_t0 = config.delivery.radio_tref - config.star.age_ini
-        radio_t0 *= 1e9 # Convert Gyr to yr
+        radionuclides = []
+        if config.interior.radiogenic_heat:
+            # offset by age_ini, which converts model simulation time to the
+            # actual age
+            radio_t0 = config.delivery.radio_tref - config.star.age_ini
+            radio_t0 *= 1e9 # Convert Gyr to yr
 
-        def _append_radnuc(_iso, _cnc):
-            radionuclides.append(_Radionuclide(
-                                    name = _iso,
-                                    t0_years = radio_t0,
-                                    abundance = radnuc_data[_iso]["abundance"],
-                                    concentration = _cnc,
-                                    heat_production = radnuc_data[_iso]["heatprod"],
-                                    half_life_years = radnuc_data[_iso]["halflife"],
-                                ))
+            def _append_radnuc(_iso, _cnc):
+                radionuclides.append(
+                    _Radionuclide(
+                        name = _iso,
+                        t0_years = radio_t0,
+                        abundance = radnuc_data[_iso]["abundance"],
+                        concentration = _cnc,
+                        heat_production = radnuc_data[_iso]["heatprod"],
+                        half_life_years = radnuc_data[_iso]["halflife"],
+                    ))
 
-        if config.delivery.radio_K > 0.0:
-            _append_radnuc("k40", config.delivery.radio_K)
+            if config.delivery.radio_K > 0.0:
+                _append_radnuc("k40", config.delivery.radio_K)
 
-        if config.delivery.radio_Th > 0.0:
-            _append_radnuc("th232", config.delivery.radio_Th)
+            if config.delivery.radio_Th > 0.0:
+                _append_radnuc("th232", config.delivery.radio_Th)
 
-        if config.delivery.radio_U > 0.0:
-            _append_radnuc("u235", config.delivery.radio_U)
-            _append_radnuc("u238", config.delivery.radio_U)
+            if config.delivery.radio_U > 0.0:
+                _append_radnuc("u235", config.delivery.radio_U)
+                _append_radnuc("u238", config.delivery.radio_U)
 
-    param = Parameters(
+        param = Parameters(
             boundary_conditions = boundary_conditions,
             energy = energy,
             initial_condition = initial_condition,
@@ -209,94 +231,118 @@ def SetupAragogSolver(config:Config, hf_row:dict, interior_o:Interior_t):
             solver = solver,
             )
 
-    aragog_solver = Solver(param)
+        self.aragog_solver = Solver(param)
 
-def UpdateAragogSolver(dt:float, hf_row:dict, interior_o:Interior_t,
-                            output_dir:str = None):
+    def update_solver(self, dt:float, hf_row:dict, interior_o:Interior_t,
+                                output_dir:str = None):
 
-    # Set solver time
-    # hf_row["Time"] is in yr so do not need to scale as long as scaling time is secs_per_year
-    aragog_solver.parameters.solver.start_time = hf_row["Time"]
-    aragog_solver.parameters.solver.end_time = hf_row["Time"] + dt
+        # Set solver time
+        # hf_row["Time"] is in yr so do not need to scale as long as scaling
+        # time is secs_per_year
+        self.aragog_solver.parameters.solver.start_time = hf_row["Time"]
+        self.aragog_solver.parameters.solver.end_time = hf_row["Time"] + dt
 
-    # Get temperature field from previous run
-    if output_dir is not None: # read it from output directory
-        Tfield = read_last_Tfield(output_dir, hf_row["Time"])
-    else: # get it from solver
-        Tfield = aragog_solver.temperature_staggered[:, -1]
+        # Get temperature field from previous run
+        if output_dir is not None: # read it from output directory
+            Tfield = read_last_Tfield(output_dir, hf_row["Time"])
+        else: # get it from solver
+            Tfield = self.aragog_solver.temperature_staggered[:, -1]
 
-    # Update initial condition
-    Tfield = Tfield / aragog_solver.parameters.scalings.temperature
-    aragog_solver.parameters.initial_condition.initial_condition = 2 # switch to user-defined init
-    aragog_solver.parameters.initial_condition.init_temperature = Tfield
+        # Update initial condition
+        Tfield = Tfield / self.aragog_solver.parameters.scalings.temperature
+        # switch to user-defined init
+        self.aragog_solver.parameters.initial_condition.initial_condition = 2
+        self.aragog_solver.parameters.initial_condition.init_temperature = (
+            Tfield)
 
-    # Update boundary conditions
-    aragog_solver.parameters.boundary_conditions.outer_boundary_value = hf_row["F_atm"]
+        # Update boundary conditions
+        self.aragog_solver.parameters.boundary_conditions.outer_boundary_value\
+            = hf_row["F_atm"]
 
-    # Update tidal heating within the mantle
-    aragog_solver.parameters.energy.tidal_array = \
-        interior_o.tides / aragog_solver.parameters.scalings.power_per_mass
+        # Update tidal heating within the mantle
+        self.aragog_solver.parameters.energy.tidal_array = (
+            interior_o.tides /
+            self.aragog_solver.parameters.scalings.power_per_mass)
 
-def WriteAragogOutput(output_dir:str, time:float):
+    def run_solver(self, hf_row, interior_o, dirs):
+        # Run Aragog solver
+        self.aragog_solver.initialize()
+        self.aragog_solver.solve()
 
-    aragog_output: Output = Output(aragog_solver)
+        # Get Aragog output
+        output = self.get_output(hf_row, interior_o)
+        sim_time = self.aragog_solver.parameters.solver.end_time
 
-    fpath = os.path.join(output_dir,"data","%.0f_int.nc"%time)
-    aragog_output.write_at_time(fpath,-1)
+        # Write output to a file
+        self.write_output(dirs["output"], sim_time)
 
-def GetAragogOutput(hf_row:dict, interior_o:Interior_t):
+        return sim_time, output
 
-    aragog_output: Output = Output(aragog_solver)
-    aragog_output.state.update(aragog_output.solution.y, aragog_output.solution.t)
-    output = {}
+    def write_output(self, output_dir:str, time:float):
 
-    output["M_mantle"] = aragog_output.mantle_mass
-    output["T_magma"] = aragog_output.solution_top_temperature
-    output["Phi_global"] = aragog_output.melt_fraction_global
-    output["RF_depth"] = aragog_output.rheological_front
-    output["F_int"] = aragog_output.convective_heat_flux_basic[-1,-1] # Need to be revised for consistency
+        aragog_output: Output = Output(self.aragog_solver)
 
-    if (output["Phi_global"] > (1.0-1.0e-8)):
-        output["M_mantle_liquid"] = output["M_mantle"]
-        output["M_mantle_solid"] = 0.0
-    elif (output["Phi_global"] < 1.e-8):
-        output["M_mantle_liquid"] = 0.0
-        output["M_mantle_solid"] = output["M_mantle"]
-    else:
-        output["M_mantle_liquid"] = output["M_mantle"] * output["Phi_global"]
-        output["M_mantle_solid"] = output["M_mantle"] * (1.0 - output["Phi_global"])
+        fpath = os.path.join(output_dir,"data","%d_int.nc"%time)
+        aragog_output.write_at_time(fpath,-1)
 
-    # Calculate surface area
-    radii = aragog_output.radii_km_basic * 1e3 # [m]
-    area  = 4 * np.pi * radii[-1]**2 # [m^2]
+    def get_output(self, hf_row:dict, interior_o:Interior_t):
 
-    # Mass at each mesh layer
-    mass_s = aragog_output.mass_staggered[:,-1] # [kg]
+        aragog_output: Output = Output(self.aragog_solver)
+        aragog_output.state.update(aragog_output.solution.y,
+                                   aragog_output.solution.t)
+        output = {"M_mantle": aragog_output.mantle_mass,
+                  "T_magma": aragog_output.solution_top_temperature,
+                  "Phi_global": aragog_output.melt_fraction_global,
+                  "RF_depth": aragog_output.rheological_front,
+                  "F_int": aragog_output.convective_heat_flux_basic[-1, -1]}
 
-    # Radiogenic heating
-    Hradio_s = aragog_output.heating_radio[:,-1]  # [W kg-1]
-    output["F_radio"] = np.dot(Hradio_s, mass_s) / area  # [W m-2]
+        if output["Phi_global"] > (1.0 - 1.0e-8):
+            output["M_mantle_liquid"] = output["M_mantle"]
+            output["M_mantle_solid"] = 0.0
+        elif output["Phi_global"] < 1.e-8:
+            output["M_mantle_liquid"] = 0.0
+            output["M_mantle_solid"] = output["M_mantle"]
+        else:
+            output["M_mantle_liquid"] = output["M_mantle"] * output["Phi_global"]
+            output["M_mantle_solid"] = (output["M_mantle"] *
+                                        (1.0 - output["Phi_global"]))
 
-    # Tidal heating flux
-    Htidal_s = aragog_output.heating_tidal[:,-1]  # [W kg-1]
-    output["F_tidal"] = np.dot(Htidal_s, mass_s)/area
+        # Calculate surface area
+        radii = aragog_output.radii_km_basic * 1e3 # [m]
+        area  = 4 * np.pi * radii[-1]**2 # [m^2]
 
-    # Store arrays
-    # FIX ME - Should extract values from staggered nodes rather than cropping basic nodes.
-    interior_o.phi      = np.array(aragog_output.melt_fraction_staggered[:,-1])
-    interior_o.visc     = np.power(10.0, aragog_output.log10_viscosity_staggered[:,-1])
-    interior_o.density  = np.array(aragog_output.density_basic[:,-1])[1:]
-    interior_o.radius   = radii[:] # length N+1
-    interior_o.mass     = mass_s[:]
-    interior_o.temp     = np.array(aragog_output.temperature_K_staggered[:,-1])
-    interior_o.pres     = np.array(aragog_output.pressure_GPa_staggered[:,-1] * 1e9)
+        # Mass at each mesh layer
+        mass_s = aragog_output.mass_staggered[:,-1] # [kg]
 
-    return output
+        # Radiogenic heating
+        Hradio_s = aragog_output.heating_radio[:,-1]  # [W kg-1]
+        output["F_radio"] = np.dot(Hradio_s, mass_s) / area  # [W m-2]
+
+        # Tidal heating flux
+        Htidal_s = aragog_output.heating_tidal[:,-1]  # [W kg-1]
+        output["F_tidal"] = np.dot(Htidal_s, mass_s)/area
+
+        # Store arrays
+        # FIX ME - Should extract values from staggered nodes rather than cropping
+        # basic nodes.
+        interior_o.phi      = np.array(aragog_output.melt_fraction_staggered[:,-1])
+        interior_o.visc     = np.power(
+            10.0, aragog_output.log10_viscosity_staggered[:,-1])
+        interior_o.density  = np.array(
+            aragog_output.density_basic[:,-1])[1:]
+        interior_o.radius   = radii[:] # length N+1
+        interior_o.mass     = mass_s[:]
+        interior_o.temp     = np.array(
+            aragog_output.temperature_K_staggered[:,-1])
+        interior_o.pres     = np.array(
+            aragog_output.pressure_GPa_staggered[:,-1] * 1e9)
+
+        return output
 
 def read_last_Tfield(output_dir:str, time:float):
 
     # Read Aragog output at last run
-    fpath = os.path.join(output_dir,"data","%.0f_int.nc"%time)
+    fpath = os.path.join(output_dir,"data","%d_int.nc"%time)
     out = read_ncdf(fpath)
 
     # Get temperature field at basic nodes and interpolate to staggered nodes
@@ -324,4 +370,5 @@ def read_ncdf(fpath:str):
     return out
 
 def read_ncdfs(output_dir:str, times:list):
-    return [read_ncdf(os.path.join(output_dir, "data", "%.0f_int.nc"%t)) for t in times]
+    return [read_ncdf(os.path.join(output_dir, "data", "%d_int.nc"%t))
+            for t in times]

--- a/src/proteus/interior/aragog.py
+++ b/src/proteus/interior/aragog.py
@@ -279,9 +279,10 @@ class AragogRunner:
             self.aragog_solver.parameters.scalings.power_per_mass)
 
     def run_solver(self, hf_row, interior_o, dirs):
+        print(f"Initial sim time: {self.aragog_solver.parameters.solver.start_time}")
         # Run Aragog solver
         self.aragog_solver.solve()
-
+        print(f"Final sim time: {self.aragog_solver.parameters.solver.end_time}")
         # Get Aragog output
         output = self.get_output(hf_row, interior_o)
         sim_time = self.aragog_solver.parameters.solver.end_time

--- a/src/proteus/interior/common.py
+++ b/src/proteus/interior/common.py
@@ -73,6 +73,8 @@ class Interior_t():
         # Current time step length [yr]
         self.dt = 1.0
 
+        self.aragog_solver = None
+
         # Number of levels
         self.nlev_b = int(nlev_b)
         self.nlev_s = self.nlev_b - 1

--- a/src/proteus/interior/wrapper.py
+++ b/src/proteus/interior/wrapper.py
@@ -171,10 +171,11 @@ def run_interior(dirs:dict, config:Config,
 
     elif config.interior.module == 'aragog':
         # Import
-        from proteus.interior.aragog import RunAragog
+        from proteus.interior.aragog import AragogRunner
 
         # Run Aragog
-        sim_time, output = RunAragog(config, dirs, hf_row, hf_all, interior_o)
+        sim_time, output = AragogRunner().run(config, dirs, hf_row, hf_all,
+                                              interior_o)
 
     elif config.interior.module == 'dummy':
         # Import

--- a/src/proteus/interior/wrapper.py
+++ b/src/proteus/interior/wrapper.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from proteus.config import Config
 
 log = logging.getLogger("fwl."+__name__)
-AragogRunnerInstance = AragogRunner()
 
 def update_gravity(hf_row:dict):
     '''
@@ -172,9 +171,11 @@ def run_interior(dirs:dict, config:Config,
         sim_time, output = ReadSPIDER(dirs, config, hf_row["R_int"], interior_o)
 
     elif config.interior.module == 'aragog':
+        AragogRunnerInstance = AragogRunner(config, dirs, hf_row, hf_all, 
+                                            interior_o)
         # Run Aragog
-        sim_time, output = AragogRunnerInstance.run(config, dirs, hf_row, hf_all,
-                                              interior_o)
+        sim_time, output = AragogRunnerInstance.run_solver(hf_row, interior_o,
+                                                           dirs)
 
     elif config.interior.module == 'dummy':
         # Import

--- a/src/proteus/interior/wrapper.py
+++ b/src/proteus/interior/wrapper.py
@@ -11,11 +11,13 @@ import scipy.optimize as optimise
 from proteus.interior.common import Interior_t
 from proteus.utils.constants import M_earth, R_earth, const_G, element_list
 from proteus.utils.helper import UpdateStatusfile
+from proteus.interior.aragog import AragogRunner
 
 if TYPE_CHECKING:
     from proteus.config import Config
 
 log = logging.getLogger("fwl."+__name__)
+AragogRunnerInstance = AragogRunner()
 
 def update_gravity(hf_row:dict):
     '''
@@ -170,11 +172,8 @@ def run_interior(dirs:dict, config:Config,
         sim_time, output = ReadSPIDER(dirs, config, hf_row["R_int"], interior_o)
 
     elif config.interior.module == 'aragog':
-        # Import
-        from proteus.interior.aragog import AragogRunner
-
         # Run Aragog
-        sim_time, output = AragogRunner().run(config, dirs, hf_row, hf_all,
+        sim_time, output = AragogRunnerInstance.run(config, dirs, hf_row, hf_all,
                                               interior_o)
 
     elif config.interior.module == 'dummy':

--- a/src/proteus/interior/wrapper.py
+++ b/src/proteus/interior/wrapper.py
@@ -8,10 +8,10 @@ import numpy as np
 import pandas as pd
 import scipy.optimize as optimise
 
+from proteus.interior.aragog import AragogRunner
 from proteus.interior.common import Interior_t
 from proteus.utils.constants import M_earth, R_earth, const_G, element_list
 from proteus.utils.helper import UpdateStatusfile
-from proteus.interior.aragog import AragogRunner
 
 if TYPE_CHECKING:
     from proteus.config import Config
@@ -171,7 +171,7 @@ def run_interior(dirs:dict, config:Config,
         sim_time, output = ReadSPIDER(dirs, config, hf_row["R_int"], interior_o)
 
     elif config.interior.module == 'aragog':
-        AragogRunnerInstance = AragogRunner(config, dirs, hf_row, hf_all, 
+        AragogRunnerInstance = AragogRunner(config, dirs, hf_row, hf_all,
                                             interior_o)
         # Run Aragog
         sim_time, output = AragogRunnerInstance.run_solver(hf_row, interior_o,

--- a/tests/integration/test_integration_physical.py
+++ b/tests/integration/test_integration_physical.py
@@ -33,6 +33,7 @@ IMAGE_LIST = (
         "plot_population_mass_radius.png"
         )
 
+
 @pytest.fixture(scope="module")
 def physical_run():
     runner = Proteus(config_path=config_path)


### PR DESCRIPTION
Fixes #353 
i.e. `aragog_solver` is no longer a `global`.
but the [Aragog computational efficiency problem](https://github.com/ExPlanetology/aragog/issues/47) remains.

This fix:

1. Introduction of `AragogRunner` class.
2. `aragog_solver` is an attribute of `interior_o` i.e. an attibute of an instance of `Interior_t`.
3. `AragogRunner.__init__` has a line `interior_o.aragog_solver.initialize()`.  This will trigger a [Solver().initialize in Aragog](https://github.com/ExPlanetology/aragog/blob/b86e217838c128b5709e9948990acc0ba949c2b9/aragog/solver.py#L436). Most likely there is a lot there, [like reading in files](https://github.com/ExPlanetology/aragog/blob/b86e217838c128b5709e9948990acc0ba949c2b9/aragog/phase.py#L202), that is, in fact, solver independent.
5. Last line of `AragogRunner.__init__`: `self.aragog_solver = interior_o.aragog_solver`
