### PR TITLE
Clarify versioning scheme in CONTRIBUTING.md to specify format and re…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ The documentation is hosted on [readthedocs](https://readthedocs.io/projects/fwl
 
 ### Making a release
 
-The versioning scheme we use is [CalVer](https://calver.org/).
+The versioning scheme we use is [CalVer](https://calver.org/), in the format `YY.MM.DD`, without a leading 'v'. This means that releases are made based on the date of the release.
 
 0. Update requirements files:
 


### PR DESCRIPTION
This pull request updates the documentation in `CONTRIBUTING.md` to clarify the versioning scheme used for releases. The main change is a more detailed explanation of the CalVer format, specifying that releases use the `YY.MM.DD` format without a leading 'v', and are date-based. Closes #479 