### PR TITLE
Fix main badge and coverage CI failing on a corrupted shell exit

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -369,6 +369,13 @@ runs:
       shell: bash -el {0}
       run: |
         set -euo pipefail
+        # This step runs in a login shell (needed for the conda env used by
+        # the install scripts below). On the hosted runners the login
+        # shell's logout hook (~/.bash_logout -> clear_console) fails on
+        # the console-less runner and overwrites the step's exit status,
+        # so the explicit exit 0 below arrives as exit 1. Removing the
+        # hook keeps this step's own exit status authoritative.
+        rm -f "$HOME/.bash_logout"
         branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
         case "$branch" in
           '' | main | master)

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -369,42 +369,43 @@ runs:
       shell: bash -el {0}
       run: |
         set -euo pipefail
-        # This step runs in a login shell (needed for the conda env used by
-        # the install scripts below). On the hosted runners the login
-        # shell's logout hook (~/.bash_logout -> clear_console) fails on
-        # the console-less runner and overwrites the step's exit status,
-        # so the explicit exit 0 below arrives as exit 1. Removing the
-        # hook keeps this step's own exit status authoritative.
-        rm -f "$HOME/.bash_logout"
+        # This step runs in a login shell (needed for the conda env used
+        # by the install scripts below). A login shell must never end on
+        # an explicit exit 0 here: on the hosted runners the logout hook
+        # (~/.bash_logout -> clear_console) fails on the console-less
+        # runner and overwrites an explicitly requested zero exit status,
+        # while natural end-of-script completion is unaffected. Both
+        # success arms therefore fall through to the end of the script;
+        # only genuine failures use explicit nonzero exits.
         branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
         case "$branch" in
           '' | main | master)
-            echo "On '${branch:-detached HEAD}'; keeping the released submodules (no paired branch)."
-            exit 0 ;;
+            echo "On '${branch:-detached HEAD}'; keeping the released submodules (no paired branch)." ;;
+          *)
+            # name|repo-url|install-script
+            for spec in \
+              "aragog|https://github.com/FormingWorlds/aragog.git|tools/get_aragog.sh" \
+              "Zalmoxis|https://github.com/FormingWorlds/Zalmoxis.git|tools/get_zalmoxis.sh"; do
+              name="${spec%%|*}"; rest="${spec#*|}"; url="${rest%%|*}"; script="${rest#*|}"
+              # git ls-remote --exit-code: 0 = branch present, 2 = genuinely absent,
+              # any other code = probe failure (e.g. a network blip). Only a clean
+              # "absent" keeps the PyPI release; a probe failure on a feature branch
+              # fails loudly rather than silently dropping paired-branch-only code,
+              # which would otherwise resurface as an AttributeError or a non-
+              # converging solve in the slow tests.
+              rc=0
+              git ls-remote --exit-code --heads "$url" "$branch" >/dev/null 2>&1 || rc=$?
+              if [ "$rc" -eq 0 ]; then
+                echo "$name has a matching '$branch' branch; installing it editable to shadow the PyPI release."
+                bash "$script" --force
+              elif [ "$rc" -eq 2 ]; then
+                echo "No $name branch named '$branch'; keeping the released $name (PyPI)."
+              else
+                echo "ERROR: git ls-remote failed (exit $rc) probing $name for branch '$branch'; refusing to silently keep the PyPI release." >&2
+                exit 1
+              fi
+            done ;;
         esac
-        # name|repo-url|install-script
-        for spec in \
-          "aragog|https://github.com/FormingWorlds/aragog.git|tools/get_aragog.sh" \
-          "Zalmoxis|https://github.com/FormingWorlds/Zalmoxis.git|tools/get_zalmoxis.sh"; do
-          name="${spec%%|*}"; rest="${spec#*|}"; url="${rest%%|*}"; script="${rest#*|}"
-          # git ls-remote --exit-code: 0 = branch present, 2 = genuinely absent,
-          # any other code = probe failure (e.g. a network blip). Only a clean
-          # "absent" keeps the PyPI release; a probe failure on a feature branch
-          # fails loudly rather than silently dropping paired-branch-only code,
-          # which would otherwise resurface as an AttributeError or a non-
-          # converging solve in the slow tests.
-          rc=0
-          git ls-remote --exit-code --heads "$url" "$branch" >/dev/null 2>&1 || rc=$?
-          if [ "$rc" -eq 0 ]; then
-            echo "$name has a matching '$branch' branch; installing it editable to shadow the PyPI release."
-            bash "$script" --force
-          elif [ "$rc" -eq 2 ]; then
-            echo "No $name branch named '$branch'; keeping the released $name (PyPI)."
-          else
-            echo "ERROR: git ls-remote failed (exit $rc) probing $name for branch '$branch'; refusing to silently keep the PyPI release." >&2
-            exit 1
-          fi
-        done
 
     # BOREAS is an optional dependency: users opt in via
     # tools/get_boreas.sh. CI installs it explicitly (at the ref pinned

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -367,6 +367,10 @@ jobs:
       - name: List downloaded artifacts
         run: find artifacts -type f | sort
       - name: Combine Linux .coverage files
+        # Runs in a non-login shell: the step needs no conda environment,
+        # and its empty-report branch ends on an explicit exit 0, which
+        # the login shell's logout hook corrupts on the hosted runners.
+        shell: bash
         run: |
           # Combine .coverage SQLite files from Linux runners into the
           # canonical coverage.xml. macOS .coverage files are NOT


### PR DESCRIPTION
## Description

The "Refresh test count badges" and "Main coverage baseline" workflows fail on every push to main since the super-Earth structure merge, but this is not a test or coverage regression. The setup-proteus "Install paired-branch submodules" step runs in a login shell so the submodule install scripts can see the conda environment, and on the hosted runners the login shell's logout hook (`~/.bash_logout` calling `clear_console`) fails on the console-less runner and overwrites the step's requested zero exit status. The step reached its success path and printed its keep-released-submodules message, yet was recorded as exit 1, which failed both main-only workflows. This makes the step's success paths fall through to the natural end of the script instead of an explicit `exit 0`; only genuine probe failures use an explicit nonzero exit, which the logout hook cannot mask into success. The nightly coverage-aggregate combine step carried the same latent defect and now runs in a non-login shell so its exit status is authoritative.

## Validation of changes

Reproduced the exit-status corruption locally in a login shell with the runner's logout hook, and confirmed the natural-fallthrough success path returns 0 while genuine probe failures still return nonzero. Dispatched the "Main coverage baseline" workflow on both commits and it ran green. The main-only badge and coverage workflows can only run on a push to main, so the final confirmation is the first push-to-main run after this merges. macOS and Linux, Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
