### PR TITLE
Ls/zenodo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "pandas",
     "scipy",
     "sympy",
+    "zenodo-get",
     "astropy"
 ]
 

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -41,6 +41,23 @@ def download_zenodo_folder(zenodo_id: str, folder_dir: Path):
     with open(out,'w') as hdl:
         sp.run(cmd, check=True, stdout=hdl, stderr=hdl)
 
+def get_zenodo_record(folder: str) -> str | None:
+    """
+    Get Zenodo record ID for a given folder.
+
+    Inputs :
+        - folder : str
+            Folder name to get the Zenodo record ID for
+
+    Returns :
+        - str | None : Zenodo record ID or None if not found
+    """
+    zenodo_map = {
+        'Frostflow/48': '15696415',
+        'Honeyside/4096': '15696457',
+    }
+    return zenodo_map.get(folder, None)
+
 def download_OSF_folder(*, storage, folders: list[str], data_dir: Path):
     """
     Download a specific folder in the OSF repository
@@ -186,7 +203,7 @@ def download_spectral_file(name:str, bands:str):
         folder = f'{name}/{bands}',
         target = "spectral_files",
         osf_id = 'vehxg',
-        zenodo_id= None,
+        zenodo_id= get_zenodo_record(f'{name}/{bands}'),
         desc = f'{name}{bands} spectral file',
     )
 

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -131,14 +131,15 @@ def download(
                     success = True
             except RuntimeError as e:
                 log.warning(f"    Zenodo download failed: {e}")
-            
+                folder_dir.rmdir()
+
             if not success:
                 try:
                     download_OSF_folder(storage=storage, folders=[folder], data_dir=data_dir)
                     success = True
                 except RuntimeError as e:
                     log.warning(f"    OSF download failed: {e}")
-            
+
             if success:
                 break
 
@@ -157,7 +158,6 @@ def download_surface_albedos():
     """
     Download surface optical properties
     """
-
     download(
         folder = 'Hammond24',
         target = "surface_albedos",


### PR DESCRIPTION
This PR adds Zenodo as another remote host for forming world data. The download function has been modified such that it tries to download the data from Zenodo first and then from the OSF if it fails.