### PR TITLE
Track ocean quantities in PROTEUS, as calculated by AGNI

### DIFF
--- a/input/planets/earth.toml
+++ b/input/planets/earth.toml
@@ -10,13 +10,14 @@ version = "2.0"
         write_mod   = 2
 
     [params.dt]
-        starspec     = 3e6
+        starspec     = 1e7
         starinst     = 1e2
-        minimum      = 1e4
+        minimum      = 3e4
+        initial      = 3e4
 
         [params.dt.adaptive]
-            atol         = 0.02
-            rtol         = 0.10
+            atol         = 0.03
+            rtol         = 0.12
 
     [params.stop]
 
@@ -44,7 +45,7 @@ version = "2.0"
     module  = "mors"
     [star.mors]
         rot_pcntle = 50.0
-        age_now = 0.414
+        age_now = 4.57 # Gyr
         spec    = "stellar_spectra/Named/sun.txt"
 
 [orbit]
@@ -62,6 +63,7 @@ version = "2.0"
     surf_state      = "fixed"
     rayleigh        = true
     module          = "agni"
+    albedo_pl       = 0.15      # test guess, contribution from clouds
 
     [atmos_clim.agni]
         p_top          = 1e-4
@@ -79,7 +81,8 @@ version = "2.0"
     module = "dummy"
 
     [interior.dummy]
-        ini_tmagma = 2700.0
+        ini_tmagma = 2000.0
+
 
     [interior.aragog]
         ini_tmagma = 3000.0
@@ -94,17 +97,17 @@ version = "2.0"
     module = "none"
 
     [delivery.elements]
-        # H_oceans    = 0.0       # Hydrogen inventory in units of equivalent Earth oceans
-        H_ppmw      = 109.0     # Hydrogen inventory in ppmw relative to mantle mass
+        H_oceans    = 3.0       # Hydrogen inventory in units of equivalent Earth oceans
+        # H_ppmw      = 109.0     # Hydrogen inventory in ppmw relative to mantle mass
 
-        # CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
-        C_ppmw      = 109.0       # Carbon inventory in ppmw relative to mantle mass
+        CH_ratio    = 1.0       # C/H mass ratio in mantle/atmosphere system
+        # C_ppmw      = 109.0       # Carbon inventory in ppmw relative to mantle mass
 
-        # NH_ratio    = 0.018       # N/H mass ratio in mantle/atmosphere system
-        N_ppmw      = 2.01       # Nitrogen inventory in ppmw relative to mantle mass
+        NH_ratio    = 0.018       # N/H mass ratio in mantle/atmosphere system
+        # N_ppmw      = 2.01       # Nitrogen inventory in ppmw relative to mantle mass
 
-        # SH_ratio    = 2.16       # S/H mass ratio in mantle/atmosphere system
-        S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mantle mass
+        SH_ratio    = 2.16       # S/H mass ratio in mantle/atmosphere system
+        # S_ppmw      = 235.0     # Sulfur inventory in ppmw relative to mantle mass
 
 
 [observe]

--- a/input/planets/earth.toml
+++ b/input/planets/earth.toml
@@ -12,10 +12,11 @@ version = "2.0"
     [params.dt]
         starspec     = 3e6
         starinst     = 1e2
+        minimum      = 1e4
 
         [params.dt.adaptive]
             atol         = 0.02
-            rtol         = 0.07
+            rtol         = 0.10
 
     [params.stop]
 
@@ -63,7 +64,7 @@ version = "2.0"
     module          = "agni"
 
     [atmos_clim.agni]
-        condensation    = true
+        condensation   = true
         spectral_group = "Dayspring"
         spectral_bands = "16"
 
@@ -77,7 +78,7 @@ version = "2.0"
     module = "dummy"
 
     [interior.dummy]
-        ini_tmagma = 3000.0
+        ini_tmagma = 2800.0
 
     [interior.aragog]
         ini_tmagma = 3000.0

