### PR TITLE
Add unit tests for cpl_visual animation tooling

### DIFF
--- a/tests/plot/test_cpl_visual.py
+++ b/tests/plot/test_cpl_visual.py
@@ -351,10 +351,7 @@ def test_plot_visual_entry_calls_plot_visual(tmp_path):
         plot_visual_entry(handler)
 
     mock_pv.assert_called_once()
-    call_args = mock_pv.call_args
-    assert (
-        call_args.kwargs.get('idx', call_args.args[2] if len(call_args.args) > 2 else -1) == -1
-    )
+    assert mock_pv.call_args.kwargs['idx'] == -1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Adds 18 unit tests for `src/proteus/plot/cpl_visual.py` (`plot_visual`, `anim_visual`, and their entry points)
- All matplotlib rendering, file I/O, NetCDF reads, and subprocess calls are fully mocked (<1s total runtime)

## Context

PR #640 (`hn/animate`) adds animation tooling but Codecov reports only 5.26% patch coverage with 68 missing lines in `cpl_visual.py`. These tests cover the key code paths (format validation, missing-data guards, full render path, ffmpeg subprocess handling, entry-point wrappers) so that #640 can pass coverage checks and be merged.

## Test plan

- [x] All 18 new tests pass (`pytest tests/plot/test_cpl_visual.py -v`)
- [x] Full unit suite passes (531 passed, 0 failed)
- [x] Ruff lint and format clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add mocked coverage for plotting/ffmpeg orchestration without altering production behavior.
> 
> **Overview**
> Adds a new `tests/plot/test_cpl_visual.py` suite covering `plot_visual`, `anim_visual`, and their entry-point wrappers.
> 
> The tests validate format/osamp guards and missing-data failure paths, and mock NetCDF reads, matplotlib rendering, filesystem interactions, and `ffmpeg` subprocess behavior to exercise both error handling and the happy-path frame render/animation assembly without external dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78e326ab4cf6dc4634f17926f941c4235216ace1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->