### PR TITLE
Introduce auto-assign of new PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Tutorial:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# The PROTEUS Maintainer team will automatically assigned to review each PR to main.
+# The PROTEUS Maintainer team will automatically be assigned to review each PR to main.
 * @FormingWorlds/proteus-maintainer


### PR DESCRIPTION
Introduce CODEOWNERS file to enable automatic assignment of PRs to a team.

For now, this is the proteus-maintainers team only, but we can consider extending this to the entire proteus-developer team.