### PR TITLE
Termination criterion for planet entering star's roche limit

### DIFF
--- a/input/demos/orbit_dummy.toml
+++ b/input/demos/orbit_dummy.toml
@@ -4,7 +4,7 @@ version = "2.0"
 [params]
     [params.out]
         path        = "orbit_dummy"
-        logging     = "ERROR"
+        logging     = "INFO"
         plot_mod    = 0      # Plotting frequency, 0: wait until completion | n: every n iterations
         write_mod   = 400      # Write CSV frequency, 0: wait until completion | n: every n iterations
         archive_mod = 'none'
@@ -39,9 +39,15 @@ version = "2.0"
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
+        # atmospheric escape
         [params.stop.escape]
             enabled   = true
-            p_stop    = 1.0  # bar, model will terminate with p_surf < p_stop
+            p_stop    = 1.0   # bar, model will terminate with p_surf < p_stop
+
+        # disintegration
+        [params.stop.disint]
+            enabled   = true
+            offset    = 1.8e9 # correction to calculated Roche limit [m]
 
 
 [star]

--- a/input/demos/orbit_physical.toml
+++ b/input/demos/orbit_physical.toml
@@ -39,9 +39,15 @@ version = "2.0"
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
+        # atmospheric escape
         [params.stop.escape]
             enabled   = true
-            p_stop    = 1.0  # bar, model will terminate with p_surf < p_stop
+            p_stop    = 1.0   # bar, model will terminate with p_surf < p_stop
+
+        # disintegration
+        [params.stop.disint]
+            enabled   = true
+            offset    = 0     # correction to calculated Roche limit [m]
 
 
 # Star

--- a/input/demos/sat_dummy.toml
+++ b/input/demos/sat_dummy.toml
@@ -39,10 +39,15 @@ version = "2.0"
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
+        # atmospheric escape
         [params.stop.escape]
             enabled   = true
             p_stop    = 1.0  # bar, model will terminate with p_surf < p_stop
 
+        # disintegration
+        [params.stop.disint]
+            enabled   = false
+            offset    = 0.0  # correction to calculated Roche limit [m]
 
 [star]
     mass    = 1.0       # M_sun

--- a/input/demos/sat_physical.toml
+++ b/input/demos/sat_physical.toml
@@ -39,9 +39,15 @@ version = "2.0"
             atol    = 0.2     # absolute tolerance [W m-2]
             rtol    = 1e-3    # relative tolerance
 
+        # atmospheric escape
         [params.stop.escape]
             enabled   = true
-            p_stop    = 1.0  # bar, model will terminate with p_surf < p_stop
+            p_stop    = 1.0   # bar, model will terminate with p_surf < p_stop
+
+        # disintegration
+        [params.stop.disint]
+            enabled   = true
+            offset    = 0     # correction to calculated Roche limit [m]
 
 
 # Star

--- a/src/proteus/config/_params.py
+++ b/src/proteus/config/_params.py
@@ -204,6 +204,19 @@ class StopEscape:
     enabled: bool   = field(default=True)
     p_stop:float    = field(default=1, validator=(gt(0),lt(1e6)))
 
+@define
+class StopDisint:
+    """Parameters for planet disintegration stopping criteria.
+
+    Attributes
+    ----------
+    enabled: bool
+        Enable criteria if True
+    offset: float
+        Absolute correction (+/-) to (increase/decrease) calculated Roche limit [m].
+    """
+    enabled: bool   = field(default=False)
+    offset: float   = field(default=0)
 
 @define
 class StopParams:
@@ -223,12 +236,15 @@ class StopParams:
         Parameters for radiative equilibrium criteria.
     escape: StopEscape
         Parameters for escape criteria.
