### PR TITLE
Run the badge workflow steps in a non-login shell

### DIFF
--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -31,7 +31,13 @@ concurrency:
 
 defaults:
   run:
-    shell: bash -el {0}
+    # Use a non-login shell by default. A login shell runs its logout
+    # profile on exit, which on Ubuntu calls clear_console; on a runner with
+    # no console that returns non-zero and overrides the step's exit status,
+    # so any step that ends with an explicit exit reports failure even when
+    # it succeeded. Only the generator step needs the conda environment, and
+    # it opts back into the login shell explicitly.
+    shell: bash
 
 jobs:
   refresh-badges:
@@ -64,6 +70,9 @@ jobs:
           full-data: 'false'
 
       - name: Regenerate badge JSON files
+        # The generator imports proteus and every optional submodule, so it
+        # needs the conda environment that the login shell activates.
+        shell: bash -el {0}
         run: |
           python tools/generate_test_badges.py --out badge_payload/
 


### PR DESCRIPTION
## Description

Fix the test-count badge workflow, which failed on its first push to main even though every step did the right thing. The publish step ran in the job's default login shell, whose `~/.bash_logout` calls `clear_console` on exit; on a console-less runner that returns non-zero and, as the last command before the shell exits, overrode the step's own `exit 0` into `exit 1`. The job now defaults to a non-login `shell: bash` so the logout profile never runs; only the generator step keeps the login shell, because it needs conda to import proteus. The floor guard is unchanged.

## Validation of changes

- Reproduced the exit-code corruption with an xtrace run, then confirmed the fix: with the non-login default the regenerate and publish steps complete and exit correctly, the generator collects the full suite (2766 total, 2517 unit, 260 integration), and the badges-branch endpoints return 200.
- The non-main guard remains authoritative: a dispatch from a non-main ref is correctly refused, so the badge can only be published from main.

Test configuration: ubuntu-latest, Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