--- a/input/planets/earth.toml
+++ b/input/planets/earth.toml
@@ -6,6 +6,8 @@ version = "2.0"
     [params.out]
         path        = "earth"
         logging     = "INFO"
+        plot_mod    = 10
+        write_mod   = 2
 
     [params.dt]
         starspec     = 3e6
@@ -17,24 +19,21 @@ version = "2.0"
 
     [params.stop]
 
-        [params.stop.iters]
-            enabled = true
-
         [params.stop.time]
             enabled = true
             maximum = 4.567e+9
 
         [params.stop.solid]
-            enabled  = true
+            enabled  = false
             phi_crit = 0.005
 
         [params.stop.radeqm]
-            enabled = true
+            enabled = false
             atol    = 0.1
             rtol    = 1e-3
 
         [params.stop.escape]
-            enabled   = true
+            enabled   = false
             p_stop    = 1.0
 
 [star]
@@ -61,20 +60,24 @@ version = "2.0"
 [atmos_clim]
     surf_state      = "fixed"
     rayleigh        = true
+    condensation    = true
     module          = "agni"
 
     [atmos_clim.agni]
         spectral_group = "Dayspring"
-        spectral_bands = "48"
+        spectral_bands = "16"
 
 [escape]
     module = "none"
 
 [interior]
-    radiogenic_heat = true
+    radiogenic_heat = false
     tidal_heat      = false
 
-    module = "aragog"
+    module = "dummy"
+
+    [interior.dummy]
+        init_tmagma = 3000.0
 
     [interior.aragog]
         ini_tmagma = 3000.0

--- a/input/planets/earth.toml
+++ b/input/planets/earth.toml
@@ -21,7 +21,7 @@ version = "2.0"
 
         [params.stop.time]
             enabled = true
-            maximum = 4.567e+9
+            maximum = 4.44e+9 # 4.54 Gyr minus age_ini
 
         [params.stop.solid]
             enabled  = false
@@ -33,8 +33,8 @@ version = "2.0"
             rtol    = 1e-3
 
         [params.stop.escape]
-            enabled   = false
-            p_stop    = 1.0
+            enabled   = true
+            p_stop    = 0.2
 
 [star]
     mass    = 1.0
@@ -60,15 +60,15 @@ version = "2.0"
 [atmos_clim]
     surf_state      = "fixed"
     rayleigh        = true
-    condensation    = true
     module          = "agni"
 
     [atmos_clim.agni]
+        condensation    = true
         spectral_group = "Dayspring"
         spectral_bands = "16"
 
 [escape]
-    module = "none"
+    module = "zephyrus"
 
 [interior]
     radiogenic_heat = false
@@ -77,7 +77,7 @@ version = "2.0"
     module = "dummy"
 
     [interior.dummy]
-        init_tmagma = 3000.0
+        ini_tmagma = 3000.0
 
     [interior.aragog]
         ini_tmagma = 3000.0

--- a/input/planets/earth.toml
+++ b/input/planets/earth.toml
@@ -64,6 +64,7 @@ version = "2.0"
     module          = "agni"
 
     [atmos_clim.agni]
+        p_top          = 1e-4
         condensation   = true
         spectral_group = "Dayspring"
         spectral_bands = "16"
@@ -78,7 +79,7 @@ version = "2.0"
     module = "dummy"
 
     [interior.dummy]
-        ini_tmagma = 2800.0
+        ini_tmagma = 2700.0
 
     [interior.aragog]
         ini_tmagma = 3000.0

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -366,7 +366,7 @@ def _solve_energy(atmos, loops_total:int, dirs:dict, config:Config):
         # default parameters
         linesearch  = 2
         easy_start  = False
-        dx_max      = config.interior.spider.tsurf_atol*2+5.0
+        dx_max      = float(config.atmos_clim.agni.dx_max)
         ls_increase = 1.01
         perturb_all = True
         max_steps   = 70

