### PR TITLE
Append to helpfile on disk, rather than writing a new file, when possible

### DIFF
--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -480,7 +480,7 @@ class Proteus:
 
             # Write helpfile to disk
             if multiple(self.loops["total"], self.config.params.out.write_mod):
-                WriteHelpfileToCSV(self.directories["output"], self.hf_all)
+                WriteHelpfileToCSV(self.directories["output"], self.hf_all, append=self.hf_row)
 
             # Print info to terminal and log file
             PrintCurrentState(self.hf_row)


### PR DESCRIPTION
This PR introduces a small change to improve how the model output data is written to the disk. 

Previously, the entire Pandas dataframe `hf_all` would be written to a CSV file `runtime_helpfile.csv` each time the function `WriteHelpfileToCSV()` is called. This is a frequent operation, and writing the whole DF every time is expensive.

Now, the model will only *append* to this CSV file while the model is running. This saves time and computing resources by avoiding the extra file I/O operations.