### PR TITLE
Update get_socrates script to obtain code from FormingWorlds/SOCRATES repo

### DIFF
--- a/tools/get_socrates.sh
+++ b/tools/get_socrates.sh
@@ -26,6 +26,15 @@ if [ -n "$RAD_DIR" ]; then
     sleep 5
 fi
 
+portable_realpath() {
+    if command -v realpath >/dev/null 2>&1; then
+        realpath "$1"
+    else
+        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+    fi
+}
+
+
 # Check SSH access to GitHub
 ssh -T git@github.com
 if [ $? -eq 1 ]; then
@@ -38,10 +47,19 @@ fi
 # use_ssh=false
 
 # Download
-root=$(dirname $(realpath $0))
-root=$(realpath "$root/..")
-socpath="$root/socrates"
+root=$(dirname $(portable_realpath $0))
+root=$(portable_realpath "$root/..")
+
+if [ -n "$1" ]; then
+    socpath="$(portable_realpath "$1")"
+else
+    socpath="$root/socrates"
+fi
 rm -rf "$socpath"
+
+set -euo pipefail
+
+
 if [ "$use_ssh" = true ]; then
     git clone git@github.com:FormingWorlds/SOCRATES.git "$socpath"
 else


### PR DESCRIPTION
## Description
We have moved from nichollsh/SOCRATES to FormingWorlds/SOCRATES, which enables us to remain in sync with the Metoffice repo.

This PR updates the `get_socrates.sh` script to reflect this change. It is a copy of the `get_socrates.sh` script from AGNI.


## Validation of changes
Obtains SOCRATES from correct repo and maintains all existing functionality. Tested on Fedora 43 with Python 3.12.


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people
@timlichtenberg 
