### PR TITLE
Run install-all and update-all from any directory

### DIFF
--- a/docs/How-to/installation.md
+++ b/docs/How-to/installation.md
@@ -32,7 +32,11 @@ variables, and reference data downloads in a single command.
     disk space (5 GB minimum), creates `FWL_DATA` if needed, and sets the
     environment variables. Pass `--export-env` to write the environment
     variables to your shell rc file. To refresh an existing installation later,
-    use `proteus update-all` (see [Diagnose and update](doctor.md)).
+    use `proteus update-all` (see [Diagnose and update](doctor.md)). Both
+    commands operate on the PROTEUS source tree, which they locate from the
+    installed package (editable installs) or, for a plain wheel install, from
+    the current directory when it is a PROTEUS clone; with neither available
+    they exit with an error.
 
 ### 1. System packages
 

--- a/src/proteus/cli.py
+++ b/src/proteus/cli.py
@@ -58,6 +58,7 @@ if _should_apply_deterministic(sys.argv, os.environ):
 import shutil  # noqa: E402
 import subprocess  # noqa: E402
 import tempfile  # noqa: E402
+import tomllib  # noqa: E402
 
 import click  # noqa: E402
 
@@ -781,6 +782,36 @@ def _update_input_data(config_path: Path):
         return False
 
 
+def _is_proteus_root(path: Path) -> bool:
+    """Return True when ``path`` holds the PROTEUS source tree.
+
+    Identity is checked by the project name in ``pyproject.toml``, so an
+    arbitrary Python project, a stale editable-install pointer, or a
+    directory that merely contains some ``pyproject.toml`` is never
+    accepted as the install target. Any filesystem error while probing
+    counts as "not a PROTEUS root".
+
+    Parameters
+    ----------
+    path : Path
+        Candidate directory.
+
+    Returns
+    -------
+    bool
+        Whether the directory holds the ``fwl-proteus`` project.
+    """
+    try:
+        pyproject = path / 'pyproject.toml'
+        if not pyproject.is_file():
+            return False
+        with open(pyproject, 'rb') as fh:
+            name = tomllib.load(fh).get('project', {}).get('name', '')
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    return name == 'fwl-proteus'
+
+
 def _resolve_proteus_root() -> Path:
     """Return the PROTEUS source tree root, independent of the working directory.
 
@@ -791,39 +822,51 @@ def _resolve_proteus_root() -> Path:
     Deriving the root from the caller's current directory breaks the moment the
     command is run from anywhere other than the checkout.
 
-    For a non-editable install (plain wheel) the package location does not sit
-    in a source tree; in that case the current directory is used when it is
-    itself a PROTEUS checkout, which keeps the command usable for wheel users
-    standing inside a clone.
+    Both candidates are verified to actually hold the ``fwl-proteus`` project
+    before being accepted, and the chosen root is announced. For a non-editable
+    install (plain wheel) the package location does not sit in a source tree;
+    in that case the current directory is used when it is itself a PROTEUS
+    checkout, which keeps the command usable for wheel users standing inside a
+    clone.
 
     Returns
     -------
     Path
-        Absolute path to the directory containing ``pyproject.toml``.
+        Absolute path to the PROTEUS source tree.
 
     Raises
     ------
     SystemExit
-        If no source tree is reachable from either the installed package or
-        the current directory. There is then no checkout to set up or update,
-        so the command exits with a clear message instead of a confusing
-        downstream error.
+        If no PROTEUS source tree is reachable from either the installed
+        package or the current directory. There is then no checkout to set up
+        or update, so the command exits with a clear message instead of a
+        confusing downstream error.
     """
+    root = None
     try:
-        return Path(get_proteus_dir())
-    except EnvironmentError as exc:
-        cwd = Path.cwd()
-        if (cwd / 'pyproject.toml').is_file() and (cwd / 'tools' / 'get_socrates.sh').is_file():
-            click.secho(f'[i] Using the PROTEUS checkout at {cwd}', fg='cyan')
-            return cwd
+        candidate = Path(get_proteus_dir())
+    except EnvironmentError:
+        candidate = None
+    if candidate is not None and _is_proteus_root(candidate):
+        root = candidate
+    else:
+        try:
+            cwd = Path.cwd()
+        except OSError:
+            cwd = None
+        if cwd is not None and _is_proteus_root(cwd):
+            root = cwd
+    if root is None:
         click.secho(
-            f'[x] Cannot locate the PROTEUS source tree ({exc}). '
+            '[x] Cannot locate the PROTEUS source tree. '
             "'install-all' and 'update-all' need a PROTEUS git checkout: "
             'install PROTEUS in editable mode (pip install -e) or run the '
             'command from inside a clone of the repository.',
             fg='red',
         )
         raise SystemExit(1)
+    click.secho(f'[i] PROTEUS root: {root}', fg='cyan')
+    return root
 
 
 @cli.command()
@@ -860,8 +903,6 @@ def install_all(export_env: bool, config_path: Path | None):
             fg='red',
         )
         raise SystemExit(1)
-
-    """Install SOCRATES, AGNI, and configure PROTEUS environment."""
 
     # --- Step 1: FWL_DATA directory ---
     fwl_data = resolve_fwl_data_dir()
@@ -984,16 +1025,19 @@ def update_all(export_env: bool, config_path: Path | None):
             fg='red',
         )
         raise SystemExit(1)
-    """Update SOCRATES, AGNI, and refresh PROTEUS environment."""
 
     # --- Step 1: update all Python packages ---
     subprocess.run([sys.executable, '-m', 'pip', 'install', '-U', '-e', str(root)], check=True)
 
     # --- Step 2: FWL_DATA check ---
