### PR TITLE
Fix PROTEUS schematic 

### DIFF
--- a/docs/How-to/config.md
+++ b/docs/How-to/config.md
@@ -137,7 +137,7 @@ for ideas of how to set up your config in practice.
 
     1. Decide on a good parameter name (*e.g.* `my_star_var`), and under which section to place it (*e.g.* `star`).
        Add the new variable to the [config submodule](https://github.com/FormingWorlds/PROTEUS/tree/main/src/proteus/config/_star.py).
-    2. Add the type for your variable, *e.g.* [float][], [int][], [str][].
+    2. Add the type for your variable, *e.g.* [`float`](https://docs.python.org/3/library/functions.html#float), [`int`](https://docs.python.org/3/library/functions.html#int), [`str`](https://docs.python.org/3/library/stdtypes.html#str).
        You can also add complex types, please check the [code](https://github.com/FormingWorlds/PROTEUS/tree/main/src/proteus/config) for inspiration.
     3. Add a [validator](https://www.attrs.org/en/stable/api.html#module-attrs.validators)!
        If your variable has a maximum value (*e.g.* 10), you can add a validator to make sure

--- a/docs/How-to/usage.md
+++ b/docs/How-to/usage.md
@@ -255,7 +255,7 @@ Access the atmospheric postprocessing functionality via the command line interfa
 ```console
 julia tools/multiprofile_postprocess.jl output/[outputdir] 0,36,45,89
 ```
-This example finds results for 4 zenith angles, namely [0,36,45,89], but the script works for any number of zenith angles and creates a new `..._atm_z{angle}.nc` file in the `data` directory, within the output directory, for each angle.
+This example finds results for 4 zenith angles, namely \[0,36,45,89\], but the script works for any number of zenith angles and creates a new `..._atm_z{angle}.nc` file in the `data` directory, within the output directory, for each angle.
 
 ## Archiving output files
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,8 +36,8 @@ title: PROTEUS
 
 <b>PROTEUS</b> (/ˈproʊtiəs, PROH-tee-əs) is a modular Python framework that simulates the coupled evolution of the atmospheres and interiors of rocky planets and exoplanets. Inspired by the Greek god of elusive sea change, who could change his form at will, PROTEUS is designed to be flexible and adaptable to a wide range of planetary environments. It can foretell the future, but answers only to those who are capable of asking the right questions.<br>
 
-<object type="image/svg+xml" data="../assets/proteus_modules_schematic.svg" class="arch-diagram arch-diagram--light"></object>
-<object type="image/svg+xml" data="../assets/proteus_modules_schematic_darkmode.svg" class="arch-diagram arch-diagram--dark"></object>
+<object type="image/svg+xml" data="assets/proteus_modules_schematic.svg" class="arch-diagram arch-diagram--light"></object>
+<object type="image/svg+xml" data="assets/proteus_modules_schematic_darkmode.svg" class="arch-diagram arch-diagram--dark"></object>
 
 <p style="text-align: center;"><strong>Schematic of PROTEUS components and corresponding modules.</strong></p>
 

--- a/docs/submodules.md
+++ b/docs/submodules.md
@@ -3,7 +3,7 @@
 PROTEUS is a modular simulation framework: the physics is split across several submodules, shown in the schematic below. Click any module in the diagram to open its documentation, or navigate to it from the sidebar.
 
 
-<object type="image/svg+xml" data="../assets/proteus_modules_schematic.svg" class="arch-diagram arch-diagram--light"></object>
-<object type="image/svg+xml" data="../assets/proteus_modules_schematic_darkmode.svg" class="arch-diagram arch-diagram--dark"></object>
+<object type="image/svg+xml" data="assets/proteus_modules_schematic.svg" class="arch-diagram arch-diagram--light"></object>
+<object type="image/svg+xml" data="assets/proteus_modules_schematic_darkmode.svg" class="arch-diagram arch-diagram--dark"></object>
 
 <p style="text-align: center;"><strong>Schematic of PROTEUS components and corresponding modules.</strong></p>


### PR DESCRIPTION
## Description
This PR should fix the issue with the PROTEUS schematic not rendering, by fixing the image paths. 

It also resolves two Zensical `unresolved link reference` warnings that are not fixed or made redundant in upcoming PR #678. Merge issues are avoided this way. 

## Validation of changes
Built the docs locally on chrome and safari.


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people
@nichollsh 
