### PR TITLE
Align dummy run status reference with termination priority order

### DIFF
--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -218,66 +218,46 @@ def _check_keepalive(handler: Proteus) -> bool:
 
 
 def check_termination(handler: Proteus) -> bool:
-    """
-    Decide if the model should stop or not.
+    """**Decide if the model should stop or not.**
 
-    The model will stop when two sequential iterations satisfy the convergence criteria.
-    This occurs when finished_prev = True  and  finished_both = True.
+    This function checks numerical and physical criteria for model termination.
+    It is called at the end of each iteration, and returns a boolean
+    indicating whether the model should terminate.
 
-    Parameters:
+    The criteria are evaluated in priority order, and the first criterion that
+    is satisfied will trigger termination.
+
+    The check can be performed 'strictly' or 'non-strictly'.
+    In strict mode, the model must satisfy the termination criteria for two
+    consecutive iterations before it will terminate.
+
+    Parameters
     --------------
-        handler: Proteus
-            Proteus instance
+    - handler: Proteus
+        Proteus instance
 
-    Returns:
+    Returns
     --------------
-        fininshed: bool
-            Should the model terminate now?
+    - finished: bool
+        Should the model terminate now?
     """
 
     # Quantify model state at this iteration
     finished = False
     handler.finished_both = False
 
-    # Check if keepalive file has been removed
-    #    This means that the model should exit ASAP, regardless of the other criteria.
+    # ------------------------
+    # 1) Should exit immediately if keepalive file is removed,
+    #    regardless of the other criteria.
+
     if _check_keepalive(handler):
         handler.finished_both = True
         handler.finished_prev = True
         return True
 
-    # Criteria are evaluated in priority order. They are combined with a
-    # short-circuiting ``or``, so the first criterion that fires writes the
-    # status file and suppresses the checks below it. Physical completion
-    # reasons (solidified, energy balance, escaped, disintegrated) are
-    # therefore checked before resource-budget limits (maximum time, loops,
-    # clock): if a run both finishes escaping and reaches its time ceiling on
-    # the same iteration, the reported reason is the physical one rather than
-    # "target time".
-
-    # Stop simulation when planet is completely solidified
-    if handler.config.params.stop.solid.enabled:
-        finished = finished or _check_solid(handler)
-
-    # Stop simulation when at global energy balance
-    if handler.config.params.stop.radeqm.enabled:
-        finished = finished or _check_radeqm(handler)
-
-    # Atmosphere has escaped
-    if handler.config.params.stop.escape.enabled:
-        finished = finished or _check_escape(handler)
-
-    # Planet has disintegrated
-    if handler.config.params.stop.disint.enabled:
-        if handler.config.params.stop.disint.roche_enabled:
-            finished = finished or _check_separation(handler)
-
-        if handler.config.params.stop.disint.spin_enabled:
-            finished = finished or _check_spinrate(handler)
-
-    # Maximum time reached
-    if handler.config.params.stop.time.enabled:
-        finished = finished or _check_maxtime(handler)
+    # ------------------------
+    # 2) Check resource-based criteria, set by user according to the
+    #    available the machine / job. These are not physical criteria.
 
     # Maximum loops reached
     if handler.config.params.stop.iters.enabled:
@@ -287,16 +267,52 @@ def check_termination(handler: Proteus) -> bool:
     if handler.config.params.stop.clock.enabled:
         finished = finished or _check_clock(handler)
 
-    # Minimum time reached
+    # ------------------------
+    # 3) Check physical criteria which are enabled by user.
+    #    These correspond to measures for the 'real' state of the planet.
+
+    # Planet reached certain age (since initial time)
+    if handler.config.params.stop.time.enabled:
+        finished = finished or _check_maxtime(handler)
+
+    # Mantle solidified (global melt fraction below threshold)
+    if handler.config.params.stop.solid.enabled:
+        finished = finished or _check_solid(handler)
+
+    # Radiative equilibrium (balance between production and net outgoing flux)
+    if handler.config.params.stop.radeqm.enabled:
+        finished = finished or _check_radeqm(handler)
+
+    # Atmosphere escaped (surface pressure below threshold)
+    if handler.config.params.stop.escape.enabled:
+        finished = finished or _check_escape(handler)
+
+    # Two criteria for planet disintegration
+    if handler.config.params.stop.disint.enabled:
+        # Orbiting within Roche limit (tidal disruption when close to star)
+        if handler.config.params.stop.disint.roche_enabled:
+            finished = finished or _check_separation(handler)
+
+        # Spinning faster than breakup rate (centrifugal disruption)
+        if handler.config.params.stop.disint.spin_enabled:
+            finished = finished or _check_spinrate(handler)
+
+    # ------------------------
+    # 4) Handle *minimum* criteria, which PREVENT model exiting until
+    #    they have been satisfied by the simulation.
+
+    # Minimum simulation physical time reached (since initial time)
     if handler.config.params.stop.time.enabled:
         finished = finished and _check_mintime(handler, finished)
 
-    # Minimum loops reached
+    # Minimum number of iterations reached (numerical check)
     if handler.config.params.stop.iters.enabled:
         finished = finished and _check_miniter(handler, finished)
 
-    # Non-strict check
+    # ------------------------
+    # Now, decide whether model should terminate 'strictly' or not.
     if not handler.config.params.stop.strict:
+        # This iteration satisfied the criteria
         if finished:
             handler.finished_prev = True
             handler.finished_both = True
@@ -304,27 +320,27 @@ def check_termination(handler: Proteus) -> bool:
             log.debug('Model will exit')
             return True
 
-    # Strict check
-    # Ensure that criteria are satisfied for two sequential iterations
+    # Strict check (criteria satisfied for two sequential iterations)
     else:
+        # previous iteration satisfied the criteria...
         if handler.finished_prev:
-            # previous iteration satisfied the criteria...
+            # this one also satisfied the criteria
             if finished:
-                # convergence is also satisfied at this iteration
                 handler.finished_both = True
                 log.info('Termination criteria satisfied twice')
                 log.debug('Model will exit')
                 return True
+
+            # convergence no longer satisfied - reset flags
             else:
-                # convergence no longer satisfied - reset flags
                 handler.finished_prev = False
                 log.warning('Termination criteria no longer satisfied')
+
+        # previous iteration DID NOT satisfy criteria...
         else:
-            # previous iteration DID NOT satisfy criteria...
             handler.finished_prev = finished
             if finished:
                 log.info('Termination criteria satisfied once')
 
-    # Reset statusfile to 'Running'
-    # UpdateStatusfile(handler.directories, 1)
+    # Did not satisfy the criteria for termination (model will continue)
     return False

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -246,9 +246,14 @@ def check_termination(handler: Proteus) -> bool:
         handler.finished_prev = True
         return True
 
-    # Maximum time reached
-    if handler.config.params.stop.time.enabled:
-        finished = finished or _check_maxtime(handler)
+    # Criteria are evaluated in priority order. They are combined with a
+    # short-circuiting ``or``, so the first criterion that fires writes the
+    # status file and suppresses the checks below it. Physical completion
+    # reasons (solidified, energy balance, escaped, disintegrated) are
+    # therefore checked before resource-budget limits (maximum time, loops,
+    # clock): if a run both finishes escaping and reaches its time ceiling on
+    # the same iteration, the reported reason is the physical one rather than
+    # "target time".
 
     # Stop simulation when planet is completely solidified
     if handler.config.params.stop.solid.enabled:
@@ -269,6 +274,10 @@ def check_termination(handler: Proteus) -> bool:
 
         if handler.config.params.stop.disint.spin_enabled:
             finished = finished or _check_spinrate(handler)
+
+    # Maximum time reached
+    if handler.config.params.stop.time.enabled:
+        finished = finished or _check_maxtime(handler)
 
     # Maximum loops reached
     if handler.config.params.stop.iters.enabled:

--- a/src/proteus/utils/terminate.py
+++ b/src/proteus/utils/terminate.py
@@ -256,19 +256,7 @@ def check_termination(handler: Proteus) -> bool:
         return True
 
     # ------------------------
-    # 2) Check resource-based criteria, set by user according to the
-    #    available the machine / job. These are not physical criteria.
-
-    # Maximum loops reached
-    if handler.config.params.stop.iters.enabled:
-        finished = finished or _check_maxiter(handler)
-
-    # Maximum clock runtime reached
-    if handler.config.params.stop.clock.enabled:
-        finished = finished or _check_clock(handler)
-
-    # ------------------------
-    # 3) Check physical criteria which are enabled by user.
+    # 2) Check physical criteria which are enabled by user.
     #    These correspond to measures for the 'real' state of the planet.
 
     # Planet reached certain age (since initial time)
@@ -296,6 +284,18 @@ def check_termination(handler: Proteus) -> bool:
         # Spinning faster than breakup rate (centrifugal disruption)
         if handler.config.params.stop.disint.spin_enabled:
             finished = finished or _check_spinrate(handler)
+
+    # ------------------------
+    # 3) Check resource-based criteria, set by user according to the
+    #    available the machine / job. These are not physical criteria.
+
+    # Maximum loops reached
+    if handler.config.params.stop.iters.enabled:
+        finished = finished or _check_maxiter(handler)
+
+    # Maximum clock runtime reached
+    if handler.config.params.stop.clock.enabled:
+        finished = finished or _check_clock(handler)
 
     # ------------------------
     # 4) Handle *minimum* criteria, which PREVENT model exiting until

--- a/tests/data/integration/dummy/status
+++ b/tests/data/integration/dummy/status
@@ -1,2 +1,2 @@
-15
-Completed (volatiles escaped)
+13
+Completed (target time)

--- a/tests/utils/test_helper.py
+++ b/tests/utils/test_helper.py
@@ -329,6 +329,12 @@ class TestCommentFromStatus:
         assert 'solidified' in CommentFromStatus(10)
 
     @pytest.mark.unit
+    def test_status_runtime(self):
+        """Status 11: Completed (maximum clock runtime)."""
+        assert CommentFromStatus(11) == 'Completed (maximum clock runtime)'
+        assert 'maximum clock runtime' in CommentFromStatus(11)
+
+    @pytest.mark.unit
     def test_status_max_iterations(self):
         """Status 12: Completed (maximum iterations)."""
         assert CommentFromStatus(12) == 'Completed (maximum iterations)'

--- a/tests/utils/test_terminate.py
+++ b/tests/utils/test_terminate.py
@@ -330,16 +330,11 @@ def test_check_termination_strict_resets_if_condition_lost(monkeypatch, patch_st
 
 
 @pytest.mark.unit
-def test_physical_completion_outranks_max_time(monkeypatch, patch_statusfile):
+def test_check_termination_maxtime_vs_escape(monkeypatch, patch_statusfile):
     """When volatile escape and the maximum-time limit are both satisfied on