-    try:
-        fwl_data = resolve_fwl_data_dir()
-    except EnvironmentError:
-        click.secho('[x] FWL_DATA not set. Run `proteus install-all` first.', fg='red')
+    # resolve_fwl_data_dir always returns a path; an update only makes sense
+    # when the data directory from a previous installation actually exists.
+    fwl_data = resolve_fwl_data_dir()
+    if not fwl_data.is_dir():
+        click.secho(
+            f'[x] FWL_DATA directory not found at {fwl_data}. Run `proteus install-all` first.',
+            fg='red',
+        )
         raise SystemExit(1)
     click.secho(f'[+] Using FWL_DATA: {fwl_data}', fg='green')
 

--- a/src/proteus/cli.py
+++ b/src/proteus/cli.py
@@ -65,7 +65,7 @@ from proteus import Proteus  # noqa: E402
 from proteus import __version__ as proteus_version  # noqa: E402
 from proteus.config import read_config_object  # noqa: E402
 from proteus.utils.data import download_sufficient_data  # noqa: E402
-from proteus.utils.helper import resolve_fwl_data_dir  # noqa: E402
+from proteus.utils.helper import get_proteus_dir, resolve_fwl_data_dir  # noqa: E402
 from proteus.utils.logs import setup_logger  # noqa: E402
 
 config_option = click.option(
@@ -781,18 +781,68 @@ def _update_input_data(config_path: Path):
         return False
 
 
+def _resolve_proteus_root() -> Path:
+    """Return the PROTEUS source tree root, independent of the working directory.
+
+    ``install-all`` and ``update-all`` clone the sibling submodules (SOCRATES,
+    AGNI) next to the package source and run an editable ``pip install`` against
+    the source tree, so they must locate the repository from the installed
+    package itself rather than from the directory the command was invoked in.
+    Deriving the root from the caller's current directory breaks the moment the
+    command is run from anywhere other than the checkout.
+
+    For a non-editable install (plain wheel) the package location does not sit
+    in a source tree; in that case the current directory is used when it is
+    itself a PROTEUS checkout, which keeps the command usable for wheel users
+    standing inside a clone.
+
+    Returns
+    -------
+    Path
+        Absolute path to the directory containing ``pyproject.toml``.
+
+    Raises
+    ------
+    SystemExit
+        If no source tree is reachable from either the installed package or
+        the current directory. There is then no checkout to set up or update,
+        so the command exits with a clear message instead of a confusing
+        downstream error.
+    """
+    try:
+        return Path(get_proteus_dir())
+    except EnvironmentError as exc:
+        cwd = Path.cwd()
+        if (cwd / 'pyproject.toml').is_file() and (cwd / 'tools' / 'get_socrates.sh').is_file():
+            click.secho(f'[i] Using the PROTEUS checkout at {cwd}', fg='cyan')
+            return cwd
+        click.secho(
+            f'[x] Cannot locate the PROTEUS source tree ({exc}). '
+            "'install-all' and 'update-all' need a PROTEUS git checkout: "
+            'install PROTEUS in editable mode (pip install -e) or run the '
+            'command from inside a clone of the repository.',
+            fg='red',
+        )
+        raise SystemExit(1)
+
+
 @cli.command()
 @click.option('--export-env', is_flag=True, help='Add FWL_DATA and RAD_DIR to shell rc.')
 @click.option(
     '--config-path',
     type=click.Path(dir_okay=False, path_type=Path),
-    default=Path('input/all_options.toml'),
-    help='Path to the TOML config file',
+    default=None,
+    help='Path to the TOML config file (default: input/all_options.toml under the PROTEUS root)',
 )
-def install_all(export_env: bool, config_path: Path):
+def install_all(export_env: bool, config_path: Path | None):
     """Install PROTEUS, required submodules, and get lookup data from online sources."""
-    # --- Step 0: Check available disk space---
-    available_disk_space_in_B = shutil.disk_usage('.').free
+    # --- Step 0: Locate the source tree and check available disk space ---
+    # The submodule checkouts and the build land under the source tree, so
+    # the disk gate measures that filesystem, not the caller's.
+    root = _resolve_proteus_root()
+    if config_path is None:
+        config_path = root / 'input' / 'all_options.toml'
+    available_disk_space_in_B = shutil.disk_usage(root).free
     G = 1e9
     available_disk_space_in_GB = available_disk_space_in_B / G
     required_disk_space_in_GB = 5
@@ -819,12 +869,11 @@ def install_all(export_env: bool, config_path: Path):
     click.secho(f'[+] FWL_DATA directory: {fwl_data}', fg='green')
 
     # --- Step 2: Install SOCRATES ---
-    root = Path.cwd()
     socrates_dir = root / 'socrates'
     if not socrates_dir.exists():
         click.secho('[+] Installing SOCRATES...', fg='blue')
         try:
-            subprocess.run(['bash', 'tools/get_socrates.sh'], check=True)
+            subprocess.run(['bash', str(root / 'tools' / 'get_socrates.sh')], check=True)
         except subprocess.CalledProcessError as e:
             click.secho('[x] Failed to install SOCRATES', fg='red')
             click.echo(e)
@@ -862,7 +911,7 @@ def install_all(export_env: bool, config_path: Path):
         click.secho('[+] Installing AGNI...', fg='blue')
         try:
             subprocess.run(
-                ['git', 'clone', 'https://github.com/nichollsh/AGNI.git'],
+                ['git', 'clone', 'https://github.com/nichollsh/AGNI.git', str(agni_dir)],
                 check=True,
             )
             subprocess.run(['bash', 'src/get_agni.sh', '0'], cwd=agni_dir, env=env, check=True)
@@ -906,13 +955,18 @@ def install_all(export_env: bool, config_path: Path):
 @click.option(
     '--config-path',
     type=click.Path(dir_okay=False, path_type=Path),
-    default=Path('input/all_options.toml'),
-    help='Path to the TOML config file',
+    default=None,
+    help='Path to the TOML config file (default: input/all_options.toml under the PROTEUS root)',
 )
-def update_all(export_env: bool, config_path: Path):
+def update_all(export_env: bool, config_path: Path | None):
     """Update PROTEUS, submodules, and lookup data from online sources."""
-    # --- Step 0: Check available disk space---
-    available_disk_space_in_B = shutil.disk_usage('.').free
+    # --- Step 0: Locate the source tree and check available disk space ---
+    # The submodule refreshes and the build land under the source tree, so
+    # the disk gate measures that filesystem, not the caller's.
+    root = _resolve_proteus_root()
+    if config_path is None:
+        config_path = root / 'input' / 'all_options.toml'
+    available_disk_space_in_B = shutil.disk_usage(root).free
     G = 1e9
     available_disk_space_in_GB = available_disk_space_in_B / G
     required_disk_space_in_GB = 5
@@ -932,9 +986,8 @@ def update_all(export_env: bool, config_path: Path):
         raise SystemExit(1)
     """Update SOCRATES, AGNI, and refresh PROTEUS environment."""
 
-    root = Path.cwd()
     # --- Step 1: update all Python packages ---
-    subprocess.run([sys.executable, '-m', 'pip', 'install', '-U', '-e', '.'], check=True)
+    subprocess.run([sys.executable, '-m', 'pip', 'install', '-U', '-e', str(root)], check=True)
 
     # --- Step 2: FWL_DATA check ---
     try:
@@ -949,7 +1002,7 @@ def update_all(export_env: bool, config_path: Path):
     if socrates_dir.exists():
         click.secho('[+] Updating SOCRATES...', fg='blue')
         try:
-            subprocess.run(['bash', 'tools/get_socrates.sh'], check=True)
+            subprocess.run(['bash', str(root / 'tools' / 'get_socrates.sh')], check=True)
             click.secho('[+] SOCRATES updated', fg='green')
         except subprocess.CalledProcessError as e:
             click.secho('[x] Failed to update SOCRATES', fg='red')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1393,6 +1393,7 @@ def _stub_disk_usage_low():
 @pytest.mark.unit
 def test_install_all_aborts_on_low_disk(monkeypatch, tmp_path):
     """``install-all`` exits non-zero when free disk is below the 5 GB threshold."""
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_low())
 
     res = runner.invoke(cli.cli, ['install-all'])
