### PR TITLE
Delete quarantined snapshots and warn on outsized baseline swaps

### DIFF
--- a/src/proteus/interior_energetics/wrapper.py
+++ b/src/proteus/interior_energetics/wrapper.py
@@ -2826,6 +2826,17 @@ def update_structure_from_interior(
             not force and actual_shift > config.interior_struct.zalmoxis.mesh_max_shift
         )
 
+        # The unclamped baseline can jump far from the previous mesh; surface
+        # that so a large swap is visible in the log. With no .prev mesh on
+        # disk, blend_mesh_files returns 0.0 and this cannot fire.
+        if force and actual_shift > config.interior_struct.zalmoxis.mesh_max_shift:
+            log.warning(
+                'One-time baseline mesh swap shift %.1f%% exceeds mesh_max_shift '
+                '%.1f%% and lands on the interior solver unclamped in a single step',
+                actual_shift * 100,
+                config.interior_struct.zalmoxis.mesh_max_shift * 100,
+            )
+
         # Track convergence steps; give up after 20 consecutive blends
         # to avoid infinite rapid-update loops when Zalmoxis and SPIDER
         # persistently disagree (e.g. extreme mass / low CMF)

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -1229,7 +1229,10 @@ def select_resumable_snapshot(
     (when ``require_atm``) snapshots both open cleanly, move any incomplete
     trailing snapshot files aside (``.incomplete`` suffix) so the modules'
     latest-file globs land on the complete pair, and return the helpfile
-    truncated to that row.
+    truncated to that row. Once a resumable row is found, the quarantined
+    files are deleted: the helpfile is truncated below their rows, so they
+    can never back a resume and would otherwise be swept into the final
+    data archive.
 
     Each half is probed with its own writer's filename convention. The
     interior name depends on the module: Aragog writes ``'%d_int.nc'``
@@ -1315,6 +1318,14 @@ def select_resumable_snapshot(
             'No complete interior+atmosphere snapshot pair found in the '
             'helpfile history; cannot resume from disk.'
         )
+    if quarantined:
+        # The helpfile is truncated below the dropped rows, so these files
+        # can never back a resume; delete them so the final archive sweep
+        # does not pick them up.
+        for dst, _original in quarantined:
+            if os.path.exists(dst):
+                os.remove(dst)
+        log.info('Deleted %d quarantined snapshot file(s)', len(quarantined))
     if not dropped:
         return hf_all, []
     return hf_all.iloc[: keep_idx + 1].reset_index(drop=True), sorted(dropped)

--- a/tests/interior_energetics/test_wrapper.py
+++ b/tests/interior_energetics/test_wrapper.py
@@ -245,6 +245,76 @@ def test_force_baseline_ignores_unmet_triggers():
     assert forced[0] == pytest.approx(50.0, rel=1e-12)
 
 
+@pytest.mark.unit
+def test_force_baseline_warns_when_swap_exceeds_mesh_max_shift(tmp_path, caplog):
+    """The unclamped baseline swap warns when its shift exceeds mesh_max_shift.
+
+    force=True disables the blend cap, so a baseline mesh far from the .prev
+    mesh lands on the interior solver in a single step. A 15% shift against
+    mesh_max_shift=5% must produce the warning with both numbers; the
+    companion 2% run through the same path must stay silent, pinning the
+    threshold rather than an unconditional log line. In both runs the forced
+    path must leave convergence tracking inactive (no clamped intermediate
+    exists for later steps to reconcile).
+    """
+    hf_row = {
+        'Time': 1100.0,
+        'T_magma': 3000.0,
+        'Phi_global': 0.8,
+        'R_int': 6.371e6,
+        'gravity': 9.81,
+    }
+    (tmp_path / 'data').mkdir(exist_ok=True)
+
+    def _run(shift):
+        config = _mock_config(mesh_max_shift=0.05)
+        mesh_file = str(tmp_path / 'spider_mesh.dat')
+        dirs = {
+            'output': str(tmp_path),
+            'spider': '/tmp/spider',
+            'spider_mesh': mesh_file,
+            'spider_mesh_prev': mesh_file + '.prev',
+            'mesh_shift_active': False,
+            'mesh_convergence_steps': 0,
+        }
+        with (
+            patch(
+                'proteus.interior_struct.zalmoxis.zalmoxis_solver',
+                return_value=(3.504e6, mesh_file),
+            ),
+            patch('proteus.interior_energetics.wrapper.np.savetxt'),
+            patch('proteus.interior_energetics.wrapper.shutil.copy2'),
+            patch(
+                'proteus.interior_energetics.spider.blend_mesh_files',
+                return_value=shift,
+            ),
+            patch('proteus.interior_energetics.wrapper.gc.collect'),
+            caplog.at_level('WARNING', logger='fwl.proteus.interior_energetics.wrapper'),
+        ):
+            update_structure_from_interior(
+                dirs, config, hf_row, interior_o, 0.0, 3000.0, 0.8, force=True
+            )
+        return dirs
+
+    interior_o = _mock_interior_o()
+    dirs_above = _run(0.15)
+    warns = [r.getMessage() for r in caplog.records if 'mesh_max_shift' in r.message]
+    assert len(warns) == 1
+    # Both numbers appear so the log line is actionable on its own.
+    assert '15.0%' in warns[0]
+    assert '5.0%' in warns[0]
+    # Invariant: the forced baseline never enters mesh convergence tracking,
+    # even when the shift exceeds the cap.
+    assert dirs_above['mesh_shift_active'] is False
+    assert dirs_above['mesh_convergence_steps'] == 0
+
+    # Discrimination guard: a shift below the threshold stays silent.
+    caplog.clear()
+    dirs_below = _run(0.02)
+    assert not [r for r in caplog.records if 'mesh_max_shift' in r.message]
+    assert dirs_below['mesh_shift_active'] is False
+
+
 def _dirs_hf_with_composition_delta():
     """Build dirs + hf_row carrying a dissolved-H2O fraction change that is
     above the composition trigger threshold (w 1.0e-3 -> 2.0e-3, dw = 100%)."""

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -2516,6 +2516,41 @@ def test_select_resumable_snapshot_raises_when_no_complete_pair(tmp_path):
         select_resumable_snapshot(str(tmp_path), _hf_times([10, 20]))
 
 
+@pytest.mark.unit
+def test_failed_selection_restores_quarantined_files(tmp_path):
+    """A failed selection restores every quarantined file and deletes none.
+
+    A successful selection deletes the quarantined trailing files, which are
+    unusable once the helpfile is truncated below them; a FAILED selection
+    must do the opposite and put every file back under its original name, so
+    a failed resume attempt stays lossless and a later retry or manual
+    inspection sees the run directory exactly as it was. Discrimination:
+    each file carries unique bytes and the restored files must match them,
+    so a re-created placeholder or a cross-file swap cannot pass.
+    """
+    data = tmp_path / 'data'
+    data.mkdir()
+    payloads = {}
+    for t in (10, 20):
+        for half in ('int', 'atm'):
+            p = data / f'{t}_{half}.nc'
+            _write_corrupt_nc(str(p))
+            # Make each corrupt file unique so restore is distinguishable
+            # from recreation; appending keeps the file corrupt.
+            p.write_bytes(p.read_bytes() + p.name.encode())
+            payloads[p.name] = p.read_bytes()
+
+    with pytest.raises(RuntimeError, match='No complete'):
+        select_resumable_snapshot(str(tmp_path), _hf_times([10, 20]))
+
+    leftovers = sorted(f.name for f in data.iterdir())
+    assert leftovers == sorted(payloads), (
+        'originals must be back under their exact names with no .incomplete strays'
+    )
+    for name, blob in payloads.items():
+        assert (data / name).read_bytes() == blob
+
+
 def _write_valid_json(path: str) -> str:
     """Create a minimal, valid SPIDER-style interior JSON snapshot."""
     with open(path, 'w') as fh:

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -2409,11 +2409,12 @@ def test_select_resumable_snapshot_keeps_complete_latest(tmp_path):
 
 @pytest.mark.unit
 def test_select_resumable_snapshot_falls_back_on_corrupt_atm(tmp_path):
-    """A truncated latest _atm.nc trims to the prior pair and quarantines both halves.
+    """A truncated latest _atm.nc trims to the prior pair and deletes both halves.
 
     The interior half being intact must not save the step: the atmosphere
-    half is required, so the row is dropped and both 30_*.nc files are moved
-    aside so the modules' latest-file globs land on time 20.
+    half is required, so the row is dropped and both 30_*.nc files are
+    deleted so the modules' latest-file globs land on time 20 and the
+    archive sweep cannot pick them up.
     """
     data = tmp_path / 'data'
     data.mkdir()
@@ -2427,8 +2428,8 @@ def test_select_resumable_snapshot_falls_back_on_corrupt_atm(tmp_path):
 
     assert dropped == [30]
     assert int(out.iloc[-1]['Time']) == 20
-    assert (data / '30_atm.nc.incomplete').exists()
-    assert (data / '30_int.nc.incomplete').exists()
+    assert not (data / '30_atm.nc.incomplete').exists()
+    assert not (data / '30_int.nc.incomplete').exists()
     assert not (data / '30_atm.nc').exists()
     assert not (data / '30_int.nc').exists()
 
@@ -2448,11 +2449,11 @@ def test_select_resumable_snapshot_falls_back_on_corrupt_int(tmp_path):
 
     assert dropped == [30]
     assert int(out.iloc[-1]['Time']) == 20
-    # Both halves of the incomplete pair are quarantined (symmetry with the
+    # Both halves of the incomplete pair are deleted (symmetry with the
     # corrupt-atm case): a stray valid 30_atm.nc must not be left for the
     # atmosphere module's latest-file glob to pick up against a missing 30_int.
-    assert (data / '30_int.nc.incomplete').exists()
-    assert (data / '30_atm.nc.incomplete').exists()
+    assert not (data / '30_int.nc.incomplete').exists()
+    assert not (data / '30_atm.nc.incomplete').exists()
     assert not (data / '30_int.nc').exists()
     assert not (data / '30_atm.nc').exists()
 
@@ -2644,9 +2645,9 @@ def test_select_resumable_snapshot_falls_back_on_corrupt_spider_json(tmp_path):
 
     assert dropped == [30]
     assert int(out.iloc[-1]['Time']) == 20
-    # The incomplete latest half is quarantined so SPIDER's latest-json glob
+    # The incomplete latest half is deleted so SPIDER's latest-json glob
     # lands on time 20, not the truncated 30.json.
-    assert (data / '30.json.incomplete').exists()
+    assert not (data / '30.json.incomplete').exists()
     assert not (data / '30.json').exists()
 
 
@@ -2750,7 +2751,7 @@ def test_select_resumable_snapshot_rejects_cross_row_atm_collision(tmp_path):
     # them.
     assert (data / '30_atm.nc').exists()
     assert (data / '30.json').exists()
-    # 30.7's orphaned interior is quarantined so SPIDER's latest-json glob
+    # 30.7's orphaned interior is deleted so SPIDER's latest-json glob
     # cannot load it against the 30.2-trimmed helpfile.
-    assert (data / '31.json.incomplete').exists()
+    assert not (data / '31.json.incomplete').exists()
     assert not (data / '31.json').exists()


### PR DESCRIPTION
## Description

Two small follow-ups in the resume and structure-baseline machinery, split out of the #706 discussion. Neither changes physics results. Closes #733; together with the guard short-circuit carried by #740, closes #736.

Please review and merge #740 before this one: item 1 of #736 rides there, so the `Closes #736` line here is only correct once #740 is in. This PR is otherwise independent of #740 (no shared hunks) and can be reviewed in parallel.

* Quarantined snapshot files are now deleted after a successful resume selection (#733). When `select_resumable_snapshot` picks a resume row, the trailing snapshot files past that row are renamed to `*.incomplete`; previously nothing ever removed them, and since `_snapshot_time` does not recognize the suffix they were invisible to `remove_old` and the rolling snapshots-only archive but still swept into `data.tar` by the final unfiltered `archive.update(remove_files=True)`, restoring corrupt netCDF members to disk on every later extract. Once a selection succeeds the helpfile is already truncated below the quarantined rows, so those files can never be used again; the selector now deletes them at that point and logs how many were removed. The failure path is unchanged: when no resumable pair exists, the quarantined files are still restored to their original names before the RuntimeError, so a failed resume attempt remains lossless. Of the two fixes proposed on the issue, this one keeps `_snapshot_time`, `remove_old`, and the archive filters untouched, which avoids giving the shared time parser a second meaning. The deleted files are corrupt truncations with no forensic value beyond their timestamps, which the resume log already reports.
* The one-time baseline structure solve now warns when its mesh swap exceeds `mesh_max_shift` (#736 item 2). The forced baseline bypasses the mesh-shift clamp by design (`_blend_max_shift` is infinite under `force`), so the IC-versus-callable representation offset lands on the interior solver in a single unclamped remap. `blend_mesh_files` already reports the pre-clamp shift, so the wrapper now logs a warning with the actual shift and the configured cap whenever the forced swap exceeds it. The default `liquidus_super` initial condition skips the one-time baseline entirely, so stock configs never see this path; the warning makes the rare outsized swap visible for the zalmoxis configs with a non-superliquidus temperature mode that do reach it. The warning cannot fire when no previous mesh exists, since the shift reports as zero then; the forced baseline normally runs after the initial-condition solve has written one.

## Validation of changes

Linux x86-64, Python 3.12, conda environment matching the current pins.

* `tests/utils/test_coupler.py` and `tests/interior_energetics/test_wrapper.py` pass at the unit tier (249 tests). `ruff check` and `ruff format --check` are clean on all touched files.
* The deletion fix flips four existing assertions that pinned the old leak (the corrupt-atmosphere, corrupt-interior, corrupt-SPIDER-JSON, and cross-row-collision fallback tests now assert the quarantined files are gone after a successful selection), and a dedicated failure-path test now pins the restore-not-delete split: after a failed selection every quarantined file is back under its original name with its original bytes, with no .incomplete strays. The new warning is pinned by a threshold-discriminating test: a forced swap above the cap produces exactly one warning carrying both percentages, an equal run below the cap stays silent, and the forced path is asserted to leave the incremental mesh-shift machinery untouched.
* Both changes are unit-tested only; no end-to-end resume of a real run directory was exercised.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate (no user-facing docs describe the resume quarantine or the forced baseline; nothing to update)
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

