### PR TITLE
Publish live test-count badges from a workflow

### DIFF
--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -1,0 +1,199 @@
+name: Refresh test count badges
+
+# Regenerates the shields.io endpoint-badge JSON (tests-total, tests-unit,
+# tests-integration) from a full test collection and publishes it to the
+# dedicated ``badges`` branch. The testing page renders these as shields.io
+# endpoint badges, reading the JSON from this branch's raw URL. An accurate
+# count needs a complete install: a test module that importorskips a missing
+# optional dependency is dropped at collection, so this job builds the same
+# environment CI uses (setup-proteus) before running the generator, then
+# refuses to publish a count that falls below the full-suite floor.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/proteus/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'tools/generate_test_badges.py'
+      - '.github/actions/setup-proteus/**'
+      - '.github/workflows/publish-test-badges.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: badges-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -el {0}
+
+jobs:
+  refresh-badges:
+    name: Regenerate tests-*.json
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Guard against publishing from a non-main ref
+        # The push trigger is already main-only, but workflow_dispatch can
+        # be launched from any branch. Publishing another ref's test count
+        # to the public badge would be misleading, so refuse it loudly.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Badges may only be published from main; this run is on ${{ github.ref }}." >&2
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up PROTEUS environment
+        # The full install makes every optional submodule import, so the
+        # collection reflects the real suite size rather than the subset
+        # that imports under a bare install. full-data stays false: the
+        # generator only collects tests, it never runs them, so the
+        # integration-tier data set is not needed.
+        uses: ./.github/actions/setup-proteus
+        with:
+          full-data: 'false'
+
+      - name: Regenerate badge JSON files
+        run: |
+          python tools/generate_test_badges.py --out badge_payload/
+
+      - name: Publish badges to the badges branch
+        # The ``main`` ruleset blocks direct pushes, so the badge JSON is
+        # published to a dedicated ``badges`` branch that lives outside
+        # that ruleset rather than committed back onto ``main``. shields.io
+        # reads the JSON from the raw URL of this branch. The branch carries
+        # only the three JSON files plus a README; consumers that need the
+        # source tree use ``main``. No push-triggered workflow watches this
+        # branch, and the commit is marked ``[skip ci]``, so a badge refresh
+        # never starts a run against the source-less tree.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          payload="${GITHUB_WORKSPACE}/badge_payload"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          branch="badges"
+
+          # Refuse to publish a partial or malformed set. Two failure modes
+          # are guarded. A generator regression that drops a file or emits
+          # invalid JSON is caught by the presence and shields-schema checks.
+          # An incomplete install is caught by the count floors: a run that
+          # misses optional submodules collects only the subset of test
+          # modules that import, so the count drops far below the real suite
+          # size. Publishing that low number behind a green check would be
+          # worse than failing, because a reader trusts the badge. The floors
+          # sit well below the full-suite size but well above a partial
+          # install, so a degraded environment fails here instead.
+          python3 - "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          floors = {'tests-total.json': 2000, 'tests-unit.json': 1800}
+          payload = Path(sys.argv[1])
+          expected = ('tests-total.json', 'tests-unit.json', 'tests-integration.json')
+          for name in expected:
+              path = payload / name
+              if not path.is_file():
+                  sys.exit(f'Missing badge file: {path}')
+              data = json.loads(path.read_text())
+              message = str(data.get('message', '')).strip()
+              if data.get('schemaVersion') != 1 or not message:
+                  sys.exit(f'Malformed badge file: {path}')
+              floor = floors.get(name)
+              if floor is not None:
+                  try:
+                      count = int(message)
+                  except ValueError:
+                      sys.exit(f'Non-integer count in {path}: {message!r}')
+                  if count < floor:
+                      sys.exit(
+                          f'{name} count {count} is below the floor {floor}; '
+                          f'the install is probably incomplete, refusing to publish.'
+                      )
+          print(f'Validated {len(expected)} badge files.')
+          PY
+
+          # Each fallible step returns explicitly: the function is invoked
+          # from a conditional, which disables ``set -e`` inside it, so a
+          # failure must be propagated by hand rather than relied on to
+          # abort. Returns 0 on a successful push or a no-op, 1 on a
+          # retryable failure.
+          attempt_publish() {
+            local work exists rc
+
+            # Tell "branch absent" (ls-remote exit 2) apart from an
+            # unreachable remote (network/auth, other non-zero), so a
+            # transient failure is retried instead of being mistaken for
+            # an empty branch and overwritten with a root commit.
+            if git ls-remote --exit-code --heads "${remote}" "${branch}" >/dev/null 2>&1; then
+              exists=1
+            else
+              rc=$?
+              if [ "${rc}" -eq 2 ]; then
+                exists=0
+              else
+                echo "Could not reach the remote to check ${branch} (rc=${rc})." >&2
+                return 1
+              fi
+            fi
+
+            work="$(mktemp -d)" || return 1
+            cd "${work}" || return 1
+            git init -q || return 1
+
+            if [ "${exists}" -eq 1 ]; then
+              git fetch -q "${remote}" "${branch}" || return 1
+              git checkout -q FETCH_HEAD || return 1
+              # Drop everything the branch carried so the new commit holds
+              # only the freshly generated files; a stale leftover would
+              # otherwise survive the checkout-and-overwrite.
+              git rm -rfq --ignore-unmatch . >/dev/null 2>&1 || return 1
+            fi
+
+            cp "${payload}"/tests-*.json . || return 1
+            printf '%s\n' \
+              '# Test count badges' \
+              '' \
+              'Machine-generated by the `Refresh test count badges` workflow that runs on `main`.' \
+              'The testing page renders these JSON files as shields.io endpoint badges.' \
+              'Do not edit or delete this branch by hand; the source lives on `main`.' \
+              > README.md || return 1
+            git add tests-*.json README.md || return 1
+
+            if [ "${exists}" -eq 1 ] && git diff --cached --quiet; then
+              echo "Badge counts unchanged; nothing to publish."
+              return 0
+            fi
+
+            git -c user.name="actions" -c user.email="actions@github.com" \
+              commit -qm "Update test count badges [skip ci]" || return 1
+            git push -q "${remote}" "HEAD:refs/heads/${branch}" || return 1
+            echo "Published refreshed badges to the ${branch} branch."
+            return 0
+          }
+
+          # The concurrency group serialises runs on ``main``, so a competing
+          # run cannot move the branch tip mid-push; the retry only covers a
+          # transient network or fetch hiccup. Each attempt re-checks the
+          # branch state from a clean working tree.
+          for attempt in 1 2 3; do
+            if attempt_publish; then
+              exit 0
+            fi
+            echo "Publish attempt ${attempt} failed; retrying."
+            sleep 2
+          done
+          echo "Failed to publish badges after 3 attempts." >&2
+          exit 1

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -1,6 +1,6 @@
 # Test framework
 