@@ -1406,7 +1407,7 @@ def test_install_all_aborts_on_low_disk(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_aborts_when_julia_missing(monkeypatch, tmp_path):
     """``install-all`` aborts with a Julia-not-found message when julia is missing."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     # Pre-create socrates dir so the SOCRATES install path is skipped
     (tmp_path / 'socrates').mkdir()
@@ -1428,7 +1429,7 @@ def test_install_all_success_with_export_env(monkeypatch, tmp_path):
     Verifies the rc-export step writes lines, the socrates / AGNI dirs are
     detected as pre-existing, and the completion message fires.
     """
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1466,7 +1467,7 @@ def test_install_all_success_with_export_env(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_invokes_socrates_when_missing(monkeypatch, tmp_path):
     """SOCRATES install branch fires subprocess.run when the socrates/ dir is absent."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1502,7 +1503,7 @@ def test_install_all_invokes_socrates_when_missing(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_socrates_subprocess_failure_aborts(monkeypatch, tmp_path):
     """A CalledProcessError from the SOCRATES install script aborts with exit != 0."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1531,7 +1532,7 @@ def test_install_all_socrates_subprocess_failure_aborts(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_agni_clone_failure_aborts(monkeypatch, tmp_path):
     """A CalledProcessError during AGNI clone aborts the installation."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1567,6 +1568,7 @@ def test_install_all_agni_clone_failure_aborts(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_aborts_on_low_disk(monkeypatch, tmp_path):
     """``update-all`` exits non-zero when free disk is below the 5 GB threshold."""
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_low())
 
     res = runner.invoke(cli.cli, ['update-all'])
@@ -1579,7 +1581,7 @@ def test_update_all_aborts_on_low_disk(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_success_path(monkeypatch, tmp_path):
     """Happy path: socrates + AGNI present, julia found, pip + git pull all stubbed."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1612,7 +1614,7 @@ def test_update_all_success_path(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_warns_when_socrates_missing(monkeypatch, tmp_path):
     """SOCRATES-missing path emits a warning, no crash."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1634,7 +1636,7 @@ def test_update_all_warns_when_socrates_missing(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_warns_when_julia_missing(monkeypatch, tmp_path):
     """Julia-missing path emits a warning but does NOT abort (unlike install-all)."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(cli.shutil, 'which', lambda exe: None)
     monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
@@ -1656,7 +1658,7 @@ def test_update_all_warns_when_julia_missing(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_socrates_update_failure_continues(monkeypatch, tmp_path):
     """A SOCRATES update subprocess failure is reported but the command still continues."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1688,7 +1690,7 @@ def test_update_all_socrates_update_failure_continues(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_agni_update_failure_continues(monkeypatch, tmp_path):
     """An AGNI update subprocess failure is reported but the command still continues."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1719,7 +1721,7 @@ def test_update_all_agni_update_failure_continues(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_export_env_writes_rc(monkeypatch, tmp_path):
     """``update-all --export-env`` writes rc lines for FWL_DATA and RAD_DIR."""
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1741,6 +1743,306 @@ def test_update_all_export_env_writes_rc(monkeypatch, tmp_path):
     assert 'PROTEUS update completed' in res.output
     # Either exported or detected as already exported; at least one rc line touched.
     assert 'Exported' in res.output or 'already exported' in res.output
+
+
+# ---------------------------
+# run-from-anywhere contract: install-all / update-all must resolve the
+# source tree from the package location, not the caller's working directory
+# ---------------------------
+
+
+@pytest.mark.unit
+def test_update_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path):
+    """``update-all`` works when invoked from outside the checkout.
+
+    Run from any directory other than the source tree, the command must still
+    reinstall the source tree (not the caller's directory) and must invoke the
+    SOCRATES build script and the AGNI update by their absolute location under
+    the resolved root. This is the contract that breaks when the root is taken
+    from the current working directory.
+    """
+    source_root = tmp_path / 'proteus_src'
+    foreign_cwd = tmp_path / 'run_from_here'
+    source_root.mkdir()
+    (source_root / 'tools').mkdir()
+    (source_root / 'socrates').mkdir()
+    (source_root / 'AGNI').mkdir()
+    foreign_cwd.mkdir()
+
+    monkeypatch.chdir(foreign_cwd)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(source_root))
+    monkeypatch.setattr(
+        cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
+    )
+    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+
+    disk_paths = []
+
+    def fake_disk_usage(path):
+        disk_paths.append(Path(path))
+        return _stub_disk_usage_high()
+
+    monkeypatch.setattr(cli.shutil, 'disk_usage', fake_disk_usage)
+
+    captured = []
+
+    def fake_subprocess_run(cmd, **kwargs):
+        captured.append((list(cmd), dict(kwargs)))
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(cli.subprocess, 'run', fake_subprocess_run)
+
+    data_paths = []
+
+    def record_input_data(path):
+        data_paths.append(path)
+        return False
+
+    monkeypatch.setattr(cli, '_update_input_data', record_input_data)
+
+    res = runner.invoke(cli.cli, ['update-all'])
+    assert res.exit_code == 0, f'update-all output: {res.output}'
+
+    # The editable pip install targets the source tree, never the cwd or '.'.
+    pip_targets = [
+        cmd[-1] for cmd, _ in captured if 'pip' in cmd and 'install' in cmd and '-e' in cmd
+    ]
+    assert pip_targets == [str(source_root)]
+    assert str(foreign_cwd) not in pip_targets
+    # Discrimination: a cwd-derived implementation would pass the bare '.',
+    # which resolves against the caller's directory.
+    assert '.' not in pip_targets
+
+    # The SOCRATES script is referenced by its absolute path under the root, so
+    # bash can find it regardless of where the command was launched.
+    socrates_args = [a for cmd, _ in captured for a in cmd if 'get_socrates.sh' in a]
+    assert len(socrates_args) == 1
+    assert socrates_args[0].startswith(str(source_root))
+    assert str(foreign_cwd) not in socrates_args[0]
+
+    # The AGNI update runs inside the AGNI checkout under the root, not the cwd.
+    agni_cwds = [kw.get('cwd') for _, kw in captured if kw.get('cwd') is not None]
+    assert (source_root / 'AGNI') in agni_cwds
+    assert (foreign_cwd / 'AGNI') not in agni_cwds
+
+    # The disk gate measures the filesystem the update writes to.
+    assert disk_paths == [source_root]
+
+    # The default config for the data refresh sits under the root, not under
+    # the caller's directory.
+    assert data_paths == [source_root / 'input' / 'all_options.toml']
+
+    # Failures must propagate: every subprocess call runs with check=True so
+    # a nonzero exit aborts the step instead of being ignored.
+    assert captured and all(kw.get('check') is True for _, kw in captured)
+
+
+@pytest.mark.unit
+def test_install_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path):
+    """``install-all`` clones submodules next to the source tree, not the cwd.
+
+    With neither socrates/ nor AGNI/ present yet, the installer must run the
+    SOCRATES script by its absolute path under the root and clone AGNI into the
+    root, so a run launched from a foreign directory populates the checkout
+    rather than scattering submodules into the caller's directory.
+    """
+    source_root = tmp_path / 'proteus_src'
+    foreign_cwd = tmp_path / 'run_from_here'
+    source_root.mkdir()
+    (source_root / 'tools').mkdir()
+    foreign_cwd.mkdir()
+    # Deliberately no socrates/ and no AGNI/ so both install branches fire.
+
+    monkeypatch.chdir(foreign_cwd)
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(source_root))
+    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+    monkeypatch.setattr(
+        cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
+    )
+    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+
+    captured = []
+
+    def fake_subprocess_run(cmd, **kwargs):
+        captured.append((list(cmd), dict(kwargs)))
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(cli.subprocess, 'run', fake_subprocess_run)
+
+    data_paths = []
+
+    def record_input_data(path):
+        data_paths.append(path)
+        return False
+
+    monkeypatch.setattr(cli, '_update_input_data', record_input_data)
+
+    res = runner.invoke(cli.cli, ['install-all'])
+    assert res.exit_code == 0, f'install-all output: {res.output}'
+
+    # SOCRATES script referenced by absolute path under the root.
+    socrates_args = [a for cmd, _ in captured for a in cmd if 'get_socrates.sh' in a]
+    assert len(socrates_args) == 1
+    assert socrates_args[0].startswith(str(source_root))
+
+    # AGNI clone targets the root explicitly (git clone <url> <dest>), so the
+    # checkout lands under the root and never in the foreign cwd.
+    clone_dests = [cmd[-1] for cmd, _ in captured if 'clone' in cmd]
+    assert clone_dests == [str(source_root / 'AGNI')]
+    assert str(foreign_cwd) not in clone_dests[0]
+
+    # The default config for the data download sits under the root.
+    assert data_paths == [source_root / 'input' / 'all_options.toml']
+
+    # The output directory is created under the root, never in the caller's
+    # directory.
+    assert (source_root / 'output').is_dir()
+    assert not (foreign_cwd / 'output').exists()
+
+    # Failures must propagate: every subprocess call runs with check=True.
+    assert captured and all(kw.get('check') is True for _, kw in captured)
+
+
+@pytest.mark.unit
+def test_update_all_errors_cleanly_when_source_tree_missing(monkeypatch, tmp_path):
+    """``update-all`` fails fast with a clear message for a non-editable install.
+
+    When the source tree cannot be located (PROTEUS installed as a plain
+    wheel) and the working directory is not a checkout either, there is
+    nothing to reinstall editable, so the command must exit non-zero with an
+    actionable message and must NOT attempt any subprocess.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+
+    def raise_env_error():
+        raise EnvironmentError('Cannot locate PROTEUS directory.')
+
+    monkeypatch.setattr(cli, 'get_proteus_dir', raise_env_error)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return type('R', (), {'returncode': 0})()
+
+    monkeypatch.setattr(cli.subprocess, 'run', fake_run)
+
+    res = runner.invoke(cli.cli, ['update-all'])
+    assert res.exit_code != 0
+    assert 'Cannot locate the PROTEUS source tree' in res.output
+    # Discrimination: it bailed out before running pip (or anything else), and
+    # the success banner is absent.
+    assert calls == []
+    assert 'PROTEUS update completed' not in res.output
+
+
+@pytest.mark.unit
+def test_install_all_errors_cleanly_when_source_tree_missing(monkeypatch, tmp_path):
+    """``install-all`` fails fast with a clear message for a non-editable install."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+
+    def raise_env_error():
+        raise EnvironmentError('Cannot locate PROTEUS directory.')
+
+    monkeypatch.setattr(cli, 'get_proteus_dir', raise_env_error)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return type('R', (), {'returncode': 0})()
+
+    monkeypatch.setattr(cli.subprocess, 'run', fake_run)
+
+    res = runner.invoke(cli.cli, ['install-all'])
+    assert res.exit_code != 0
+    assert 'Cannot locate the PROTEUS source tree' in res.output
+    # Discrimination: no submodule subprocess ran, the completion banner is
+    # absent, and the abort precedes the FWL_DATA directory creation.
+    assert calls == []
+    assert 'PROTEUS installation completed' not in res.output
+    assert not (tmp_path / 'fwl_data').exists()
+
+
+@pytest.mark.unit
+def test_resolve_proteus_root_returns_directory_with_pyproject(monkeypatch, tmp_path):
+    """``_resolve_proteus_root`` returns the source root, not the working dir.
+
+    The resolved path is taken from the installed package location and must
+    contain ``pyproject.toml``; changing the process working directory must not
+    change the answer.
+    """
+    monkeypatch.chdir(tmp_path)
+    root = cli._resolve_proteus_root()
+    assert (root / 'pyproject.toml').is_file()
+    # Discrimination: the result is decoupled from the cwd we just moved to and
+    # is an absolute path.
+    assert root != tmp_path
+    assert root.is_absolute()
+
+
+@pytest.mark.unit
+def test_resolve_proteus_root_exits_when_source_tree_unlocatable(monkeypatch, tmp_path):
+    """``_resolve_proteus_root`` turns a missing source tree into a clean exit.
+
+    A bare wheel install has no ``pyproject.toml`` to find, and a working
+    directory without the checkout markers offers no fallback; the helper
+    converts the underlying ``EnvironmentError`` into ``SystemExit`` so the
+    CLI prints an actionable message instead of a raw traceback.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    def raise_env_error():
+        raise EnvironmentError('Cannot locate PROTEUS directory.')
+
+    monkeypatch.setattr(cli, 'get_proteus_dir', raise_env_error)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli._resolve_proteus_root()
+    # Discrimination: a clean exit-code-1, not the raw EnvironmentError and not
+    # a success (code 0).
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.unit
+def test_resolve_proteus_root_falls_back_to_checkout_cwd(monkeypatch, tmp_path):
+    """A wheel install run from inside a checkout uses that checkout.
+
+    When the package location yields no source tree, the helper accepts the
+    working directory only if it carries the checkout markers (pyproject.toml
+    plus tools/get_socrates.sh); a directory holding only the pyproject.toml
+    of some other project must still exit.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    def raise_env_error():
+        raise EnvironmentError('Cannot locate PROTEUS directory.')
+
+    monkeypatch.setattr(cli, 'get_proteus_dir', raise_env_error)
+
+    # Edge case: a generic Python project directory is not accepted.
+    (tmp_path / 'pyproject.toml').write_text('[project]\nname = "other"\n')
+    with pytest.raises(SystemExit) as excinfo:
+        cli._resolve_proteus_root()
+    assert excinfo.value.code == 1
+
+    # With both checkout markers present the working directory is used.
+    (tmp_path / 'tools').mkdir()
+    (tmp_path / 'tools' / 'get_socrates.sh').write_text('#!/bin/bash\n')
+    root = cli._resolve_proteus_root()
+    assert root == tmp_path
+    assert root.is_absolute()
 
 
 # ---------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1390,11 +1390,36 @@ def _stub_disk_usage_low():
     return Usage(total=1_000_000_000_000, used=0, free=1_000_000_000)
 
 