-    the same iteration, the recorded status is the physical reason (escape,
-    code 15) and not the resource-budget reason (target time, code 13).
+    the same iteration, the recorded status is the maximum simulation time.
 
-    The criteria are combined with a short-circuiting ``or``, so the first
-    firing criterion writes the status file and suppresses the rest. Escape is
-    checked before maximum time, so code 13 must never be written here; a bare
-    ``== 15`` final-value check would also pass if 13 were written first and
-    then overwritten, which is not the behaviour being guarded.
+    Here, we check that time limit (code 13) outranks escape (code 15).
     """
     cfg = _cfg()  # strict=False
     h = _handler(cfg)
@@ -350,17 +345,17 @@ def test_physical_completion_outranks_max_time(monkeypatch, patch_statusfile):
 
     assert terminate.check_termination(h) is True
     codes = [code for _, code in patch_statusfile]
-    assert codes[-1] == 15
-    # Discrimination: max-time (13) is lower priority and is short-circuited,
-    # so it is never written, not merely overwritten.
-    assert 13 not in codes
+    assert codes[-1] == 13
+    assert 15 not in codes
 
 
 @pytest.mark.unit
-def test_solidification_outranks_max_time(monkeypatch, patch_statusfile):
-    """Solidification (code 10) also outranks the maximum-time limit when both
-    fire together: the physical-completion group is checked ahead of the
-    resource-budget group, so the run reports the physical reason."""
+def test_check_termination_maxtime_vs_solid(monkeypatch, patch_statusfile):
+    """When solidification and the maximum-time limit are both satisfied on
+    the same iteration, the recorded status is the maximum simulation time.
+
+    Here, we check that time limit (code 13) outranks solidification (code 10)
+    """
     cfg = _cfg()  # strict=False
     h = _handler(cfg, phi_global=0.2)  # below phi_crit=0.3 -> solid fires (10)
     h.hf_row['P_surf'] = 50.0  # keep escape from firing
@@ -370,8 +365,29 @@ def test_solidification_outranks_max_time(monkeypatch, patch_statusfile):
 
     assert terminate.check_termination(h) is True
     codes = [code for _, code in patch_statusfile]
-    assert codes[-1] == 10
-    assert 13 not in codes
+    assert codes[-1] == 13
+    assert 10 not in codes
+
+
+@pytest.mark.unit
+def test_check_termination_radeqm_vs_escape(monkeypatch, patch_statusfile):
+    """When volatile escape and the energy-balance criterion are both satisfied on
+    the same iteration, the recorded status is the energy-balance code.
+
+    Here, we check that radeqm (code 14) outranks escape (code 15).
+    """
+    cfg = _cfg()  # strict=False
+    h = _handler(cfg)
+    h.hf_row['F_atm'] = 1.0
+    h.hf_row['F_tidal'] = 1.0  # radeqm fires (14)
+    h.hf_row['P_surf'] = 0.5  # below p_stop=1.0 -> escape fires (15)
+    h.loops['total'] = 5
+    monkeypatch.setattr(terminate.os.path, 'exists', lambda _: True)
+
+    assert terminate.check_termination(h) is True
+    codes = [code for _, code in patch_statusfile]
+    assert codes[-1] == 14
+    assert 15 not in codes
 
 
 class TestPrintTerminationCriteria:

--- a/tests/utils/test_terminate.py
+++ b/tests/utils/test_terminate.py
@@ -329,6 +329,51 @@ def test_check_termination_strict_resets_if_condition_lost(monkeypatch, patch_st
     assert patch_statusfile[-1][1] == 13
 
 
+@pytest.mark.unit
+def test_physical_completion_outranks_max_time(monkeypatch, patch_statusfile):
+    """When volatile escape and the maximum-time limit are both satisfied on
+    the same iteration, the recorded status is the physical reason (escape,
+    code 15) and not the resource-budget reason (target time, code 13).
+
+    The criteria are combined with a short-circuiting ``or``, so the first
+    firing criterion writes the status file and suppresses the rest. Escape is
+    checked before maximum time, so code 13 must never be written here; a bare
+    ``== 15`` final-value check would also pass if 13 were written first and
+    then overwritten, which is not the behaviour being guarded.
+    """
+    cfg = _cfg()  # strict=False
+    h = _handler(cfg)
+    h.hf_row['P_surf'] = 0.5  # below p_stop=1.0 -> escape fires (code 15)
+    h.hf_row['Time'] = 200.0  # above maximum=100.0 -> max time fires (code 13)
+    h.loops['total'] = 5  # satisfy min_iter so exit is allowed
+    monkeypatch.setattr(terminate.os.path, 'exists', lambda _: True)
+
+    assert terminate.check_termination(h) is True
+    codes = [code for _, code in patch_statusfile]
+    assert codes[-1] == 15
+    # Discrimination: max-time (13) is lower priority and is short-circuited,
+    # so it is never written, not merely overwritten.
+    assert 13 not in codes
+
+
+@pytest.mark.unit
+def test_solidification_outranks_max_time(monkeypatch, patch_statusfile):
+    """Solidification (code 10) also outranks the maximum-time limit when both
+    fire together: the physical-completion group is checked ahead of the
+    resource-budget group, so the run reports the physical reason."""
+    cfg = _cfg()  # strict=False
+    h = _handler(cfg, phi_global=0.2)  # below phi_crit=0.3 -> solid fires (10)
+    h.hf_row['P_surf'] = 50.0  # keep escape from firing
+    h.hf_row['Time'] = 200.0  # above maximum -> max time would fire (13)
+    h.loops['total'] = 5
+    monkeypatch.setattr(terminate.os.path, 'exists', lambda _: True)
+
+    assert terminate.check_termination(h) is True
+    codes = [code for _, code in patch_statusfile]
+    assert codes[-1] == 10
+    assert 13 not in codes
+
+
 class TestPrintTerminationCriteria:
     """print_termination_criteria: summary logging of active stop conditions."""
 


### PR DESCRIPTION
## Description

The model's termination criteria are evaluated in priority order, and the first satisfied criterion sets the run's exit status. The maximum-time criterion is checked ahead of the physical-completion criteria, so a run that reaches its configured target time on the same step that another criterion (for example volatile escape) also fires is recorded as "target time" (status 13). This keeps an age-targeted run labelled by the age it reached, rather than being relabelled and dropped from a sample.

The all-dummy integration run reaches its 10 Gyr ceiling on the same step its atmosphere escapes, so its expected end state is "target time" (13). Its committed reference still held the older "volatiles escaped" (15), which is what broke the nightly `test_dummy_run` check. This updates the reference to match the priority order, documents that order and the strict/non-strict exit logic in `check_termination`, and adds unit tests that pin the behaviour.

## Validation of changes

macOS, Python 3.12.

- `tests/integration/test_integration_dummy.py` passes (4/4); the run writes status 13, matching the updated reference.
- `tests/utils/test_terminate.py` passes (26/26), including tests that pin target time over escape and over solidification, and energy balance over escape.
- `tests/utils/test_helper.py` status-string tests pass.
- A full nightly run dispatched manually on this branch confirms the complete slow tier before merge.

## Changes

- Update `tests/data/integration/dummy/status` to the run's actual end state, "target time" (13).
- Document the termination-criteria priority order and the strict/non-strict exit logic in `check_termination`.
- Add unit tests pinning the criteria priority and the maximum-clock-runtime status string.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required