### PR TITLE
Report the main branch state in every CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 </h1>
 
 <p align="center">
-  <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-pr-checks.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-pr-checks.yml?branch=main&label=Unit%20Tests">
+  <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/coverage-baseline.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/coverage-baseline.yml?branch=main&label=Unit%20Tests">
   </a>
   <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-nightly.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-nightly.yml?branch=main&label=Integration%20Tests">

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -1,7 +1,7 @@
 # Test framework
 
 [![codecov](https://img.shields.io/codecov/c/github/FormingWorlds/PROTEUS?label=coverage&logo=codecov)](https://app.codecov.io/gh/FormingWorlds/PROTEUS){target="_blank" rel="noopener"}
-[![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-pr-checks.yml?label=Unit%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-pr-checks.yml){target="_blank" rel="noopener"}
+[![Unit Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/coverage-baseline.yml?branch=main&label=Unit%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/coverage-baseline.yml){target="_blank" rel="noopener"}
 [![Integration Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/PROTEUS/ci-nightly.yml?branch=main&label=Integration%20Tests)](https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-nightly.yml){target="_blank" rel="noopener"}
 [![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-total.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}
 [![unit tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/PROTEUS/badges/tests-unit.json)](https://proteus-framework.org/testing){target="_blank" rel="noopener"}

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ hide:
 </h1>
 
 <p align="center">
-  <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-pr-checks.yml" target="_blank" rel="noopener">
+  <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/coverage-baseline.yml" target="_blank" rel="noopener">
     <img src="badges/unit.svg" alt="Unit tests status">
   </a>
   <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/ci-nightly.yml" target="_blank" rel="noopener">

--- a/tests/test_readme_badges.py
+++ b/tests/test_readme_badges.py
@@ -41,7 +41,7 @@ EXPECTED_BADGES = [
 ]
 
 # Workflow files referenced by badge URLs
-BADGE_WORKFLOW_FILES = ['ci-pr-checks.yml', 'ci-nightly.yml', 'docs.yaml']
+BADGE_WORKFLOW_FILES = ['coverage-baseline.yml', 'ci-nightly.yml', 'docs.yaml']
 
 
 @pytest.fixture
@@ -137,7 +137,8 @@ def test_workflow_badges_reference_existing_workflows(workflow_file):
     """Workflow badge URLs must reference workflow files that actually exist.
 
     Checks that the workflow YAML files referenced in badge URLs
-    (ci-pr-checks.yml, ci-nightly.yml, docs.yaml) exist in .github/workflows/.
+    (coverage-baseline.yml, ci-nightly.yml, docs.yaml) exist in
+    .github/workflows/.
     """
     workflow_path = PROTEUS_ROOT / '.github' / 'workflows' / workflow_file
     assert workflow_path.is_file(), (

--- a/tests/tools/test_cache_badges.py
+++ b/tests/tools/test_cache_badges.py
@@ -2,8 +2,9 @@
 
 Covers the network-free logic: static shields URL escaping, the SVG-versus-HTML
 validation that decides whether a fetched body is written, the placeholder
-fallback, the run-conclusion to badge-style mapping, and the
-fetch/last-good/placeholder branch in cache_badge.
+fallback, the run-conclusion to badge-style mapping, the fetch/last-good/
+placeholder branch in cache_badge, the main-branch run query in
+_latest_conclusion, and the workflow-to-badge mapping that reports main.
 
 Testing standards: docs/How-to/test_infrastructure.md, test_categorization.md,
 test_building.md
@@ -12,6 +13,7 @@ test_building.md
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -38,6 +40,22 @@ def _load_cache_badges():
 
 
 cb = _load_cache_badges()
+
+
+class _FakeResp:
+    """Minimal context-manager stand-in for a urlopen response body."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._body
 
 
 def test_static_shields_url_escapes_dash_underscore_space():
@@ -117,3 +135,79 @@ def test_cache_badge_writes_fetched_svg(tmp_path, monkeypatch):
     result = cb.cache_badge(tmp_path, 'docs', ['http://src'], 1, 1)
     assert result == 'ok'
     assert (tmp_path / 'docs.svg').read_bytes() == b'<svg>ok</svg>'
+
+
+def test_latest_conclusion_queries_completed_main_runs(monkeypatch):
+    """Resolve the latest completed run on main and map its conclusion.
+
+    The branch=main filter is what makes the badge report main: without it a
+    transient feature-branch run would be the 'latest' and freeze the badge on
+    an unrelated result. status=completed drops the in-progress docs deploy that
+    invokes this script, whose null conclusion would render as 'no status'. An
+    empty run history yields None (no status yet, not a fabricated one); an
+    unreachable API yields the 'unknown' sentinel so the caller keeps last-good.
+    """
+    calls = {'url': None, 'attempts': 0}
+    # No real sleeps: the retry backoff would otherwise blow the unit budget.
+    monkeypatch.setattr(cb.time, 'sleep', lambda _s: None)
+
+    def make_urlopen(payload=None, raises=False):
+        def fake_urlopen(req, timeout=None):
+            calls['url'] = req.full_url
+            calls['attempts'] += 1
+            if raises:
+                raise cb.urllib.error.URLError('unreachable')
+            return _FakeResp(json.dumps(payload).encode())
+
+        return fake_urlopen
+
+    # Happy path: the newest completed run on main is a success.
+    monkeypatch.setattr(
+        cb.urllib.request,
+        'urlopen',
+        make_urlopen({'workflow_runs': [{'conclusion': 'success'}]}),
+    )
+    assert cb._latest_conclusion('coverage-baseline.yml', 1, 1) == 'success'
+    # Both filters must be present: branch scopes to main, status drops the
+    # in-progress caller run. A missing branch filter is the exact regression
+    # this pins against.
+    assert 'branch=main' in calls['url']
+    assert 'status=completed' in calls['url']
+    assert 'coverage-baseline.yml/runs' in calls['url']
+
+    # Boundary: no runs recorded yet returns None, never a made-up conclusion.
+    monkeypatch.setattr(cb.urllib.request, 'urlopen', make_urlopen({'workflow_runs': []}))
+    assert cb._latest_conclusion('coverage-baseline.yml', 1, 1) is None
+
+    # Error contract: an unreachable API returns 'unknown' after exhausting the
+    # requested retries. The attempt count discriminates a no-retry regression
+    # (1) and an off-by-one (3) from the correct 2.
+    calls['attempts'] = 0
+    monkeypatch.setattr(cb.urllib.request, 'urlopen', make_urlopen(raises=True))
+    assert cb._latest_conclusion('coverage-baseline.yml', 1, 2) == 'unknown'
+    assert calls['attempts'] == 2
+
+
+def test_status_workflows_map_unit_to_main_coverage_baseline():
+    """The unit badge resolves the workflow that runs the unit suite on main.
+
+    coverage-baseline.yml runs the unit suite on every push to main, so its run
+    conclusion reflects main's unit-test health. The pull_request-only PR-check
+    workflow never runs on main, so a badge pointed at it would never satisfy
+    the branch=main query and would freeze; this pins the mapping against that
+    regression and confirms the other two badges are unchanged.
+    """
+    mapping = {label: workflow for _name, workflow, label in cb._STATUS_WORKFLOWS}
+    assert mapping['Unit Tests'] == 'coverage-baseline.yml'
+    assert mapping['Integration Tests'] == 'ci-nightly.yml'
+    assert mapping['Docs'] == 'docs.yaml'
+    # No badge may point at the pull_request-only workflow: it never runs on
+    # main and so would never satisfy the branch=main query.
+    workflows = {workflow for _name, workflow, _label in cb._STATUS_WORKFLOWS}
+    assert 'ci-pr-checks.yml' not in workflows
+    # Badge names line up in order with the SVG files the docs pages embed.
+    assert [name for name, _wf, _label in cb._STATUS_WORKFLOWS] == [
+        'unit',
+        'integration',
+        'docs',
+    ]

--- a/tools/cache_badges.py
+++ b/tools/cache_badges.py
@@ -49,6 +49,16 @@ _REPO = 'FormingWorlds/PROTEUS'
 _BRANCH = 'main'
 _USER_AGENT = 'PROTEUS-docs-badge-cache'
 
+# Workflow-status badges as (badge name, workflow file, label). Each workflow
+# runs on main, so the branch=main query in _latest_conclusion resolves a real
+# run: coverage-baseline runs the unit suite on every push to main, ci-nightly
+# runs the integration suite on schedule, and docs runs on every push to main.
+_STATUS_WORKFLOWS: list[tuple[str, str, str]] = [
+    ('unit', 'coverage-baseline.yml', 'Unit Tests'),
+    ('integration', 'ci-nightly.yml', 'Integration Tests'),
+    ('docs', 'docs.yaml', 'Docs'),
+]
+
 # Map a GitHub Actions run conclusion to the badge message and colour. Every
 # failure-class conclusion maps to red so a broken run is never shown as a
 # neutral grey badge. A null conclusion (queued or in progress) shows no status.
@@ -76,7 +86,7 @@ def _latest_conclusion(workflow: str, timeout: float, retries: int) -> str | Non
     Parameters
     ----------
     workflow : str
-        Workflow file name, for example ``ci-pr-checks.yml``.
+        Workflow file name, for example ``coverage-baseline.yml``.
     timeout : float
         Per-request timeout in seconds.
     retries : int
@@ -89,14 +99,16 @@ def _latest_conclusion(workflow: str, timeout: float, retries: int) -> str | Non
         run has no conclusion yet, or the sentinel ``'unknown'`` if the API
         could not be reached or reported no runs.
     """
-    # Query the latest COMPLETED run of the workflow. status=completed excludes
-    # the in-progress docs deploy that is calling this (a null conclusion would
-    # otherwise render the Docs badge as "no status"). No branch filter: the
-    # PR-check workflows run on pull_request, never on main, so a branch=main
-    # filter would match only stale historical runs and freeze the badge.
+    # Query the latest COMPLETED run of the workflow on main. Every badge
+    # reports the state of main, and all three source workflows run there:
+    # coverage-baseline on push, ci-nightly on schedule, docs on push. The
+    # branch=main filter therefore always resolves a real run, and
+    # status=completed excludes the in-progress docs deploy that is calling
+    # this (a null conclusion would otherwise render the Docs badge as
+    # "no status").
     url = (
         f'https://api.github.com/repos/{_REPO}/actions/workflows/'
-        f'{workflow}/runs?status=completed&per_page=1'
+        f'{workflow}/runs?branch={_BRANCH}&status=completed&per_page=1'
     )
     headers = {'User-Agent': _USER_AGENT, 'Accept': 'application/vnd.github+json'}
     token = os.environ.get('GITHUB_TOKEN')
@@ -350,9 +362,9 @@ def main() -> int:
         return (name, [url] if url else [])
 
     status_badges: list[tuple[str, list[str]]] = [
-        status('unit', 'ci-pr-checks.yml', 'Unit Tests'),
-        status('integration', 'ci-nightly.yml', 'Integration Tests'),
-        status('docs', 'docs.yaml', 'Docs'),
+        status(name, workflow, label) for name, workflow, label in _STATUS_WORKFLOWS
+    ]
+    status_badges += [
         ('codecov', [f'https://codecov.io/gh/{_REPO}/branch/{_BRANCH}/graph/badge.svg']),
         ('license', ['https://img.shields.io/badge/License-Apache_2.0-blue.svg']),
         (


### PR DESCRIPTION
## Description

The Unit Tests CI badge disagreed between the README (green) and the docs homepage (red). It pointed at `ci-pr-checks.yml`, which runs only on pull requests and manual dispatches and never on a push to main, so the README badge sat green on sporadic dispatches while the cached docs badge baked in a transient failure from an unrelated feature-branch PR run.

This retargets the Unit Tests badge to `coverage-baseline.yml`, which runs the unit suite on every push to main, and scopes the badge cache query to completed runs on main, so every CI badge in the README and the docs reports the state of main.

No linked issue.

## Changes

- README, docs homepage, and the test-framework page: the Unit Tests badge now links to `coverage-baseline.yml` with a `branch=main` filter. Integration and Docs badges already reported main and are unchanged.
- `tools/cache_badges.py`: the run query is scoped to `branch=main`, and the unit, integration, and docs badges resolve from a single status-workflow list with the unit entry pointing at `coverage-baseline.yml`.
- Tests: `tests/tools/test_cache_badges.py` pins the main-branch run query and the unit to `coverage-baseline.yml` mapping; `tests/test_readme_badges.py` checks that `coverage-baseline.yml` (the workflow the badge now references) exists.

## Validation of changes

- `pytest tests/tools/test_cache_badges.py tests/test_readme_badges.py`: 22 passed.
- Ran `tools/cache_badges.py` against the live GitHub API: `unit.svg`, `integration.svg`, and `docs.svg` all render "passing" from real main-branch runs.
- Verified the README badge source directly: the shields.io endpoint for `coverage-baseline.yml?branch=main` returns "Unit Tests: passing".
- `ruff check` and `ruff format` clean on the changed files; `bash tools/validate_test_structure.sh` passes.
- Test configuration: macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