+def _pin_proteus_root(monkeypatch, root):
+    """Shape ``root`` as a PROTEUS checkout and pin resolution to it.
+
+    Writes the project marker the resolver verifies, points the package
+    lookup at ``root``, and pre-sets RAD_DIR so the commands' setdefault
+    cannot leak an environment variable past the test.
+    """
+    root.mkdir(exist_ok=True)
+    (root / 'pyproject.toml').write_text('[project]\nname = "fwl-proteus"\n')
+    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(root))
+    monkeypatch.setenv('RAD_DIR', str(root / 'socrates'))
+
+
+def _make_fwl_data(monkeypatch, tmp_path):
+    """Point FWL_DATA at an existing directory, as after an installation."""
+    fwl = tmp_path / 'fwl_data'
+    fwl.mkdir(exist_ok=True)
+    monkeypatch.setenv('FWL_DATA', str(fwl))
+
+
 @pytest.mark.unit
 def test_install_all_aborts_on_low_disk(monkeypatch, tmp_path):
     """``install-all`` exits non-zero when free disk is below the 5 GB threshold."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_low())
+    # Defensive stub: a regression past the gate must fail an assertion, not
+    # launch a real installer.
+    monkeypatch.setattr(
+        cli.subprocess, 'run', lambda cmd, **kw: type('R', (), {'returncode': 0})()
+    )
 
     res = runner.invoke(cli.cli, ['install-all'])
     assert res.exit_code != 0
@@ -1407,11 +1432,16 @@ def test_install_all_aborts_on_low_disk(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_aborts_when_julia_missing(monkeypatch, tmp_path):
     """``install-all`` aborts with a Julia-not-found message when julia is missing."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     # Pre-create socrates dir so the SOCRATES install path is skipped
     (tmp_path / 'socrates').mkdir()
     monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    # Defensive stub: a regression into the SOCRATES branch must fail an
