### PR TITLE
Raise the janus-aragog slow-tier test timeout to 9000 s

### DIFF
--- a/tests/integration/test_slow_janus_aragog.py
+++ b/tests/integration/test_slow_janus_aragog.py
@@ -34,10 +34,11 @@ Invariants asserted:
   Phi_global (|dPhi| < 0.5).
 - Cross-cutting mass + stability helpers.
 
-Runtime budget: ~3-5 min macOS GHA (SOCRATES init + JANUS Python
-per-step solve is light), ~5-10 min Linux GHA (CVode setup tax on
-Aragog dominates JANUS-side cost). The 3600 s timeout sits well
-inside the slow-tier 120 min step cap.
+Runtime budget: this test runs only on Linux (skipped on macOS;
+see the ``skipif`` below), where the coupled two-step JANUS +
+Aragog solve takes ~90-110 min, dominated by the CVode setup tax
+on the Aragog interior. The 9000 s per-test timeout sits inside
+the slow-tier job cap with headroom for runner variance.
 
 See also:
 - docs/How-to/test_infrastructure.md
@@ -69,7 +70,7 @@ from tests.integration.conftest import (
 # but parr is not consistently prepended).
 pytestmark = [
     pytest.mark.slow,
-    pytest.mark.timeout(7200),
+    pytest.mark.timeout(9000),
     pytest.mark.skipif(
         sys.platform == 'darwin',
         reason='cpl_chem_atmosphere plot xarr/parr length mismatch on macOS JANUS; Linux covers JANUS path',


### PR DESCRIPTION
## Description

Raises the per-test timeout on the janus-aragog slow-tier integration test (`tests/integration/test_slow_janus_aragog.py::test_janus_aragog_two_timesteps`) from 7200 s to 9000 s, and refreshes the module docstring to match the test's real runtime.

The coupled two-step JANUS + Aragog run takes about 90-110 min on Linux (it is skipped on macOS), and its timeout was sitting only ~12% above the observed maximum. Ordinary runner-to-runner variance in the nightly slow tier pushed a single run over the 7200 s ceiling and failed the `janus-inference / ubuntu-latest` job, even though nothing about the science changed. 9000 s restores roughly 40% headroom over the worst observed run while staying inside the slow-tier job cap.

The docstring previously claimed a 3600 s timeout and a 5-10 min Linux runtime; both were stale. It now states the actual Linux-only runtime and the 9000 s ceiling.

## Validation of changes

This is a timeout-ceiling and docstring change to a nightly-only slow-tier test; it does not alter any assertion, fixture, or production code, and the file does not run in the fast PR tier.

- `pytest --collect-only tests/integration/test_slow_janus_aragog.py` collects cleanly (1 test) with the updated marker.
- `ruff check` and `ruff format --check` clean on the file.
- `bash tools/validate_test_structure.sh` passes.

Runtime evidence from the recent nightlies on main (call time for the test): 07-07 5824 s, 07-08 5330 s, 07-09 6405 s (already only ~11% under the old ceiling), 07-10 >7200 s (timed out). The ~20% night-to-night swing exceeds the old headroom, which is why the ceiling needed raising.

Tested on macOS with Python 3.12 (collection + lint + structure checks); the timed test itself runs on Linux in the nightly tier.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
