### PR TITLE
Retry nightly artifact uploads on transient network resets

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -87,7 +87,17 @@ jobs:
             --cov-fail-under=0 \
             -v --tb=short
       - name: Upload unit + smoke artifacts
+        id: upload-unit
         if: always()
+        # These artifacts carry this tier's coverage data and test results.
+        # The Linux run is combined into the canonical nightly-coverage
+        # report that PR runs union against, so a transient artifact-service
+        # reset is retried once before the shard is left out rather than
+        # dropped on the first blip. The retry sets overwrite so a
+        # half-registered first attempt does not block it. If both attempts
+        # fail the tier stays green (its tests passed) and coverage-aggregate
+        # degrades to the tolerated missing-shard path.
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: tier-unit-${{ matrix.os }}
@@ -99,6 +109,22 @@ jobs:
             junit-smoke-${{ matrix.os }}.xml
           if-no-files-found: ignore
           include-hidden-files: true
+          retention-days: 14
+      - name: Retry unit + smoke artifact upload
+        if: always() && steps.upload-unit.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: tier-unit-${{ matrix.os }}
+          path: |
+            .coverage.unit.${{ matrix.os }}
+            coverage-unit-${{ matrix.os }}.xml
+            coverage-smoke-${{ matrix.os }}.xml
+            junit-unit-${{ matrix.os }}.xml
+            junit-smoke-${{ matrix.os }}.xml
+          if-no-files-found: ignore
+          include-hidden-files: true
+          overwrite: true
           retention-days: 14
 
   # ============================================================
@@ -137,7 +163,11 @@ jobs:
             --cov-fail-under=0 \
             -v --tb=short
       - name: Upload integration artifacts
+        id: upload-int
         if: always()
+        # See the unit tier upload: retry a transient reset once, then
+        # tolerate a dropped shard rather than reddening a passing tier.
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: tier-int-${{ matrix.os }}
@@ -147,6 +177,20 @@ jobs:
             junit-int-${{ matrix.os }}.xml
           if-no-files-found: ignore
           include-hidden-files: true
+          retention-days: 14
+      - name: Retry integration artifact upload
+        if: always() && steps.upload-int.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: tier-int-${{ matrix.os }}
+          path: |
+            .coverage.integration.${{ matrix.os }}
+            coverage-int-${{ matrix.os }}.xml
+            junit-int-${{ matrix.os }}.xml
+          if-no-files-found: ignore
+          include-hidden-files: true
+          overwrite: true
           retention-days: 14
 
   # ============================================================
@@ -261,7 +305,13 @@ jobs:
             --log-cli-format='%(asctime)s %(levelname)s %(name)s: %(message)s' \
             -v --tb=short
       - name: Upload slow shard artifacts
+        id: upload-slow
         if: always()
+        # See the unit tier upload. On Linux this shard is the only source
+        # for lines no faster tier reaches, so losing it understates the
+        # nightly coverage the PR runs union against. Retry a transient
+        # reset once before tolerating a dropped shard.
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: tier-slow-${{ matrix.shard }}-${{ matrix.os }}
@@ -271,6 +321,20 @@ jobs:
             junit-slow-${{ matrix.shard }}-${{ matrix.os }}.xml
           if-no-files-found: ignore
           include-hidden-files: true
+          retention-days: 14
+      - name: Retry slow shard artifact upload
+        if: always() && steps.upload-slow.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: tier-slow-${{ matrix.shard }}-${{ matrix.os }}
+          path: |
+            .coverage.slow.${{ matrix.shard }}.${{ matrix.os }}
+            coverage-slow-${{ matrix.shard }}-${{ matrix.os }}.xml
+            junit-slow-${{ matrix.shard }}-${{ matrix.os }}.xml
+          if-no-files-found: ignore
+          include-hidden-files: true
+          overwrite: true
           retention-days: 14
 
   # ============================================================
@@ -470,7 +534,15 @@ jobs:
           flags: nightly
           name: nightly-full-suite
       - name: Upload nightly-coverage artifact
+        id: upload-nightly-cov
         if: always()
+        # This is the canonical artifact the PR runs download for the
+        # estimated-total and diff-cover gates. Retry a transient reset
+        # once so a network blip does not red the aggregate on passing
+        # science. If both attempts fail the PR side already tolerates a
+        # missing nightly artifact and falls back to the unit-only
+        # estimate, so tolerate rather than red.
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: nightly-coverage
@@ -481,6 +553,21 @@ jobs:
             coverage-integration-only.json
             nightly-timestamp.txt
           if-no-files-found: ignore
+          retention-days: 30
+      - name: Retry nightly-coverage upload
+        if: always() && steps.upload-nightly-cov.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-coverage
+          path: |
+            coverage.xml
+            coverage-branch-nightly.json
+            coverage-by-type.json
+            coverage-integration-only.json
+            nightly-timestamp.txt
+          if-no-files-found: ignore
+          overwrite: true
           retention-days: 30
 
   # ============================================================


### PR DESCRIPTION
## Description

The nightly workflow's diagnostic artifact uploads can fail the whole tier job when GitHub's artifact service drops the connection mid-upload, even though the tests themselves passed. A recent nightly went red only because the slow-tier macOS upload hit `Failed to FinalizeArtifact: Unable to make request: ECONNRESET` after a fully green test run; the ubuntu twin passed. This adds a single retry to each coverage-artifact upload so a transient network reset no longer reds a passing science run.

I use a retry rather than a bare `continue-on-error` on the first attempt. The PR coverage jobs download the nightly artifacts filtered on `workflow_conclusion: success`, so simply swallowing the failure would turn a red nightly into a green one that silently carries partial coverage, which the PR runs would then trust. Retrying first preserves the artifact in the normal case and only degrades to a tolerated missing shard if both attempts fail. The retry sets `overwrite: true` so a half-registered first attempt does not block it.

The change covers the four upload steps whose artifacts feed the coverage aggregate: the unit+smoke tier, the integration tier, the slow shards, and the canonical `nightly-coverage` artifact that PR runs union against. The Codecov upload is left untouched since it is non-blocking by default. If both upload attempts fail, the tier stays green (its tests passed) and `coverage-aggregate`, which already runs `if: always()`, degrades to its existing missing-shard path.

## Validation of changes

There is no GitHub issue for this; it is a transient infrastructure failure surfaced by the nightly run on main.

The network reset cannot be reproduced locally, so validation is by inspection and reasoning: the retry keys (`id`, `continue-on-error`, the `steps.<id>.outcome == 'failure'` guard, `overwrite: true`) are placed on the individual steps, the workflow parses, and the science steps are untouched. In the failure case the tier now retries once and, if that also fails, leaves out one shard rather than reddening a run whose tests passed, which is a state `coverage-aggregate` already tolerates. The PR-side union logic and the coverage gates are unchanged.

Test configuration: workflow-only change, no source or test files touched.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