+    # assertion, not launch a real installer.
+    monkeypatch.setattr(
+        cli.subprocess, 'run', lambda cmd, **kw: type('R', (), {'returncode': 0})()
+    )
     # Force the julia check to fail
     monkeypatch.setattr(cli, 'is_julia_installed', lambda: False)
 
@@ -1429,7 +1459,7 @@ def test_install_all_success_with_export_env(monkeypatch, tmp_path):
     Verifies the rc-export step writes lines, the socrates / AGNI dirs are
     detected as pre-existing, and the completion message fires.
     """
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1467,7 +1497,7 @@ def test_install_all_success_with_export_env(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_invokes_socrates_when_missing(monkeypatch, tmp_path):
     """SOCRATES install branch fires subprocess.run when the socrates/ dir is absent."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1503,7 +1533,7 @@ def test_install_all_invokes_socrates_when_missing(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_socrates_subprocess_failure_aborts(monkeypatch, tmp_path):
     """A CalledProcessError from the SOCRATES install script aborts with exit != 0."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1532,7 +1562,7 @@ def test_install_all_socrates_subprocess_failure_aborts(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_install_all_agni_clone_failure_aborts(monkeypatch, tmp_path):
     """A CalledProcessError during AGNI clone aborts the installation."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
@@ -1568,8 +1598,13 @@ def test_install_all_agni_clone_failure_aborts(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_aborts_on_low_disk(monkeypatch, tmp_path):
     """``update-all`` exits non-zero when free disk is below the 5 GB threshold."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_low())
+    # Defensive stub: a regression past the gate must fail an assertion, not
+    # run a real pip reinstall.
+    monkeypatch.setattr(
+        cli.subprocess, 'run', lambda cmd, **kw: type('R', (), {'returncode': 0})()
+    )
 
     res = runner.invoke(cli.cli, ['update-all'])
     assert res.exit_code != 0
@@ -1581,12 +1616,12 @@ def test_update_all_aborts_on_low_disk(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_success_path(monkeypatch, tmp_path):
     """Happy path: socrates + AGNI present, julia found, pip + git pull all stubbed."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
 
     (tmp_path / 'socrates').mkdir()
     (tmp_path / 'AGNI').mkdir()
@@ -1614,12 +1649,12 @@ def test_update_all_success_path(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_warns_when_socrates_missing(monkeypatch, tmp_path):
     """SOCRATES-missing path emits a warning, no crash."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
 
     # NO socrates dir, NO AGNI dir
     monkeypatch.setattr(
@@ -1636,10 +1671,10 @@ def test_update_all_warns_when_socrates_missing(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_warns_when_julia_missing(monkeypatch, tmp_path):
     """Julia-missing path emits a warning but does NOT abort (unlike install-all)."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(cli.shutil, 'which', lambda exe: None)
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
 
     (tmp_path / 'socrates').mkdir()
     monkeypatch.setattr(
@@ -1658,12 +1693,12 @@ def test_update_all_warns_when_julia_missing(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_socrates_update_failure_continues(monkeypatch, tmp_path):
     """A SOCRATES update subprocess failure is reported but the command still continues."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
 
     (tmp_path / 'socrates').mkdir()
     (tmp_path / 'AGNI').mkdir()
@@ -1690,12 +1725,12 @@ def test_update_all_socrates_update_failure_continues(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_agni_update_failure_continues(monkeypatch, tmp_path):
     """An AGNI update subprocess failure is reported but the command still continues."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
 
     (tmp_path / 'socrates').mkdir()
     (tmp_path / 'AGNI').mkdir()
@@ -1721,12 +1756,12 @@ def test_update_all_agni_update_failure_continues(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_update_all_export_env_writes_rc(monkeypatch, tmp_path):
     """``update-all --export-env`` writes rc lines for FWL_DATA and RAD_DIR."""
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(tmp_path))
+    _pin_proteus_root(monkeypatch, tmp_path)
     monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
     monkeypatch.setenv('SHELL', '/bin/bash')
     monkeypatch.setattr(Path, 'home', lambda: tmp_path / 'home')
     (tmp_path / 'home').mkdir()
@@ -1770,11 +1805,11 @@ def test_update_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path):
     foreign_cwd.mkdir()
 
     monkeypatch.chdir(foreign_cwd)
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(source_root))
+    _pin_proteus_root(monkeypatch, source_root)
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
-    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    _make_fwl_data(monkeypatch, tmp_path)
 
     disk_paths = []
 
@@ -1811,11 +1846,9 @@ def test_update_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path):
     pip_targets = [
         cmd[-1] for cmd, _ in captured if 'pip' in cmd and 'install' in cmd and '-e' in cmd
     ]
+    # Discrimination: a cwd-derived implementation passes the bare '.'
+    # (resolving against the caller's directory), which this equality rejects.
     assert pip_targets == [str(source_root)]
-    assert str(foreign_cwd) not in pip_targets
-    # Discrimination: a cwd-derived implementation would pass the bare '.',
-    # which resolves against the caller's directory.
-    assert '.' not in pip_targets
 
     # The SOCRATES script is referenced by its absolute path under the root, so
     # bash can find it regardless of where the command was launched.
@@ -1858,12 +1891,19 @@ def test_install_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path)
     # Deliberately no socrates/ and no AGNI/ so both install branches fire.
 
     monkeypatch.chdir(foreign_cwd)
