### PR TITLE
Termination criterion for planet disintegration when it spins too fast

### DIFF
--- a/input/all_options.toml
+++ b/input/all_options.toml
@@ -89,6 +89,16 @@ version = "2.0"
             enabled = true
             p_stop  = 5.0        # Stop surface pressure is less than this value
 
+        # disintegration
+        [params.stop.disint]
+            enabled   = true
+
+            roche_enabled = true
+            offset_roche  = 0 # correction to calculated Roche limit [m]
+
+            spin_enabled  = true
+            offset_spin   = 0 # correction to calculated Breakup period [s]
+
 
 # ----------------------------------------------------
 # Star

--- a/input/all_options.toml
+++ b/input/all_options.toml
@@ -91,7 +91,7 @@ version = "2.0"
 
         # disintegration
         [params.stop.disint]
-            enabled   = true
+            enabled   = false
 
             roche_enabled = true
             offset_roche  = 0 # correction to calculated Roche limit [m]

--- a/input/demos/orbit_dummy.toml
+++ b/input/demos/orbit_dummy.toml
@@ -47,8 +47,12 @@ version = "2.0"
         # disintegration
         [params.stop.disint]
             enabled   = true
-            offset    = 1.8e9 # correction to calculated Roche limit [m]
 
+            roche_enabled = true
+            offset_roche  = 1.8e9 # correction to calculated Roche limit [m]
+
+            spin_enabled  = true
+            offset_spin   = 0 # correction to calculated Breakup period [s]
 
 [star]
     mass    = 1.0       # M_sun

--- a/input/demos/orbit_physical.toml
+++ b/input/demos/orbit_physical.toml
@@ -47,7 +47,12 @@ version = "2.0"
         # disintegration
         [params.stop.disint]
             enabled   = true
-            offset    = 0     # correction to calculated Roche limit [m]
+
+            roche_enabled = true
+            offset_roche  = 0 # correction to calculated Roche limit [m]
+
+            spin_enabled  = true
+            offset_spin   = 0 # correction to calculated Breakup period [s]
 
 
 # Star

--- a/input/demos/sat_dummy.toml
+++ b/input/demos/sat_dummy.toml
@@ -47,7 +47,12 @@ version = "2.0"
         # disintegration
         [params.stop.disint]
             enabled   = false
-            offset    = 0.0  # correction to calculated Roche limit [m]
+
+            roche_enabled = false
+            offset_roche  = 0 # correction to calculated Roche limit [m]
+
+            spin_enabled  = false
+            offset_spin   = 0 # correction to calculated Breakup period [s]
 
 [star]
     mass    = 1.0       # M_sun

--- a/input/demos/sat_physical.toml
+++ b/input/demos/sat_physical.toml
@@ -47,7 +47,12 @@ version = "2.0"
         # disintegration
         [params.stop.disint]
             enabled   = true
-            offset    = 0     # correction to calculated Roche limit [m]
+
+            roche_enabled = true
+            offset_roche  = 0 # correction to calculated Roche limit [m]
+
+            spin_enabled  = true
+            offset_spin   = 0 # correction to calculated Breakup period [s]
 
 
 # Star

--- a/src/proteus/config/_params.py
+++ b/src/proteus/config/_params.py
@@ -212,11 +212,22 @@ class StopDisint:
     ----------
     enabled: bool
         Enable criteria if True
-    offset: float
+    roche_enabled: bool
+        Disable Roche limit criterion
+    offset_roche: float
         Absolute correction (+/-) to (increase/decrease) calculated Roche limit [m].
+    spin_enabled: bool
+        Disable Breakup period criterion
+    offset_spin: float
+        Absolute correction (+/-) to (increase/decrease) calculated Breakup period [s].
     """
-    enabled: bool   = field(default=False)
-    offset: float   = field(default=0)
+    enabled: bool       = field(default=False)
+
+    roche_enabled: bool = field(default=True)
+    offset_roche: float = field(default=0)
+
+    spin_enabled: bool = field(default=True)
+    offset_spin: float  = field(default=0)
 
 @define
 class StopParams:

--- a/src/proteus/config/_params.py
+++ b/src/proteus/config/_params.py
@@ -211,7 +211,7 @@ class StopDisint:
     Attributes
     ----------
     enabled: bool
-        Enable criteria if True
+        Enable all planet disintegration criteria if True
     roche_enabled: bool
         Disable Roche limit criterion
     offset_roche: float

--- a/src/proteus/plot/cpl_orbit.py
+++ b/src/proteus/plot/cpl_orbit.py
@@ -48,7 +48,7 @@ def plot_orbit(hf_all:pd.DataFrame, output_dir:str, plot_format:str="pdf", t0:fl
     color = "tab:red"
     y = hf_all["eccentricity"]
     ax_tr.plot(time, y, lw=lw, color=color)
-    ax_tr.set_ylabel("Planet orbital ccentricity")
+    ax_tr.set_ylabel("Planet orbital eccentricity")
     ax_tr.yaxis.label.set_color(color)
     ax_tr.tick_params(axis='y', colors=color)
     ax_tr.set_ylim(np.amin(y)/yext, np.amax(y)*yext)

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -466,7 +466,7 @@ def GetHelpfileKeys():
             "semimajorax_sat", "M_sat", "plan_sat_am", # [m], [kg], [kg m2 s-1],
 
             # Day length
-            "axial_period", # [s]
+            "axial_period", "breakup_period", # [s], [s]
 
             # Dry interior radius (calculated) and mass (from config)
             "R_int", "M_int", # [m], [kg]


### PR DESCRIPTION
- Calculates the breakup period of planet.
- Warns user if planet is rotating faster then the breakup rate.
- Adds new termination condition to stop simulation when axial period < breakup period (Closes #491 ).
- Updates all_option and demo/orbit config files to include the new configuration parameters.