### PR TITLE
Add the Zenodo DOI to the citation metadata and docs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,6 +2,9 @@ cff-version: 1.2.0
 title: "PROTEUS Framework for Planetary Evolution"
 license: "Apache-2.0"
 message: "If you use this software, please cite it as below."
+doi: "10.5281/zenodo.21358380"
+repository-code: "https://github.com/FormingWorlds/PROTEUS"
+url: "https://proteus-framework.org"
 
 authors:
 - family-names: "Lichtenberg"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The principle purpose of PROTEUS is to generate data to make scientific conclusi
 3. the Maintainers are made aware of when PROTEUS results are used in a scientific paper.
 
 A suggested acknowledgement is:
-> We thank the people who have contributed to PROTEUS and its broader ecosystem for their support and enabling the scientific outputs of this paper. PROTEUS (version XX.XX.XX) may be found online at https://github.com/FormingWorlds
+> We thank the people who have contributed to PROTEUS and its broader ecosystem for their support and enabling the scientific outputs of this paper. PROTEUS (version XX.XX.XX) may be found online at https://github.com/FormingWorlds and archived on Zenodo, where each release carries its own DOI (all versions: https://doi.org/10.5281/zenodo.21358380)
 
 <b>
 In summary:
@@ -159,13 +159,6 @@ The documentation is hosted on the [PROTEUS framework website](https://proteus-f
 ### Making a release
 
 The versioning scheme we use is [CalVer](https://calver.org/), in the format `YY.MM.DD`, without a leading 'v'. Versions are derived from git tags by [`setuptools-scm`](https://setuptools-scm.readthedocs.io/); there is no hand-edited version string anywhere in the repository.
-
-0. Update requirements files:
-
-```console
-python tools/generate_requirements_txt.py
-pip-compile -o requirements_full.txt pyproject.toml
-```
 
 1. Tag the release on `main` and push the tag:
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@
   <a href="https://proteus-framework.org">
     <img src="https://img.shields.io/website?url=https%3A%2F%2Fproteus-framework.org&label=Website&up_message=proteus-framework.org&down_message=proteus-framework.org" />
   </a>
-  <a href="https://doi.org/10.5281/zenodo.21358380">
-    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.21358380.svg">
-  </a>
 </p>
 
 **Coupled atmosphere-interior evolution of rocky planets and exoplanets.**

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
   <a href="https://proteus-framework.org">
     <img src="https://img.shields.io/website?url=https%3A%2F%2Fproteus-framework.org&label=Website&up_message=proteus-framework.org&down_message=proteus-framework.org" />
   </a>
+  <a href="https://doi.org/10.5281/zenodo.21358380">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.21358380.svg">
+  </a>
 </p>
 
 **Coupled atmosphere-interior evolution of rocky planets and exoplanets.**
@@ -59,4 +62,4 @@ Full documentation: **[proteus-framework.org/PROTEUS](https://proteus-framework.
 
 ## Community and citation
 
-Ask questions on the [discussions page](https://github.com/orgs/FormingWorlds/discussions) or [contact the developers](https://proteus-framework.org/PROTEUS/Community/contact.html). If you use PROTEUS, please cite the papers listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography.html).
+Ask questions on the [discussions page](https://github.com/orgs/FormingWorlds/discussions) or [contact the developers](https://proteus-framework.org/PROTEUS/Community/contact.html). If you use PROTEUS, please cite the papers listed in the [bibliography](https://proteus-framework.org/PROTEUS/Reference/bibliography.html). To cite the software itself, use the Zenodo concept DOI [10.5281/zenodo.21358380](https://doi.org/10.5281/zenodo.21358380), which always resolves to the latest archived release.

--- a/docs/Community/CONTRIBUTING.md
+++ b/docs/Community/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The principle purpose of PROTEUS is to generate data to make scientific conclusi
 3. the Maintainers are made aware of when PROTEUS results are used in a scientific paper.
 
 A suggested acknowledgement is:
-> We thank the people who have contributed to PROTEUS and its broader ecosystem for their support and enabling the scientific outputs of this paper. PROTEUS (version XX.XX.XX) may be found online at https://github.com/FormingWorlds
+> We thank the people who have contributed to PROTEUS and its broader ecosystem for their support and enabling the scientific outputs of this paper. PROTEUS (version XX.XX.XX) may be found online at https://github.com/FormingWorlds and archived on Zenodo, where each release carries its own DOI (all versions: https://doi.org/10.5281/zenodo.21358380)
 
 <b>
 In summary:
@@ -159,13 +159,6 @@ The documentation is hosted on the [PROTEUS framework website](https://proteus-f
 ### Making a release
 
 The versioning scheme we use is [CalVer](https://calver.org/), in the format `YY.MM.DD`, without a leading 'v'. Versions are derived from git tags by [`setuptools-scm`](https://setuptools-scm.readthedocs.io/); there is no hand-edited version string anywhere in the repository.
-
-0. Update requirements files:
-
-```console
-python tools/generate_requirements_txt.py
-pip-compile -o requirements_full.txt pyproject.toml
-```
 
 1. Tag the release on `main` and push the tag:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,10 @@ If you make use of PROTEUS, please reference the scientific manuscripts
 outlined in the [Bibliography](Reference/bibliography.md), state the code
 version used, and include an acknowledgement. We provide a suggested
 acknowledgement in the [contributing page](Community/CONTRIBUTING.md#licensing-and-credit).
+To cite the software itself, use the Zenodo concept DOI
+[10.5281/zenodo.21358380](https://doi.org/10.5281/zenodo.21358380), which
+always resolves to the latest archived release; the Zenodo record for a
+specific release also carries its own version DOI.
 
 ## License
 


### PR DESCRIPTION
## Description

PROTEUS releases are now archived on Zenodo, so this makes the software citable by a DOI. It adds the Zenodo concept DOI `10.5281/zenodo.21358380` (the version-independent identifier that resolves to the latest release) to the places people cite from:

- `CITATION.cff`: `doi`, plus `repository-code` and `url`. This is what GitHub's "Cite this repository" panel reads.
- `README.md`: a line in the "Community and citation" section.
- `docs/index.md`: a line in the "Citation and credit" section.
- `CONTRIBUTING.md` and `docs/Community/CONTRIBUTING.md`: the concept DOI added to the suggested acknowledgement.

I use the concept DOI rather than a per-release version DOI so nothing needs a hand edit on each release, which matches the existing policy of keeping no hand-edited version string in the repo (versions come from git tags via setuptools-scm). The acknowledgement and the docs note that each release also carries its own version DOI on Zenodo.

This also removes the stale first step of the "Making a release" checklist in both CONTRIBUTING files: it told maintainers to run `tools/generate_requirements_txt.py` and `pip-compile`, but neither that script nor any `requirements*.txt` exists on main any more.

## Validation of changes

macOS with Python 3.12; docs and metadata only, no code changed.

- Confirmed `10.5281/zenodo.21358380` is the concept DOI against the Zenodo API: record `21358381` reports `conceptdoi = 10.5281/zenodo.21358380` and `conceptrecid = 21358380`, and the version DOI `21358381` is release `26.07.14`. `https://doi.org/10.5281/zenodo.21358380` resolves to the latest record.
- `CITATION.cff` passes the repo's CFF validation pre-commit hook and uses only valid CFF 1.2.0 keys.
- Verified the removed release step is dead: `tools/generate_requirements_txt.py` and any `requirements*.txt` no longer exist on main, and nothing else in the tree references them.
- The DOI string is identical across all touched files, and the two CONTRIBUTING acknowledgement lines remain identical to each other.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer (docs/metadata only, no code paths changed)
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate (docs/metadata only)
- [x] I have checked that all dependencies have been updated, as required