-    monkeypatch.setattr(cli, 'get_proteus_dir', lambda: str(source_root))
-    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+    _pin_proteus_root(monkeypatch, source_root)
     monkeypatch.setattr(
         cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
     )
     monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+
+    disk_paths = []
+
+    def fake_disk_usage(path):
+        disk_paths.append(Path(path))
+        return _stub_disk_usage_high()
+
+    monkeypatch.setattr(cli.shutil, 'disk_usage', fake_disk_usage)
 
     captured = []
 
@@ -1897,7 +1937,6 @@ def test_install_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path)
     # checkout lands under the root and never in the foreign cwd.
     clone_dests = [cmd[-1] for cmd, _ in captured if 'clone' in cmd]
     assert clone_dests == [str(source_root / 'AGNI')]
-    assert str(foreign_cwd) not in clone_dests[0]
 
     # The default config for the data download sits under the root.
     assert data_paths == [source_root / 'input' / 'all_options.toml']
@@ -1906,6 +1945,13 @@ def test_install_all_anchors_paths_to_source_root_not_cwd(monkeypatch, tmp_path)
     # directory.
     assert (source_root / 'output').is_dir()
     assert not (foreign_cwd / 'output').exists()
+
+    # The AGNI setup script runs inside the cloned checkout under the root.
+    agni_cwds = [kw.get('cwd') for cmd, kw in captured if 'src/get_agni.sh' in cmd]
+    assert agni_cwds == [source_root / 'AGNI']
+
+    # The disk gate measures the filesystem the install writes to.
+    assert disk_paths == [source_root]
 
     # Failures must propagate: every subprocess call runs with check=True.
     assert captured and all(kw.get('check') is True for _, kw in captured)