-[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/PROTEUS/main?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/PROTEUS){target="_blank" rel="noopener"}
+[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/PROTEUS?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/PROTEUS){target="_blank" rel="noopener"}
 [![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-pr-checks.yml?label=Unit%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-pr-checks.yml){target="_blank" rel="noopener"}
 [![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-nightly.yml?branch=main&label=Integration%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-nightly.yml){target="_blank" rel="noopener"}
 [![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-total.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -1,5 +1,8 @@
 # Test framework
 
+[![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/PROTEUS/main?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/PROTEUS){target="_blank" rel="noopener"}
+[![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-pr-checks.yml?label=Unit%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-pr-checks.yml){target="_blank" rel="noopener"}
+[![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-nightly.yml?branch=main&label=Integration%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-nightly.yml){target="_blank" rel="noopener"}
 [![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-total.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
 [![unit tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-unit.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
 [![integration tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-integration.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
@@ -41,7 +44,7 @@ validate against published benchmarks and cross-implementation checks (e.g.
 SPIDER vs Aragog for the same initial conditions). These are the most
 expensive tests and run only in the nightly CI.
 
-The badges at the top of this page report how many tests the suite collects in each category: the total, the unit tier, and the combined smoke, integration, and slow tiers. The documentation deploy counts the tests from `pytest --collect-only` and writes the badges as static SVGs into the published site under `badges/`, so they refresh on every documentation build and load without a third-party request.
+The badge row at the top of this page carries three kinds of badge. The coverage badge reports the line coverage that codecov records for the main branch. The two status badges report the outcome of the latest pull-request checks and the latest nightly run. The three count badges report how many tests the suite collects in each category: the total, the unit tier, and the combined smoke, integration, and slow tiers. The counts come from `pytest --collect-only`, so they track the real suite as it grows.
 
 ## Functional tests vs physics tests
 

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -1,8 +1,10 @@
 # Test framework
 
-[![tests](../badges/tests-total.svg)](../How-to/testing.md){target="_blank" rel="noopener"}
-[![unit tests](../badges/tests-unit.svg)](../How-to/testing.md){target="_blank" rel="noopener"}
-[![integration tests](../badges/tests-integration.svg)](../How-to/testing.md){target="_blank" rel="noopener"}
+[![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-total.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
+[![unit tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-unit.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
+[![integration tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-integration.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
+
+These counts refresh automatically: the `Refresh test count badges` workflow regenerates the JSON on the `badges` branch on every push to `main`, and shields.io reads it live.
 
 PROTEUS is scientific simulation software where incorrect results can
 propagate silently through coupled modules. The testing framework is


### PR DESCRIPTION
## Description

This adds a workflow that keeps the test-count badges live instead of hand-maintained. PROTEUS renders static badge SVGs into the docs at build time, and the testing page carries fixed numbers that drift out of date (it has been showing ~1007 while `main` actually collects ~2766). The new workflow regenerates the shields.io endpoint JSON (`tests`, `unit tests`, `integration tests`) from a full test collection on every push to `main` and publishes it, so the testing page can point at a live count.

`main` is protected by the branch ruleset, so the workflow cannot commit the JSON back onto `main`. It publishes the three files plus a short README to the root of a dedicated unprotected `badges` branch, and the testing page reads them from that branch's raw URL. This matches the pattern already used for the protected-main repos in the ecosystem.

Getting the count right needs a complete install: a test module that `importorskip`s a missing optional dependency is dropped at collection, so a bare install undercounts badly (~1007 instead of ~2766). The workflow reuses the same `setup-proteus` environment CI uses so every optional submodule imports, and it refuses to publish any count that falls below a full-suite floor, so an incomplete install fails loudly rather than shipping a misleading low number.

The badge generator (`tools/generate_test_badges.py`) already exists and is unchanged; this PR only adds the publish workflow.

## Validation of changes

Ran the generator in a full local environment and confirmed the collected counts: total 2766, unit 2517, integration 260, all far above the ~1007 bare-install undercount. Confirmed that every collection-gating optional dependency (torch, botorch, juliacall, jax, atmodeller, vulcan, and the fwl-* submodules) is a core dependency that `setup-proteus` installs, so the CI collection reflects the whole suite.

Exercised the publish step's git logic against a throwaway local bare remote: it creates the `badges` branch on first run, is a no-op when the counts are unchanged, and overwrites cleanly when a count changes, leaving only the three JSON files and the README on the branch.

Unit-tested the count-floor guard: it passes the real counts (2766/2517/260), and fails a bare-install undercount (1007), a catastrophic zero, and a degraded unit-only count.

Tested on macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
