### PR TITLE
set output root path with an environment variable

### DIFF
--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -960,6 +960,11 @@ def get_proteus_directories(outdir='_unset') -> dict[str, str]:
         Proteus directories dict
     """
     root_dir = get_proteus_dir()
+    if os.environ.get('PROTEUS_OUTPUT_PATH') is None:
+        output_root = os.path.join(root_dir, 'output')
+    else:
+        output_root = os.environ.get('PROTEUS_OUTPUT_PATH')
+        log.info(f'Output directory root from PROTEUS_OUTPUT_PATH environment variable: {output_root}')
 
     return {
         'proteus': root_dir,
@@ -971,11 +976,11 @@ def get_proteus_directories(outdir='_unset') -> dict[str, str]:
         'tools': os.path.join(root_dir, 'tools'),
         'vulcan': os.path.join(root_dir, 'VULCAN'),
         'utils': os.path.join(root_dir, 'src', 'proteus', 'utils'),
-        'output': os.path.join(root_dir, 'output', outdir),
-        'output/data': os.path.join(root_dir, 'output', outdir, 'data'),
-        'output/observe': os.path.join(root_dir, 'output', outdir, 'observe'),
-        'output/offchem': os.path.join(root_dir, 'output', outdir, 'offchem'),
-        'output/plots': os.path.join(root_dir, 'output', outdir, 'plots'),
+        'output': os.path.join(output_root, outdir),
+        'output/data': os.path.join(output_root, outdir, 'data'),
+        'output/observe': os.path.join(output_root, outdir, 'observe'),
+        'output/offchem': os.path.join(output_root, outdir, 'offchem'),
+        'output/plots': os.path.join(output_root, outdir, 'plots'),
     }
 
 


### PR DESCRIPTION
## Description
By default, the output root path will still be the PROTEUS/output folder. This commit adds the option to change that root path by setting the PROTEUS_OUTPUT_PATH environment variable. I want to use this to run multiple PROTEUS instances at once (e.g. for #436). I know that this should in principle be done using the grid mechanism, but in my case I also need to add additional instrumentation to each run and I think this would be the quickest way to achieve this. It could also be useful in general for those that want to keep their PROTEUS directory clean of anything except code.

The only related issue I could find is #29, but the fix for that only added the named output subdirectories, it did not allow for changing the base path.

## Validation of changes
I did not run extensive tests, nor did I write the appropriate docs. This PR was meant in the first place to show and discuss the idea (and basic implementation). If it is appreciated, I can do the rest of the checklist below.

I did check whether this conflicts with #678 and it doesn't. I do see that in that PR my problem of running PROTEUS multiple times is also solved in a different way, with the auto output mode. That is also great (and I would use it now if #678 was done), but changing the root path is orthogonal and I think still useful to have on its own (e.g. as mentioned above for those that want to keep code and data separate).

## Checklist

- [ ] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required

## Relevant people
@timlichtenberg @nichollsh 