@@ -1979,17 +2025,44 @@ def test_install_all_errors_cleanly_when_source_tree_missing(monkeypatch, tmp_pa
 def test_resolve_proteus_root_returns_directory_with_pyproject(monkeypatch, tmp_path):
     """``_resolve_proteus_root`` returns the source root, not the working dir.
 
-    The resolved path is taken from the installed package location and must
-    contain ``pyproject.toml``; changing the process working directory must not
-    change the answer.
+    The resolved path comes from the installed package location and must hold
+    the PROTEUS ``pyproject.toml``; changing the process working directory to
+    an unrelated location must not change the answer.
     """
-    monkeypatch.chdir(tmp_path)
+    source_root = tmp_path / 'proteus_src'
+    elsewhere = tmp_path / 'elsewhere'
+    elsewhere.mkdir()
+    _pin_proteus_root(monkeypatch, source_root)
+    monkeypatch.chdir(elsewhere)
+
     root = cli._resolve_proteus_root()
+    assert root == source_root
     assert (root / 'pyproject.toml').is_file()
     # Discrimination: the result is decoupled from the cwd we just moved to and
     # is an absolute path.
-    assert root != tmp_path
+    assert root != elsewhere
     assert root.is_absolute()
+
+
+@pytest.mark.unit
+def test_resolve_proteus_root_prefers_package_location_over_cwd(monkeypatch, tmp_path):
+    """The package-derived root wins even when the cwd is also a checkout.
+
+    The working directory is a fallback for wheel installs only; with a valid
+    package-derived root available, standing inside a second checkout must not
+    redirect the install target to it.
+    """
+    root_a = tmp_path / 'clone_a'
+    root_b = tmp_path / 'clone_b'
+    _pin_proteus_root(monkeypatch, root_a)
+    root_b.mkdir()
+    (root_b / 'pyproject.toml').write_text('[project]\nname = "fwl-proteus"\n')
+    monkeypatch.chdir(root_b)
+
+    root = cli._resolve_proteus_root()
+    # Discrimination: a cwd-first implementation returns clone_b here.
+    assert root == root_a
+    assert root != root_b
 
 
 @pytest.mark.unit
@@ -2020,9 +2093,9 @@ def test_resolve_proteus_root_falls_back_to_checkout_cwd(monkeypatch, tmp_path):
     """A wheel install run from inside a checkout uses that checkout.
 
     When the package location yields no source tree, the helper accepts the
-    working directory only if it carries the checkout markers (pyproject.toml
-    plus tools/get_socrates.sh); a directory holding only the pyproject.toml
-    of some other project must still exit.
+    working directory only if its pyproject.toml names the fwl-proteus
+    project; a directory holding some other project's pyproject.toml must
+    still exit.
     """
     monkeypatch.chdir(tmp_path)
 
@@ -2037,12 +2110,132 @@ def test_resolve_proteus_root_falls_back_to_checkout_cwd(monkeypatch, tmp_path):
         cli._resolve_proteus_root()
     assert excinfo.value.code == 1
 
-    # With both checkout markers present the working directory is used.
-    (tmp_path / 'tools').mkdir()
-    (tmp_path / 'tools' / 'get_socrates.sh').write_text('#!/bin/bash\n')
+    # With the PROTEUS project name in place the working directory is used.
+    (tmp_path / 'pyproject.toml').write_text('[project]\nname = "fwl-proteus"\n')
     root = cli._resolve_proteus_root()
     assert root == tmp_path
     assert root.is_absolute()
+
+
+@pytest.mark.unit
+def test_is_proteus_root_rejects_invalid_candidates(tmp_path):
+    """``_is_proteus_root`` accepts only a directory holding fwl-proteus.
+
+    Probes the empty directory, a foreign project, malformed TOML, and the
+    genuine project name, so a stale editable pointer or an arbitrary Python
+    project can never be accepted as the install target.
+    """
+    # Edge case: no pyproject.toml at all.
+    assert cli._is_proteus_root(tmp_path) is False
+
+    # A different project's pyproject.toml is rejected.
+    pyproject = tmp_path / 'pyproject.toml'
+    pyproject.write_text('[project]\nname = "other"\n')
+    assert cli._is_proteus_root(tmp_path) is False
+
+    # Malformed TOML counts as not-a-root rather than raising.
+    pyproject.write_text('not [valid toml')
+    assert cli._is_proteus_root(tmp_path) is False
+
+    # The genuine project name is accepted.
+    pyproject.write_text('[project]\nname = "fwl-proteus"\n')
+    assert cli._is_proteus_root(tmp_path) is True
+
+
+@pytest.mark.unit
+def test_update_all_explicit_config_path_not_reanchored(monkeypatch, tmp_path):
+    """An explicitly passed --config-path is forwarded exactly as given.
+
+    Only the implicit default is anchored to the source root; a user-supplied
+    relative path keeps its usual cwd-relative meaning and must reach the
+    data-download step unchanged.
+    """
+    source_root = tmp_path / 'proteus_src'
+    foreign_cwd = tmp_path / 'run_from_here'
+    foreign_cwd.mkdir()
+    _pin_proteus_root(monkeypatch, source_root)
+    (source_root / 'socrates').mkdir()
+    (source_root / 'AGNI').mkdir()
+    monkeypatch.chdir(foreign_cwd)
+    _make_fwl_data(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+    monkeypatch.setattr(
+        cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
+    )
+    monkeypatch.setattr(
+        cli.subprocess, 'run', lambda cmd, **kw: type('R', (), {'returncode': 0})()
+    )
+
+    data_paths = []
+
+    def record_input_data(path):
+        data_paths.append(path)
+        return False
+
+    monkeypatch.setattr(cli, '_update_input_data', record_input_data)
+
+    res = runner.invoke(cli.cli, ['update-all', '--config-path', 'my/conf.toml'])
+    assert res.exit_code == 0, f'update-all output: {res.output}'
+    # Discrimination: a re-anchoring implementation would forward
+    # source_root / 'my/conf.toml' instead of the path as typed.
+    assert data_paths == [Path('my/conf.toml')]
+
+
+@pytest.mark.unit
+def test_install_all_explicit_config_path_not_reanchored(monkeypatch, tmp_path):
+    """``install-all`` forwards an explicit --config-path exactly as given."""
+    source_root = tmp_path / 'proteus_src'
+    foreign_cwd = tmp_path / 'run_from_here'
+    foreign_cwd.mkdir()
+    _pin_proteus_root(monkeypatch, source_root)
+    (source_root / 'socrates').mkdir()
+    (source_root / 'AGNI').mkdir()
+    monkeypatch.chdir(foreign_cwd)
+    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'fwl_data'))
+    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+    monkeypatch.setattr(
+        cli.shutil, 'which', lambda exe: '/usr/local/bin/julia' if exe == 'julia' else None
+    )
+    monkeypatch.setattr(
+        cli.subprocess, 'run', lambda cmd, **kw: type('R', (), {'returncode': 0})()
+    )
+
+    data_paths = []
+
+    def record_input_data(path):
+        data_paths.append(path)
+        return False
+
+    monkeypatch.setattr(cli, '_update_input_data', record_input_data)
+
+    res = runner.invoke(cli.cli, ['install-all', '--config-path', 'my/conf.toml'])
+    assert res.exit_code == 0, f'install-all output: {res.output}'
+    # Discrimination: a re-anchoring implementation would forward
+    # source_root / 'my/conf.toml' instead of the path as typed.
+    assert data_paths == [Path('my/conf.toml')]
+
+
+@pytest.mark.unit
+def test_update_all_aborts_when_fwl_data_missing(monkeypatch, tmp_path):
+    """``update-all`` exits with guidance when the FWL_DATA directory is absent.
+
+    Updating presumes a prior installation; with FWL_DATA pointing at a
+    directory that does not exist, the command must abort with the
+    install-all hint rather than continue against a non-existent data tree.
+    """
+    _pin_proteus_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli.shutil, 'disk_usage', lambda path: _stub_disk_usage_high())
+    monkeypatch.setenv('FWL_DATA', str(tmp_path / 'no_such_dir'))
+    monkeypatch.setattr(
+        cli.subprocess, 'run', lambda cmd, **kw: type('R', (), {'returncode': 0})()
+    )
+
+    res = runner.invoke(cli.cli, ['update-all'])
+    assert res.exit_code != 0
+    assert 'FWL_DATA directory not found' in res.output
+    assert 'install-all' in res.output
+    # Discrimination: the success banner must not fire on this path.
+    assert 'PROTEUS update completed' not in res.output
 
 
 # ---------------------------