--- a/src/proteus/atmos_clim/dummy.py
+++ b/src/proteus/atmos_clim/dummy.py
@@ -116,5 +116,7 @@ def RunDummyAtm( dirs:dict, config:Config, hf_row:dict):
     output["p_xuv"]   = hf_row["P_surf"]
     output["R_xuv"]   = R_obs
     output["p_obs"]   = hf_row["P_surf"]
+    output["ocean_areacov"] = 0.0
+    output["ocean_maxdepth"]= 0.0
 
     return output

--- a/src/proteus/atmos_clim/janus.py
+++ b/src/proteus/atmos_clim/janus.py
@@ -303,5 +303,7 @@ def RunJANUS(atm, dirs:dict, config:Config, hf_row:dict, hf_all:pd.DataFrame,
     output["rho_obs"]= rho_obs          # observed density [kg m-3]
     output["p_xuv"]  = p_xuv/1e5        # Closest pressure from Pxuv    [bar]
     output["R_xuv"]  = r_xuv            # Radius at Pxuv                [m]
+    output["ocean_areacov"] = 0.0
+    output["ocean_maxdepth"]= 0.0
 
     return output

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -146,21 +146,14 @@ def run_atmosphere(atmos_o:Atmos_t, config:Config, dirs:dict, loop_counter:dict,
         # Run dummy atmosphere model
         atm_output = RunDummyAtm(dirs, config, hf_row)
 
-    # Store atmosphere module output variables
-    #    observables
-    hf_row["rho_obs"]= atm_output["rho_obs"] # [kg m-3]
-    hf_row["p_obs"]  = atm_output["p_obs"]   # [bar]
-    hf_row["R_obs"]  = atm_output["R_obs"]   # [m]
-    #    fluxes
-    hf_row["F_atm"]  = atm_output["F_atm"]
-    hf_row["F_olr"]  = atm_output["F_olr"]
-    hf_row["F_sct"]  = atm_output["F_sct"]
-    hf_row["F_net"]  = hf_row["F_int"] - hf_row["F_atm"]
-    hf_row["bond_albedo"]= atm_output["albedo"]
-    hf_row["T_surf"] = atm_output["T_surf"]
-    #    escape
-    hf_row["p_xuv"]  = atm_output["p_xuv"]    # Closest pressure to Pxuv    [bar]
-    hf_row["R_xuv"]  = atm_output["R_xuv"]    # Radius at p_xuv [m]
+    # Store variables common to `hf_row` and `atm_output`
+    for key in atm_output.keys():
+        if key in hf_row.keys():
+            hf_row[key] = atm_output[key]
+
+    # Copy special cases
+    hf_row["F_net"]       = hf_row["F_int"] - hf_row["F_atm"]
+    hf_row["bond_albedo"] = atm_output["albedo"]
 
     # Calculate bolometric observables (measured at infinite distance)
     update_bolometry(hf_row)

--- a/src/proteus/config/_atmos_clim.py
+++ b/src/proteus/config/_atmos_clim.py
@@ -79,6 +79,8 @@ class Agni:
         Use real gas equations of state in atmosphere, where possible.
     psurf_thresh: float
         Use the transparent-atmosphere solver when P_surf is less than this value [bar].
+    dx_max: float
+        Nominal maximum step size to T(p) during the solver process, although this is dynamic.
     """
 
     spectral_group: str     = field(default=None)
@@ -98,6 +100,7 @@ class Agni:
     latent_heat: bool       = field(default=False)
     real_gas: bool          = field(default=False)
     psurf_thresh: bool      = field(default=0.1, validator=ge(0))
+    dx_max: float           = field(default=35.0, validator=gt(1))
 
     @property
     def chemistry_int(self) -> int:

--- a/src/proteus/config/_atmos_clim.py
+++ b/src/proteus/config/_atmos_clim.py
@@ -34,6 +34,9 @@ def valid_agni(instance, attribute, value):
     if instance.agni.chemistry and instance.agni.condensation:
         raise ValueError("`atmos_clim.agni`: Cannot enable condensation and chemistry at the same time")
 
+    if instance.agni.latent_heat and not instance.agni.condensation:
+        raise ValueError("`atmos_clim.agni`: Must set `condensation=true` if setting `latent_heat=true`")
+
     # set spectral files?
     if not instance.agni.spectral_group:
         raise ValueError("Must set atmos_clim.agni.spectral_group")
@@ -69,7 +72,9 @@ class Agni:
     overlap_method: str
         Gas overlap method. Choices: random overlap ("ro"), RO with resorting+rebinning ("rorr"), equivalent extinction ("ee").
     condensation: bool
-        Enable volatile condensation/phase change in the atmosphere.
+        Enable volatile rainout in the atmosphere and ocean formation below.
+    latent_heat: bool
+        Account for latent heat from condense/evap when solving temperature profile.
     real_gas: bool
         Use real gas equations of state in atmosphere, where possible.
     psurf_thresh: float
@@ -90,6 +95,7 @@ class Agni:
     solution_rtol: float    = field(default=0.15,  validator=gt(0))
     overlap_method: str     = field(default='ee', validator=check_overlap)
     condensation: bool      = field(default=False)
+    latent_heat: bool       = field(default=False)
     real_gas: bool          = field(default=False)
     psurf_thresh: bool      = field(default=0.1, validator=ge(0))
 

--- a/src/proteus/escape/wrapper.py
+++ b/src/proteus/escape/wrapper.py
@@ -30,7 +30,7 @@ def run_escape(config:Config, hf_row:dict, dt:float, stellar_track):
 
     if not config.escape.module:
         hf_row["esc_rate_total"] = 0.0
-        log.info("Escape is disabled, bulk rate = %.2e kg s-1"%hf_row["esc_rate_total"])
+        log.info(f"Escape is disabled, bulk rate = {hf_row["esc_rate_total"]:.2e} kg s-1")
         return
 
     elif config.escape.module == 'zephyrus':
@@ -42,10 +42,7 @@ def run_escape(config:Config, hf_row:dict, dt:float, stellar_track):
     else:
         raise ValueError(f"Invalid escape model: {config.escape.module}")
 
-    log.info(
-        "Bulk escape rate = %.2e kg s-1"
-        % (hf_row["esc_rate_total"] * secs_per_year, hf_row["esc_rate_total"])
-        )
+    log.info(f"Bulk escape rate = {hf_row["esc_rate_total"]:.2e} kg s-1")
 
     # calculate new elemental inventories
     solvevol_target = calc_new_elements(hf_row, dt,

--- a/src/proteus/escape/wrapper.py
+++ b/src/proteus/escape/wrapper.py
@@ -43,7 +43,7 @@ def run_escape(config:Config, hf_row:dict, dt:float, stellar_track):
         raise ValueError(f"Invalid escape model: {config.escape.module}")
 
     log.info(
-        "Bulk escape rate: %.2e kg yr-1 = %.2e kg s-1"
+        "Bulk escape rate = %.2e kg s-1"
         % (hf_row["esc_rate_total"] * secs_per_year, hf_row["esc_rate_total"])
         )
 

--- a/src/proteus/orbit/wrapper.py
+++ b/src/proteus/orbit/wrapper.py
@@ -211,4 +211,3 @@ def run_orbit(hf_row:dict, config:Config, dirs:dict, interior_o:Interior_t):
 
     # Call tides module for satellite, calculates heating rates and new love number
     # To Do
-

--- a/src/proteus/orbit/wrapper.py
+++ b/src/proteus/orbit/wrapper.py
@@ -204,9 +204,11 @@ def run_orbit(hf_row:dict, config:Config, dirs:dict, interior_o:Interior_t):
     else:
         hf_row["Imk2"] = 0.0
 
+    # Print info
+    if config.orbit.module is not None:
+        log.info("    Pla H_tide = %.1e W kg-1 (mean) "%np.mean(interior_o.tides))
+        log.info("    Pla Im(k2) = %.1e "%hf_row["Imk2"])
+
     # Call tides module for satellite, calculates heating rates and new love number
     # To Do
 
-    # Print info
-    log.info("    Pla H_tide = %.1e W kg-1 (mean) "%np.mean(interior_o.tides))
-    log.info("    Pla Im(k2) = %.1e "%hf_row["Imk2"])

--- a/src/proteus/plot/cpl_chem_atmosphere.py
+++ b/src/proteus/plot/cpl_chem_atmosphere.py
@@ -50,12 +50,6 @@ def plot_chem_atmosphere( output_dir:str, chem_module:str, plot_format="pdf",
 
     parr = atm_profile["pl"] * 1e-5  # convert to bar
 
-    # Check that the arrays are the right way up
-    if parr[1] > parr[0]:
-        # needs flipping
-        for key in atm_profile.keys():
-            atm_profile[key] = atm_profile[key][::-1]
-
     # Get year
     year = float(nc_fpath.split("/")[-1].split("_atm")[0])
 
@@ -114,7 +108,6 @@ def plot_chem_atmosphere( output_dir:str, chem_module:str, plot_format="pdf",
     ax.xaxis.set_major_locator(LogLocator(numticks=1000))
 
     ax.set_ylabel("Pressure [bar]")
-    ax.invert_yaxis()
     ax.set_yscale("log")
     ax.set_ylim(bottom=np.amax(parr), top=np.amin(parr))
     ax.yaxis.set_major_locator(LogLocator(numticks=1000))

--- a/src/proteus/plot/cpl_global.py
+++ b/src/proteus/plot/cpl_global.py
@@ -182,14 +182,14 @@ def plot_global(hf_all: pd.DataFrame, output_dir: str, config: Config,
 
     # PLOT ax_tr
     ax_tr.plot( hf["Time"], hf["P_surf"], color='black', linestyle='dashed', lw=lw*1.5, label=r'Total')
-    bar_min, bar_max = 0.1, 10.0
+    bar_min, bar_max = 0.1, 1.0
     bar_max = max(bar_max, np.amax(hf["P_surf"]))
     for vol in gas_list:
         if not vol_present[vol]:
             continue
         ax_tr.plot( hf["Time"], vol_bars[vol], color=get_colour(vol), lw=lw, alpha=al, label=latexify(vol))
         bar_min = min(bar_min, np.amin(vol_bars[vol]))
-    ax_tr.set_ylim(max(1.0e-7,min(bar_min, 1.0e-1)), bar_max * 2.0)
+    ax_tr.set_ylim(max(1.0e-5,min(bar_min, 1.0e-1)), bar_max * 2.0)
     ax_tr.yaxis.set_major_locator(ticker.LogLocator(base=10.0, numticks=5) )
 
     # PLOT ax_cr

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -503,6 +503,9 @@ def GetHelpfileKeys():
             # Escape
             "esc_rate_total", "p_xuv", "R_xuv", # [kg s-1], [bar], [m]
 
+            # Surface liquid-ocean statistics
+            "ocean_areacov", "ocean_maxdepth", # [1], [m]
+
             # Atmospheric composition
             "M_atm", "P_surf", "atm_kg_per_mol", # [kg], [bar], [kg mol-1]
             ]


### PR DESCRIPTION
Ocean depth, area, and composition are calculated by AGNI (version 1.7.2) based on the amount of rain reaching the surface. This PR adds functionality to store ocean area fraction and maximum depth in the PROTEUS output helpfile. Closes #488 

These ocean quantities set to zero if using the JANUS and dummy atmosphere modules.

Adapted the `earth.toml` configuration for demonstrating ocean formation. Also updated config parser to expose more parameters to the user, rather than keeping them hardcoded.