### PR TITLE
fix(doctor): use semantic versioning for update checks

### DIFF
--- a/src/proteus/doctor.py
+++ b/src/proteus/doctor.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import importlib.metadata
 import os
+import platform
+import shutil
+import subprocess
 from functools import partial
 from importlib.metadata import PackageNotFoundError
 from typing import Callable
@@ -9,6 +12,7 @@ from typing import Callable
 import click
 import requests
 from attr import dataclass
+from packaging.version import Version, InvalidVersion
 
 from proteus.utils.coupler import _get_agni_version, get_proteus_directories
 
@@ -35,7 +39,15 @@ class BasePackage:
         except BaseException as exc:
             message = click.style(str(exc), **ERROR_STYLE)
         else:
-            if current_version != latest_version:
+            try:
+                current_ver = Version(current_version.lstrip('v'))
+                latest_ver = Version(latest_version.lstrip('v'))
+                needs_update = current_ver < latest_ver
+            except InvalidVersion:
+                # Fall back to string comparison if versions are non-standard
+                needs_update = current_version != latest_version
+
+            if needs_update:
                 message = click.style(
                     f'Update available {current_version} -> {latest_version}', fg='yellow'
                 )
@@ -101,7 +113,30 @@ def get_env_var_status_message(var: str) -> str:
 VARIABLES = (
     'FWL_DATA',
     'RAD_DIR',
+    'FC_DIR',
+    'ZALMOXIS_ROOT',
+    'LA_DIR',
 )
+
+
+def get_julia_version() -> str | None:
+    """Get Julia version if available."""
+    julia_path = shutil.which('julia')
+    if not julia_path:
+        return None
+    try:
+        result = subprocess.run(
+            ['julia', '--version'],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            # Output is like "julia version 1.10.0"
+            return result.stdout.strip().replace('julia version ', '')
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return None
 
 
 def doctor_entry():
@@ -114,3 +149,17 @@ def doctor_entry():
     for var in VARIABLES:
         message = get_env_var_status_message(var)
         click.echo(message)
+
+    click.secho('\nRuntime versions', **HEADER_STYLE)
+    python_name = click.style('Python', **OK_STYLE)
+    python_version = click.style(platform.python_version(), **OK_STYLE)
+    click.echo(f'{python_name}: {python_version}')
+
+    julia_version = get_julia_version()
+    julia_name = click.style('Julia', **OK_STYLE)
+    if julia_version:
+        julia_ver_styled = click.style(julia_version, **OK_STYLE)
+        click.echo(f'{julia_name}: {julia_ver_styled}')
+    else:
+        julia_not_found = click.style('Not found in PATH', **DEFAULT_STYLE)
+        click.echo(f'{julia_name}: {julia_not_found}')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,18 @@ def test_doctor():
     assert 'AGNI' in response.output
     assert 'fwl-mors' in response.output
 
+    # environment variables section
+    assert 'Environment variables' in response.output
+    assert 'FWL_DATA' in response.output
+    assert 'FC_DIR' in response.output
+    assert 'ZALMOXIS_ROOT' in response.output
+    assert 'LA_DIR' in response.output
+
+    # runtime versions section
+    assert 'Runtime versions' in response.output
+    assert 'Python' in response.output
+    assert 'Julia' in response.output
+
 
 @pytest.mark.unit
 def test_version():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,54 @@
+# Test PROTEUS doctor module
+from __future__ import annotations
+
+import pytest
+from packaging.version import Version
+
+
+@pytest.mark.unit
+def test_version_comparison_no_downgrade():
+    """Test that version comparison correctly identifies updates vs downgrades.
+
+    This is the fix for issue #646 where 25.11.19 -> 25.10.15 was incorrectly
+    suggested as an "upgrade" when it's actually a downgrade.
+    """
+    # These should NOT suggest an update (current >= latest)
+    test_cases_no_update = [
+        ('25.11.19', '25.10.15'),  # The original bug case
+        ('2.0.0', '1.9.9'),
+        ('1.0.1', '1.0.0'),
+        ('1.0.0', '1.0.0'),  # Same version
+    ]
+
+    for current, latest in test_cases_no_update:
+        current_ver = Version(current)
+        latest_ver = Version(latest)
+        needs_update = current_ver < latest_ver
+        assert not needs_update, f"Should NOT suggest update from {current} to {latest}"
+
+    # These SHOULD suggest an update (current < latest)
+    test_cases_needs_update = [
+        ('25.10.15', '25.11.19'),
+        ('1.0.0', '2.0.0'),
+        ('1.0.0', '1.0.1'),
+        ('1.9.9', '2.0.0'),
+    ]
+
+    for current, latest in test_cases_needs_update:
+        current_ver = Version(current)
+        latest_ver = Version(latest)
+        needs_update = current_ver < latest_ver
+        assert needs_update, f"SHOULD suggest update from {current} to {latest}"
+
+
+@pytest.mark.unit
+def test_version_comparison_with_v_prefix():
+    """Test that version comparison handles 'v' prefix correctly."""
+    # Git tags often have 'v' prefix
+    current = 'v1.0.0'
+    latest = 'v1.0.1'
+
+    current_ver = Version(current.lstrip('v'))
+    latest_ver = Version(latest.lstrip('v'))
+
+    assert current_ver < latest_ver


### PR DESCRIPTION
## Summary
Fixes #646 - The doctor command was incorrectly suggesting 'upgrades' that were actually downgrades (e.g., 25.11.19 -> 25.10.15).

## Changes
- **Fixed version comparison**: Use `packaging.version.Version` for proper semantic version comparison instead of simple string inequality
- **Added environment variable checks**: FC_DIR, ZALMOXIS_ROOT, LA_DIR now included in the doctor output
- **Added runtime version display**: Python and Julia versions are now shown in a new 'Runtime versions' section
- **Added unit tests**: New tests for version comparison logic to prevent regression

## Technical Details
The bug occurred because the original code used `current_version != latest_version` which doesn't understand semantic versioning. For example, `25.11.19` would be considered 'different' from `25.10.15`, triggering an update suggestion even though `25.11.19` is actually newer.

The fix uses `packaging.version.Version` to properly compare versions, only suggesting updates when `current_ver < latest_ver`.

## Testing
- Added unit tests in `tests/test_doctor.py` specifically for version comparison
- Updated existing CLI tests in `tests/test_cli.py` to verify new output sections