### PR DESCRIPTION
## Description

`proteus update-all` crashed when run from outside the PROTEUS directory: it derived its root from the current working directory and ran `pip install -U -e .` there, so pip tried to install whatever folder the user was standing in. `install-all` carried the same dependency in quieter forms: it cloned AGNI into the working directory and invoked the SOCRATES install script by a relative path.

Both commands now resolve the source tree from the installed package location through a shared helper, so they work from any directory:

- The editable pip reinstall targets the resolved root instead of `.`
- The SOCRATES install script is invoked by its absolute path under the root
- The AGNI clone gets an explicit destination under the root
- The disk-space gate measures the filesystem the install actually writes to
- The default `--config-path` for the data download is anchored to the root; an explicitly passed relative path still resolves against the working directory
- A wheel install run from inside a checkout falls back to using that checkout; with no checkout reachable at all, the commands exit with a clear message instead of a pip traceback

Closes https://github.com/FormingWorlds/PROTEUS/issues/693 (the command now works from any directory).

## Validation of changes

- Reproduced the reported failure on the unmodified code from a foreign working directory (the editable pip target resolves to `.`) and verified the fixed code targets the source tree instead
- 11 existing `install-all` / `update-all` tests updated to pin the resolved root explicitly; 8 new tests cover the run-from-anywhere contract (pip target, script path, clone destination, disk gate, config anchoring, output directory) and the failure and fallback paths of the root resolution
- Full unit suite passes locally: 2362 passed, 7 skipped
- `bash tools/validate_test_structure.sh` and `python tools/check_test_quality.py --check` pass; ruff check and format clean

Test configuration: macOS (Apple Silicon) with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

