### PR TITLE
Fix unit conversion error in postprocess.jl script

### DIFF
--- a/tools/postprocess.jl
+++ b/tools/postprocess.jl
@@ -172,7 +172,7 @@ function setup_atmos_from_nc!(output_dir::String, ncfile::String, spfile::String
                             input_inst, input_s0fact, input_albedo, input_zenith,
                             input_tsurf,
                             input_gravity, input_radius,
-                            nlev_c, input_pl[end], input_pl[1],
+                            nlev_c, input_pl[end]/1e5, input_pl[1]/1e5,
                             input_vmrs_scalar, "",
                             flag_gcontinuum=input_flag_continuum,
                             flag_rayleigh=input_flag_rayleigh,


### PR DESCRIPTION
## Description
A small change which fixes a bug in the `postprocess.jl` script. The atmosphere pressure boundaries (pascal) are now converted to bar before being passed to AGNI's `setup!` function.

Closes #626.


## Validation of changes
Tested by @lorlo9999 in the related issue.


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/proteus/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people
@timlichtenberg 