+    disint: StopDisint
+        Parameters for planet disintegration criteria.
     """
     iters: StopIters   = field(factory=StopIters)
     time: StopTime     = field(factory=StopTime)
     solid: StopSolid   = field(factory=StopSolid)
     radeqm: StopRadeqm = field(factory=StopRadeqm)
     escape: StopEscape = field(factory=StopEscape)
+    disint: StopDisint = field(factory=StopDisint)
 
     strict: bool        = field(default=False)
 

--- a/src/proteus/orbit/wrapper.py
+++ b/src/proteus/orbit/wrapper.py
@@ -195,6 +195,8 @@ def run_orbit(hf_row:dict, config:Config, dirs:dict, interior_o:Interior_t):
     update_rochelimit(hf_row)
     if hf_row["separation"] < hf_row["roche_limit"]:
         log.warning("Planet is orbiting within the Roche limit of its star")
+    elif hf_row["perihelion"] < hf_row["roche_limit"]:
+        log.warning("Planet is (partially) orbiting within the Roche limit of its star")
 
     # Update Hill radius
     update_hillradius(hf_row)

--- a/src/proteus/orbit/wrapper.py
+++ b/src/proteus/orbit/wrapper.py
@@ -36,6 +36,9 @@ def update_separation(hf_row:dict):
     Calculate time-averaged orbital separation on an elliptical path.
     https://physics.stackexchange.com/a/715749
 
+    Calculate periapsis distance on an elliptical path.
+    https://mathworld.wolfram.com/Periapsis.html
+
     Parameters
     -------------
         hf_row: dict
@@ -45,7 +48,16 @@ def update_separation(hf_row:dict):
     sma = hf_row["semimajorax"] # already in SI units
     ecc = hf_row["eccentricity"]
 
-    hf_row["separation"] = sma *  (1 + 0.5*ecc*ecc)
+    sma_sat = hf_row["semimajorax_sat"] # already in SI units
+
+    # Time-averaged separation
+    hf_row["separation"] = sma * (1 + 0.5*ecc*ecc)
+
+    # Periapsis distance around star
+    hf_row["perihelion"] = sma * (1 - ecc)
+
+    # Periapsis distance around planet (assuming circular orbiting satellite)
+    hf_row["perigee"]    = sma_sat
 
 def update_period(hf_row:dict):
     '''

--- a/src/proteus/orbit/wrapper.py
+++ b/src/proteus/orbit/wrapper.py
@@ -193,9 +193,9 @@ def run_orbit(hf_row:dict, config:Config, dirs:dict, interior_o:Interior_t):
 
     # Update Roche limit
     update_rochelimit(hf_row)
-    if hf_row["separation"] < hf_row["roche_limit"]:
+    if hf_row["separation"] <= hf_row["roche_limit"] + float(config.params.stop.disint.offset):
         log.warning("Planet is orbiting within the Roche limit of its star")
-    elif hf_row["perihelion"] < hf_row["roche_limit"]:
+    elif hf_row["perihelion"] <= hf_row["roche_limit"] + float(config.params.stop.disint.offset):
         log.warning("Planet is (partially) orbiting within the Roche limit of its star")
 
     # Update Hill radius

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -456,8 +456,8 @@ def GetHelpfileKeys():
             # Model tracking
             "Time", # [yr]
 
-            # Orbit semi-major axis and time-averaged separation
-            "semimajorax", "separation", # [m], [m],
+            # Orbit semi-major axis, time-averaged separation, perihelion, and perigee
+            "semimajorax", "separation", "perihelion", "perigee", # [m], [m], [m], [m],
 
             # Orbital period and eccentricity
             "orbital_period", "eccentricity", # [s], [1]

--- a/src/proteus/utils/helper.py
+++ b/src/proteus/utils/helper.py
@@ -141,6 +141,8 @@ def CommentFromStatus(status:int):
             desc = "Completed (net flux is small)"
         case 15:
             desc = "Completed (volatiles escaped)"
+        case 16:
+            desc = "Completed (planet disintegrated)"
         # Error cases
         case 20:
             desc = "Error (generic case, or configuration issue)"

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -88,6 +88,22 @@ def _check_escape(handler: Proteus) -> bool:
 
     return False
 
+# Planet has disintegrated
+def _check_perihelion(handler: Proteus) -> bool:
+    log.debug("Check perihelion")
+
+    perihelion = handler.hf_row["perihelion"]
+    roche_limit = handler.hf_row["roche_limit"]
+    offset = handler.config.params.stop.disint.offset
+    log.debug("    per, roc = %.3e, %.3e  m"%(perihelion, roche_limit-offset))
+
+    if perihelion <= roche_limit - offset:
+        UpdateStatusfile(handler.directories, 16)
+        _msg_termination("Planet has disintegrated")
+        return True
+
+    return False
+
 # Maximum time
 def _check_maxtime(handler: Proteus) -> bool:
     log.debug("Check maximum time")
@@ -184,6 +200,10 @@ def check_termination(handler: Proteus) -> bool:
     # Atmosphere has escaped
     if handler.config.params.stop.escape.enabled:
         finished = finished or _check_escape(handler)
+
+    # Planet has disintegrated
+    if handler.config.params.stop.disint.enabled:
+        finished = finished or _check_perihelion(handler)
 
     # Maximum time reached
     if handler.config.params.stop.time.enabled:

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -89,15 +89,15 @@ def _check_escape(handler: Proteus) -> bool:
     return False
 
 # Planet has disintegrated
-def _check_perihelion(handler: Proteus) -> bool:
-    log.debug("Check perihelion")
+def _check_separation(handler: Proteus) -> bool:
+    log.debug("Check separation")
 
-    perihelion = handler.hf_row["perihelion"]
+    separation = handler.hf_row["separation"]
     roche_limit = handler.hf_row["roche_limit"]
     offset = handler.config.params.stop.disint.offset
-    log.debug("    per, roc = %.3e, %.3e  m"%(perihelion, roche_limit-offset))
+    log.debug("    sep, roc = %.3e, %.3e  m"%(separation, roche_limit-offset))
 
-    if perihelion <= roche_limit - offset:
+    if separation <= roche_limit + offset:
         UpdateStatusfile(handler.directories, 16)
         _msg_termination("Planet has disintegrated")
         return True
@@ -203,7 +203,7 @@ def check_termination(handler: Proteus) -> bool:
 
     # Planet has disintegrated
     if handler.config.params.stop.disint.enabled:
-        finished = finished or _check_perihelion(handler)
+        finished = finished or _check_separation(handler)
 
     # Maximum time reached
     if handler.config.params.stop.time.enabled:


### PR DESCRIPTION
- Calculates the periapsis distance between star-planet (perihelion) and planet-satellite (perigee)
- Warns user if planet is partially orbiting within star's Roche limit (RL) (i.e. perihelion < RL)
- Adds new termination condition to stop simulation when time-averaged orbital separation < RL (Closes #487)
- Updates demo orbit config files to include the new configuration parameters