### PR TITLE
Adopt fwl-zalmoxis 26.07.13 for unified and wet JAX structure solves

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,10 @@ dependencies = [
     "fwl-calliope>=26.06.01",
     "fwl-zephyrus>=25.03.11",
     "fwl-aragog>=26.07.04",
-    "fwl-zalmoxis>=26.07.03",
+    # 26.07.13 carries the JAX structure path for the unified PALEOS
+    # mantle (the production default) and for wet mantles blending one
+    # paleos_unified volatile through the VolatileProfile (Zalmoxis #78).
+    "fwl-zalmoxis>=26.07.13",
     # The default Aragog interior solver runs on JAX: its eos/phase/solver
     # modules are equinox Modules, so jax, jaxlib, and equinox are needed by
     # a standard run, not only by the optional atmodeller backend. The three

--- a/src/proteus/interior_energetics/wrapper.py
+++ b/src/proteus/interior_energetics/wrapper.py
@@ -2508,10 +2508,11 @@ def update_structure_from_interior(
     # tabulation in jax_eos/wrapper.py collapses for this closure
     # (T_asc varies with r and ignores P).
     # zalmoxis_solver dispatches between the two: it feeds the arrays to
-    # the JAX path when the configured mantle EOS supports it (2-phase
-    # PALEOS mantle + unified core) and otherwise passes the callable to
-    # the numpy path, so the evolved T(r) reaches the density solve on
-    # either path. The arrays are already sorted strictly ascending in r
+    # the JAX path when the configured EOS layout supports it (unified
+    # or 2-phase PALEOS mantle plus unified core, with any wet profile
+    # inside the Zalmoxis JAX wet envelope) and otherwise passes the
+    # callable to the numpy path, so the evolved T(r) reaches the
+    # density solve on either path. The arrays are already sorted strictly ascending in r
     # above, as jnp.interp requires monotonically increasing xp; a
     # descending [surface, ..., CMB] array would produce ``Final M=0``
     # failures in JAX.

--- a/src/proteus/interior_energetics/wrapper.py
+++ b/src/proteus/interior_energetics/wrapper.py
@@ -1248,6 +1248,69 @@ _ADIABAT_IC_RESTORE_KEYS = (
 )
 
 
+def _sample_adiabat_temperature_arrays(outdir: str, temperature_function):
+    """Sample the adiabat closure onto the previous structure's mantle grid.
+
+    The super-liquidus adiabat closure is pressure-indexed (``f(r, P)``
+    ignores ``r``), but the Zalmoxis JAX inner path consumes an explicit
+    r-indexed ``temperature_arrays=(r_arr, T_arr)``, the only temperature
+    input its surrounding numpy Picard helper does not also read. With
+    the callable alone, the Picard density updates evaluate the hot
+    adiabat near the PALEOS phase-boundary clamps and dominate the IC
+    wall time (issue #719). The r to P map needed for the sampling is
+    the immediately preceding converged structure in
+    ``<outdir>/data/zalmoxis_output.dat`` (mantle rows; columns r, P,
+    rho, g, T): ``T_i = temperature_function(r_i, P_i)``. The file is
+    read fresh on every call, so equilibration iterations track their
+    own drifting ``P_cmb``.
+
+    Out-of-domain radii are safe by construction: the JAX RHS
+    interpolates T on radius with ``jnp.interp``, which clamps to the
+    endpoint values, extending the adiabat's deepest temperature inward
+    over the core (the closure's own pressure clip does the same) and
+    the surface temperature outward past the previous surface radius,
+    so the outer radius search may probe beyond the sampled domain.
+
+    Parameters
+    ----------
+    outdir : str
+        Output directory holding ``data/zalmoxis_output.dat``.
+    temperature_function : callable
+        Adiabat ``f(r, P) -> T`` closure to sample.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, numpy.ndarray] or None
+        ``(r_arr, T_arr)`` on the previous structure's mantle radii, or
+        None when the previous structure is unavailable or malformed;
+        the caller then passes the callable alone and the solve behaves
+        as before.
+    """
+    path = os.path.join(outdir, 'data', 'zalmoxis_output.dat')
+    try:
+        data = np.loadtxt(path)
+    except (OSError, ValueError):
+        return None
+    if data.ndim != 2 or data.shape[0] < 2 or data.shape[1] < 2:
+        return None
+    r_arr = np.ascontiguousarray(data[:, 0], dtype=float)
+    p_arr = np.ascontiguousarray(data[:, 1], dtype=float)
+    if not (np.all(np.isfinite(r_arr)) and np.all(np.isfinite(p_arr))):
+        return None
+    if np.any(np.diff(r_arr) <= 0.0) or np.any(p_arr < 0.0):
+        return None
+    try:
+        t_arr = np.array(
+            [float(temperature_function(float(r), float(P))) for r, P in zip(r_arr, p_arr)],
+            dtype=float,
+        )
+    except (TypeError, ValueError):
+        return None
+    if not np.all(np.isfinite(t_arr)) or np.any(t_arr <= 0.0):
+        return None
+    return r_arr, t_arr
+
+
 def _solve_structure_with_adiabat_or_rollback(
     config: Config,
     outdir: str,
@@ -1259,7 +1322,9 @@ def _solve_structure_with_adiabat_or_rollback(
 
     Captures the on-disk ``zalmoxis_output.dat`` and the structure-defining
     ``hf_row`` keys, calls :func:`zalmoxis_solver` with the supplied adiabat
-    ``T(P)`` closure, then enforces the mass-anchor contract
+    ``T(P)`` closure plus its r-indexed sampling (see
+    :func:`_sample_adiabat_temperature_arrays`), then enforces the
+    mass-anchor contract
     (``|M_int / M_int_target - 1| < _ZALMOXIS_MASS_ANCHOR_TOL``) and a finite,
     positive ``R_int``. On any failure it restores BOTH the saved ``hf_row``
     keys AND ``zalmoxis_output.dat`` from its ``.prev`` snapshot, so the
@@ -1283,7 +1348,9 @@ def _solve_structure_with_adiabat_or_rollback(
     num_spider_nodes : int
         SPIDER basic-node count forwarded to the solver (0 for Aragog/dummy).
     temperature_function : callable
-        Adiabat ``f(r, P) -> T`` closure handed to the Zalmoxis numpy path.
+        Adiabat ``f(r, P) -> T`` closure. Passed to the solver together
+        with the sampled r-indexed arrays; the solver's temperature-source
+        dispatch then decides which one the solve consumes.
 
     Returns
     -------
@@ -1310,6 +1377,15 @@ def _solve_structure_with_adiabat_or_rollback(
     saved = {k: hf_row[k] for k in _ADIABAT_IC_RESTORE_KEYS if k in hf_row}
     R_int_prev = float(hf_row.get('R_int', 0.0) or 0.0)
 
+    # Hand the adiabat to the solver in both representations: the P-indexed
+    # closure and its r-indexed sampling on the previous structure's grid.
+    # zalmoxis_solver's temperature-source dispatch then decides exactly as
+    # on evolved re-solves: a JAX-viable EOS withholds the callable and the
+    # JAX RHS integrates the arrays (issue #719); any other configuration
+    # keeps the callable on the numpy path unchanged. A None sampling (no
+    # or malformed previous structure) degrades to the callable-only call.
+    adiabat_arrays = _sample_adiabat_temperature_arrays(outdir, temperature_function)
+
     try:
         _cmb_radius, adiabat_mesh_file = zalmoxis_solver(
             config,
@@ -1317,6 +1393,7 @@ def _solve_structure_with_adiabat_or_rollback(
             hf_row,
             num_spider_nodes=num_spider_nodes,
             temperature_function=temperature_function,
+            temperature_arrays=adiabat_arrays,
         )
         # Mass-anchor contract: a too-loosely-converged adiabat solve is
         # treated as a failure, same as the time-evolution re-solve path.

--- a/src/proteus/interior_struct/zalmoxis.py
+++ b/src/proteus/interior_struct/zalmoxis.py
@@ -1086,14 +1086,18 @@ def _zalmoxis_jax_structure_viable(mat_dicts: dict, core_eos: str, mantle_eos: s
 
     Mirrors, on static registry properties, the preconditions that
     ``zalmoxis.jax_eos.wrapper.solve_structure_via_jax`` enforces before
-    integrating: the mantle registry entry must carry both ``solid_mantle``
-    and ``melted_mantle`` dict sub-tables (the 2-phase PALEOS layout), and
-    the core entry must resolve to the ``paleos_unified`` format. A
-    ``paleos_api`` core qualifies because
+    integrating: the mantle registry entry must be one of the two
+    supported representations, the unified single-table layout (a flat
+    entry with format ``paleos_unified`` carrying an ``eos_file``, the
+    production default) or the 2-phase PALEOS layout (both
+    ``solid_mantle`` and ``melted_mantle`` dict sub-tables), and the core
+    entry must resolve to the ``paleos_unified`` format. A ``paleos_api``
+    entry qualifies on either layer because
     ``zalmoxis.eos.paleos_api_cache.resolve_registry_entry`` materialises
-    it to ``paleos_unified`` in place before the JAX dispatch checks it.
+    it to ``paleos_unified`` (with an on-disk ``eos_file``) in place
+    before the JAX dispatch checks it.
 
-    When either precondition fails, the Zalmoxis dispatch raises inside
+    When a precondition fails, the Zalmoxis dispatch raises inside
     the JAX wrapper and falls back to the numpy ODE, which consumes
     ``temperature_function`` rather than ``temperature_arrays``; the
     caller must therefore keep the temperature callable in play.
@@ -1120,9 +1124,16 @@ def _zalmoxis_jax_structure_viable(mat_dicts: dict, core_eos: str, mantle_eos: s
     mantle_entry = mat_dicts.get(_strip_fraction_tokens(str(mantle_eos)))
     if not isinstance(mantle_entry, dict):
         return False
-    if not isinstance(mantle_entry.get('solid_mantle'), dict):
-        return False
-    if not isinstance(mantle_entry.get('melted_mantle'), dict):
+    mantle_format = mantle_entry.get('format')
+    if mantle_format == 'paleos_unified':
+        mantle_viable = bool(mantle_entry.get('eos_file'))
+    elif mantle_format == 'paleos_api':
+        mantle_viable = True
+    else:
+        mantle_viable = isinstance(mantle_entry.get('solid_mantle'), dict) and isinstance(
+            mantle_entry.get('melted_mantle'), dict
+        )
+    if not mantle_viable:
         return False
     core_entry = mat_dicts.get(_strip_fraction_tokens(str(core_eos)))
     if not isinstance(core_entry, dict):

--- a/src/proteus/interior_struct/zalmoxis.py
+++ b/src/proteus/interior_struct/zalmoxis.py
@@ -1141,6 +1141,96 @@ def _zalmoxis_jax_structure_viable(mat_dicts: dict, core_eos: str, mantle_eos: s
     return core_entry.get('format') in ('paleos_unified', 'paleos_api')
 
 
+def _volatile_profile_jax_viable(
+    volatile_profile, mat_dicts: dict, mantle_eos_extended
+) -> bool:
+    """Report whether a ``VolatileProfile`` fits the Zalmoxis JAX wet envelope.
+
+    Mirrors, on static profile and registry properties, the checks that
+    ``zalmoxis.jax_eos.wrapper._validate_wet_mantle`` and the volatile
+    cache load in ``zalmoxis.jax_eos.wrapper.solve_structure_via_jax``
+    enforce before integrating a wet mantle: no ``global_miscibility``,
+    no ``x_interior`` entries, zero (or absent) weight on the primary
+    silicate component, the primary present in the mantle mixture,
+    exactly one active volatile in the mixture, no mixture components
+    outside the profile, the volatile not ``Chabrier:H`` (its binodal
+    suppression factor is not ported to the JAX RHS), and a volatile
+    registry entry that resolves to the ``paleos_unified`` format with
+    an ``eos_file`` (``paleos_api`` entries materialise to that in
+    place).
+
+    When any check fails, the Zalmoxis dispatch raises inside the JAX
+    wrapper and falls back to the numpy ODE, which consumes
+    ``temperature_function`` rather than ``temperature_arrays``; the
+    caller must therefore keep the temperature callable in play.
+
+    Parameters
+    ----------
+    volatile_profile : VolatileProfile or None
+        Profile built by :func:`build_volatile_profile`. None reads as
+        not viable; callers gate the dry case separately.
+    mat_dicts : dict
+        EOS registry from :func:`load_zalmoxis_material_dictionaries`.
+    mantle_eos_extended : str
+        Mantle EOS string after
+        :func:`extend_mantle_eos_with_volatiles`, whose components (with
+        fraction tokens stripped) are the mantle mixture Zalmoxis
+        parses.
+
+    Returns
+    -------
+    bool
+        True when the profile matches the JAX wet envelope. False
+        otherwise, including malformed or unrecognised input: the
+        conservative answer routes the solve to the numpy path with the
+        callable attached.
+    """
+    try:
+        if volatile_profile is None:
+            return False
+        if getattr(volatile_profile, 'global_miscibility', False):
+            return False
+        if getattr(volatile_profile, 'x_interior', None):
+            return False
+        primary = str(volatile_profile.primary_component)
+        w_liquid = dict(volatile_profile.w_liquid)
+        w_solid = dict(volatile_profile.w_solid)
+        # A nonzero weight on the primary silicate is degenerate input
+        # the wrapper rejects (numpy's blend() double-counts it).
+        if float(w_liquid.get(primary, 0.0)) > 0.0 or float(w_solid.get(primary, 0.0)) > 0.0:
+            return False
+        components = [
+            _strip_fraction_tokens(token) for token in str(mantle_eos_extended).split('+')
+        ]
+        if primary not in components:
+            return False
+        managed = (set(w_liquid) | set(w_solid)) - {primary}
+        active = [
+            key
+            for key in managed
+            if (float(w_liquid.get(key, 0.0)) > 0.0 or float(w_solid.get(key, 0.0)) > 0.0)
+            and key in components
+        ]
+        if len(active) != 1:
+            return False
+        # Unmanaged extra mixture components keep their fraction only on
+        # the numpy path; the wrapper rejects them.
+        if any(c != primary and c not in managed for c in components):
+            return False
+        (vol_eos,) = active
+        if vol_eos == 'Chabrier:H':
+            return False
+        vol_entry = mat_dicts.get(vol_eos)
+        if not isinstance(vol_entry, dict):
+            return False
+        vol_format = vol_entry.get('format')
+        if vol_format == 'paleos_api':
+            return True
+        return vol_format == 'paleos_unified' and bool(vol_entry.get('eos_file'))
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
 def load_zalmoxis_material_dictionaries():
     """Build an EOS registry dict with file paths pointing to FWL_DATA.
 
@@ -2138,13 +2228,15 @@ def zalmoxis_solver(
     temperature_arrays : tuple[ndarray, ndarray] or None, optional
         Explicit r-indexed ``(r_arr, T_arr)`` for the Zalmoxis JAX path.
         Consumed only when ``use_jax=True``, the configured EOS pair
-        can take the Zalmoxis JAX dispatch (2-phase PALEOS mantle with
-        solid and melted sub-tables plus a unified PALEOS core; see
-        :func:`_zalmoxis_jax_structure_viable`), and the solve is dry
-        (no ``VolatileProfile`` in play). In that case the
+        can take the Zalmoxis JAX dispatch (a unified or 2-phase PALEOS
+        mantle plus a unified PALEOS core; see
+        :func:`_zalmoxis_jax_structure_viable`), and the solve is either
+        dry (no ``VolatileProfile`` in play) or wet with a profile
+        inside the Zalmoxis JAX wet envelope (see
+        :func:`_volatile_profile_jax_viable`). In that case the
         external callable is withheld so the inner Picard converges on
         Zalmoxis' internal linear-T profile while the JAX RHS integrates
-        against the arrays. For any other EOS configuration the solve
+        against the arrays. For any other configuration the solve
         runs on the numpy path, which consumes ``temperature_function``,
         and the callable is therefore passed through. See Zalmoxis'
         ``solve_structure_via_jax`` docstring for why both kwargs can be
@@ -2266,21 +2358,21 @@ def zalmoxis_solver(
 
     # Temperature-source dispatch for this call. temperature_arrays can be
     # consumed only by the Zalmoxis JAX inner path, which requires a
-    # 2-phase PALEOS mantle (solid_mantle + melted_mantle sub-tables) and
-    # a unified PALEOS core. Only in that case is the external callable
-    # withheld: the JAX RHS integrates against the arrays while the numpy
-    # Picard helper converges quickly on Zalmoxis' internal linear-T
-    # profile (passing the callable there lands Picard near PALEOS
-    # phase-boundary clamps and costs roughly two orders of magnitude
-    # more wall time at the same JAX arrays). For every other EOS
-    # configuration the JAX dispatch declines and the numpy ODE runs;
-    # that path consumes only the callable, so it must pass through for
-    # the solve to follow the evolved T(r) instead of rebuilding the
-    # internal temperature_mode profile from the hot initial anchor.
-    # Wet solves (volatile_profile present) also keep the callable and
-    # stay on the numpy path here: the arrays handoff and the post-solve
-    # rebuild gated on _drop_callable recompute density from the bare dry
-    # mantle EOS and would overwrite the volatile-blended column.
+    # JAX-capable EOS layout (a unified or 2-phase PALEOS mantle plus a
+    # unified PALEOS core) and, on wet solves, a VolatileProfile inside
+    # the Zalmoxis JAX wet envelope (exactly one paleos_unified volatile
+    # blended into the mantle; see _volatile_profile_jax_viable). Only in
+    # that case is the external callable withheld: the JAX RHS integrates
+    # against the arrays while the numpy Picard helper converges quickly
+    # on Zalmoxis' internal linear-T profile (passing the callable there
+    # lands Picard near PALEOS phase-boundary clamps and costs roughly
+    # two orders of magnitude more wall time at the same JAX arrays). For
+    # every other EOS configuration, and for wet solves whose profile
+    # falls outside the envelope, the JAX dispatch declines and the numpy
+    # ODE runs; that path consumes only the callable, so it must pass
+    # through for the solve to follow the evolved T(r) instead of
+    # rebuilding the internal temperature_mode profile from the hot
+    # initial anchor.
     _use_jax_active = bool(config_params.get('use_jax'))
     _jax_viable = _zalmoxis_jax_structure_viable(
         mat_dicts, config.interior_struct.zalmoxis.core_eos, mantle_eos
@@ -2288,11 +2380,16 @@ def zalmoxis_solver(
     # Surface a JAX->numpy fallback once from the PROTEUS side (see helper).
     if _use_jax_active and not _jax_viable:
         _log_jax_nonviable_once(config.interior_struct.zalmoxis.core_eos, mantle_eos)
+    _wet_jax_viable = volatile_profile is None or _volatile_profile_jax_viable(
+        volatile_profile, mat_dicts, config_params['layer_eos_config']['mantle']
+    )
+    if _use_jax_active and _jax_viable and volatile_profile is not None and not _wet_jax_viable:
+        log.debug(
+            'VolatileProfile falls outside the Zalmoxis JAX wet envelope; '
+            'the structure solve stays on the numpy path with the callable.'
+        )
     _drop_callable = (
-        _use_jax_active
-        and temperature_arrays is not None
-        and _jax_viable
-        and volatile_profile is None
+        _use_jax_active and temperature_arrays is not None and _jax_viable and _wet_jax_viable
     )
     _tf_effective = None if _drop_callable else temperature_function
     if _drop_callable:
@@ -2361,9 +2458,10 @@ def zalmoxis_solver(
     else:
         # _tf_effective carries the temperature-source decision hoisted
         # above: the callable is withheld only when the JAX inner path
-        # will actually consume temperature_arrays (2-phase PALEOS
-        # mantle + unified core); on any other EOS configuration the
-        # numpy path runs and the callable passes through. Warm-starts
+        # will actually consume temperature_arrays (JAX-viable EOS
+        # layout and, on wet solves, an in-envelope VolatileProfile);
+        # on any other configuration the numpy path runs and the
+        # callable passes through. Warm-starts
         # stay disabled on the JAX path: they drive Anderson into
         # oscillation and do not help otherwise, because the inner
         # Picard plateau at diff=0.1 is set by the lever-rule EOS kink,
@@ -2572,8 +2670,13 @@ def zalmoxis_solver(
     # (P, T_aragog) using numpy EOS before any downstream consumer reads
     # them. When the callable was honored on the numpy path instead, the
     # solver's own columns already reflect the evolved T(r) and no rebuild
-    # runs.
-    if _drop_callable:
+    # runs. Wet solves are excluded even when they took the JAX-arrays
+    # path: this rebuild evaluates the bare dry mantle EOS and would
+    # overwrite the volatile-blended density column, so on the wet JAX
+    # path the solver's own columns stand (still evaluated at the
+    # internal linear-T profile; a profile-aware rebuild is a known
+    # follow-up).
+    if _drop_callable and volatile_profile is None:
         from zalmoxis.eos.dispatch import calculate_density as _calc_rho
 
         _r_ref, _T_ref = temperature_arrays

--- a/src/proteus/interior_struct/zalmoxis.py
+++ b/src/proteus/interior_struct/zalmoxis.py
@@ -2670,14 +2670,23 @@ def zalmoxis_solver(
     # (P, T_aragog) using numpy EOS before any downstream consumer reads
     # them. When the callable was honored on the numpy path instead, the
     # solver's own columns already reflect the evolved T(r) and no rebuild
-    # runs. Wet solves are excluded even when they took the JAX-arrays
-    # path: this rebuild evaluates the bare dry mantle EOS and would
-    # overwrite the volatile-blended density column, so on the wet JAX
-    # path the solver's own columns stand (still evaluated at the
-    # internal linear-T profile; a profile-aware rebuild is a known
-    # follow-up).
-    if _drop_callable and volatile_profile is None:
+    # runs. Wet solves rebuild the mantle through the same per-shell blend
+    # the numpy solver's density update evaluates (calculate_mixed_density
+    # on the extended mantle mixture with the VolatileProfile at the local
+    # melt fraction), so the written column keeps the dissolved-volatile
+    # contribution instead of collapsing to the bare dry mantle EOS.
+    if _drop_callable:
         from zalmoxis.eos.dispatch import calculate_density as _calc_rho
+
+        # Wet path: the extended mantle mixture (primary silicate plus
+        # profile-managed volatiles), parsed from the same EOS string the
+        # solver parses, blended per shell by the profile.
+        _mantle_mixture = None
+        if volatile_profile is not None:
+            from zalmoxis.mixing import calculate_mixed_density as _calc_rho_mixed
+            from zalmoxis.mixing import parse_layer_components as _parse_mixture
+
+            _mantle_mixture = _parse_mixture(config_params['layer_eos_config']['mantle'])
 
         _r_ref, _T_ref = temperature_arrays
         _T_ref_cmb = float(_T_ref[0])
@@ -2702,17 +2711,41 @@ def zalmoxis_solver(
             else:
                 _T = float(np.interp(_r, _r_ref, _T_ref))
             _T_fixed[_i] = _T
-            _eos_here = _core_eos if _i < cmb_index else _mantle_eos
-            _rho = _calc_rho(
-                _P,
-                mat_dicts,
-                _eos_here,
-                _T,
-                _sol_f,
-                _liq_f,
-                interpolation_functions=_interp_cache,
-                mushy_zone_factor=_mzf,
-            )
+            if _mantle_mixture is not None and _i >= cmb_index:
+                # Wet mantle node: same evaluation as the numpy solver's
+                # density update. calculate_mixed_density computes the
+                # local melt fraction from the melting curves at this
+                # node's (P, T) (lever rule in compute_melt_fraction) and
+                # takes the per-component fractions from
+                # volatile_profile.apply_to_mixture. The condensed and
+                # binodal sigmoid parameters stay at the zalmoxis.mixing
+                # defaults, the same values the solver resolves when
+                # config_params carries no overrides (PROTEUS sets none).
+                _rho = _calc_rho_mixed(
+                    _P,
+                    _T,
+                    _mantle_mixture,
+                    mat_dicts,
+                    _sol_f,
+                    _liq_f,
+                    _interp_cache,
+                    mushy_zone_factors=config_params.get('mushy_zone_factors'),
+                    volatile_profile=volatile_profile,
+                )
+                if _rho is not None and not np.isfinite(_rho):
+                    _rho = None
+            else:
+                _eos_here = _core_eos if _i < cmb_index else _mantle_eos
+                _rho = _calc_rho(
+                    _P,
+                    mat_dicts,
+                    _eos_here,
+                    _T,
+                    _sol_f,
+                    _liq_f,
+                    interpolation_functions=_interp_cache,
+                    mushy_zone_factor=_mzf,
+                )
             _rho_fixed[_i] = float(_rho) if _rho is not None else float(density[_i])
         density = _rho_fixed
         temperature = _T_fixed

--- a/tests/integration/test_slow_zalmoxis_aragog_calliope.py
+++ b/tests/integration/test_slow_zalmoxis_aragog_calliope.py
@@ -3,12 +3,14 @@ with real Zalmoxis + real Aragog + real CALLIOPE.
 
 This is the heaviest end-to-end test that does not yet require a
 real atmosphere. Real Zalmoxis solves the structure (newton outer
-solver, PALEOS EOS, 150 radial levels) on the numpy path; the
-production-default unified ``PALEOS:MgSiO3`` mantle table has no JAX
-structure reader, so the structure solve runs in numpy. Real Aragog
-steps the entropy ODE on the resulting mantle (production
-``backend='jax'``: scipy-CVode with JAX-derived RHS and analytic
-Jacobian, the only JAX path exercised); real CALLIOPE partitions
+solver, PALEOS EOS, 150 radial levels); with fwl-zalmoxis >= 26.07.13
+the production-default unified ``PALEOS:MgSiO3`` mantle table has a
+JAX structure reader, so the interior-fed baseline re-solve takes the
+JAX arrays hand-off instead of the numpy fallback (the IC and
+equilibration solves, which carry no external temperature source,
+stay on numpy by design). Real Aragog steps the entropy ODE on the
+resulting mantle (production ``backend='jax'``: scipy-CVode with
+JAX-derived RHS and analytic Jacobian); real CALLIOPE partitions
 volatiles at the new T, P state. Atmosphere, star, escape, atmos_chem
 stay on dummy backends so the test isolates the interior + outgas
 coupling boundary while exercising the production-default structure
@@ -56,13 +58,15 @@ Invariants asserted:
 
 Runtime: this end-to-end real-binary test is dominated by the Aragog
 first-call JAX setup (CVode factory plus RHS and Jacobian compile)
-and the Zalmoxis structure solves on the numpy path. It completes in
-roughly 80 min on the macOS GHA runner and is gated to macOS
-(``skipif`` on linux): the unified PALEOS mantle has no JAX structure
-path, so the full-resolution coupled run on the numpy fallback
-exceeds the slow-tier walltime on the x86 ubuntu runner. The per-test
-timeout is 10800 s (180 min), the slow-tier standard, leaving generous
-headroom above the macOS runtime; the slow-tier job cap is set higher
+and the Zalmoxis structure solves. It completes in roughly 80 min on
+the macOS GHA runner and runs on every platform: with fwl-zalmoxis
+>= 26.07.13 the unified PALEOS mantle takes the JAX structure path on
+the interior-fed baseline re-solve, removing the numpy-fallback
+structure cost that previously pushed the full-resolution coupled run
+past the slow-tier walltime on the x86 ubuntu runner (an earlier
+``skipif`` gated this test to macOS for that reason). The per-test timeout is
+10800 s (180 min), the slow-tier standard, leaving generous headroom
+above the macOS runtime; the slow-tier job cap is set higher
 (210 min) so that setup time plus the per-test timeout still fit
 inside the job, letting a genuine hang trip pytest-timeout's per-test
 timer (which dumps every thread's stack) before the job-level
@@ -78,8 +82,6 @@ See also:
 
 from __future__ import annotations
 
-import sys
-
 import numpy as np
 import pytest
 
@@ -93,13 +95,6 @@ pytestmark = [pytest.mark.slow, pytest.mark.timeout(10800)]
 
 @pytest.mark.slow
 @pytest.mark.physics_invariant
-@pytest.mark.skipif(
-    sys.platform.startswith('linux'),
-    reason='Zalmoxis structure solve runs the numpy fallback (no JAX '
-    'path for the unified PALEOS mantle); the full-resolution coupled '
-    'run exceeds the slow-tier walltime on x86 runners. Exercised on '
-    'macOS. Tracked: FormingWorlds/Zalmoxis#75.',
-)
 def test_zalmoxis_aragog_calliope_two_timesteps(proteus_multi_timestep_run):
     """Two-step PROTEUS run with real Zalmoxis + Aragog + CALLIOPE on
     the Earth-IC fiducial.

--- a/tests/interior_energetics/test_wrapper_adiabat_ic.py
+++ b/tests/interior_energetics/test_wrapper_adiabat_ic.py
@@ -508,7 +508,7 @@ def test_sample_adiabat_arrays_returns_none_on_bad_input(tmp_path):
     assert _sample_adiabat_temperature_arrays(str(tmp_path), tf) is None
 
     # Non-monotone radii.
-    r, P = _write_structure_file(tmp_path)
+    _write_structure_file(tmp_path)
     data = np.loadtxt(out_path)
     data[5, 0] = data[3, 0]  # duplicate radius breaks strict monotonicity
     np.savetxt(out_path, data)
@@ -524,6 +524,14 @@ def test_sample_adiabat_arrays_returns_none_on_bad_input(tmp_path):
     # Closure returning non-finite temperatures.
     _write_structure_file(tmp_path)
     assert _sample_adiabat_temperature_arrays(str(tmp_path), lambda r, P: float('nan')) is None
+
+    # Closure raising outright (e.g. a P outside its tabulated span with a
+    # strict interpolator): degrade to the callable-only call, never raise.
+    def _raising_closure(r, P):
+        raise ValueError('P outside adiabat table span')
+
+    _write_structure_file(tmp_path)
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), _raising_closure) is None
 
 
 def test_adiabat_solve_hands_sampled_arrays_alongside_callable(tmp_path):

--- a/tests/interior_energetics/test_wrapper_adiabat_ic.py
+++ b/tests/interior_energetics/test_wrapper_adiabat_ic.py
@@ -11,6 +11,12 @@ internal linear-in-r temperature guess:
   captures zalmoxis_output.dat -> .prev, enforces the mass anchor and R_int
   validity, and on failure restores BOTH the hf_row keys AND the on-disk
   zalmoxis_output.dat so the next solver never reads the failed adiabat geometry.
+- ``_sample_adiabat_temperature_arrays``: samples the P-indexed adiabat closure
+  onto the previous structure's mantle (r, P) grid so the solve carries
+  r-indexed ``temperature_arrays`` alongside the callable and the Zalmoxis JAX
+  inner path can consume the adiabat on JAX-viable EOS layouts (issue #719);
+  returns None (callable-only degradation) on any missing or malformed
+  previous structure.
 - ``_resolve_adiabatic_ic_structure``: two-pass re-solve that hands the adiabat
   T(P) to the Zalmoxis numpy path, with mass-anchor enforcement and rollback to
   the linear-guess structure on failure.
@@ -65,6 +71,7 @@ from proteus.interior_energetics.wrapper import (
     _MONOTONIC_RINT_REL_TOL,
     _build_superliquidus_adiabat_tp,
     _resolve_adiabatic_ic_structure,
+    _sample_adiabat_temperature_arrays,
     _solve_structure_with_adiabat_or_rollback,
     _use_superliquidus_adiabat_ic,
     update_structure_from_interior,
@@ -405,6 +412,212 @@ def test_solve_helper_keeps_disk_geometry_on_success(tmp_path):
     # Accepted geometry survives: the relaxed radius and the new file content.
     assert hf_row['R_int'] == pytest.approx(1.2746e7, rel=1e-9)
     assert out_path.read_text() == adiabat_content
+
+
+# ============================================================================
+# _sample_adiabat_temperature_arrays: adiabat sampling for the JAX arrays path
+# ============================================================================
+
+
+def _write_structure_file(tmp_path, n=40, r0=6.0e6, r1=1.2007e7, p0=1.4e12, p1=1.0e5):
+    """Write a numeric zalmoxis_output.dat (mantle rows; columns r, P, rho, g, T).
+
+    Radii ascend from the CMB to the surface and pressure descends, matching
+    the file the previous structure solve writes. Returns the (r, P) columns.
+    """
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir(exist_ok=True)
+    r = np.linspace(r0, r1, n)
+    P = np.linspace(p0, p1, n)
+    rho = np.linspace(5500.0, 3300.0, n)
+    g = np.full(n, 10.0)
+    T = np.linspace(6200.0, 4000.0, n)
+    np.savetxt(
+        data_dir / 'zalmoxis_output.dat',
+        np.column_stack([r, P, rho, g, T]),
+    )
+    return r, P
+
+
+def _adiabat_closure():
+    """P-indexed adiabat closure over the _good_adiabat table (r is ignored)."""
+    adiabat = _good_adiabat()
+    P_arr, T_arr = adiabat['P'], adiabat['T']
+
+    def tf(r, P):
+        P_clipped = min(max(float(P), float(P_arr[0])), float(P_arr[-1]))
+        return float(np.interp(P_clipped, P_arr, T_arr))
+
+    return tf
+
+
+def test_sample_adiabat_arrays_matches_closure_on_previous_grid(tmp_path):
+    """The sampled arrays are the closure evaluated on the previous (r, P) grid.
+
+    The r axis is the previous structure's mantle radii (strictly increasing,
+    spanning CMB to surface, the domain the outer radius search perturbs
+    around; radii beyond it are endpoint-clamped by the JAX RHS), and every
+    T value equals the closure at that row's (r, P). Because the closure is
+    pressure-indexed and the file's P decreases outward, T decreases
+    monotonically toward the surface.
+    """
+    r_file, p_file = _write_structure_file(tmp_path)
+    tf = _adiabat_closure()
+
+    sampled = _sample_adiabat_temperature_arrays(str(tmp_path), tf)
+
+    assert sampled is not None
+    r_arr, t_arr = sampled
+    np.testing.assert_allclose(r_arr, r_file, rtol=0, atol=0)
+    assert np.all(np.diff(r_arr) > 0.0)
+    # Domain coverage: the sampling spans the previous mantle exactly.
+    assert r_arr[0] == pytest.approx(6.0e6, rel=1e-12)
+    assert r_arr[-1] == pytest.approx(1.2007e7, rel=1e-12)
+    # T pins to the closure row by row, and stays positive and finite.
+    expected = np.array([tf(r, P) for r, P in zip(r_file, p_file)])
+    np.testing.assert_allclose(t_arr, expected, rtol=1e-12)
+    assert np.all(np.isfinite(t_arr)) and np.all(t_arr > 0.0)
+    assert np.all(np.diff(t_arr) <= 0.0)
+    # Discrimination: sampling T at a fixed pressure (a plausible wrong
+    # implementation) would be constant; the true profile spans > 1000 K.
+    assert t_arr[0] - t_arr[-1] > 1000.0
+
+
+def test_sample_adiabat_arrays_returns_none_on_bad_input(tmp_path):
+    """Any missing or malformed previous structure degrades to None.
+
+    None routes the caller to the callable-only solve, the pre-#719 behavior,
+    so every guard here is a safety valve rather than an error path: missing
+    file, non-numeric content, non-monotone radii, non-finite pressure, and a
+    closure returning non-finite temperatures.
+    """
+    tf = _adiabat_closure()
+
+    # Missing file.
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), tf) is None
+
+    # Non-numeric content (the rollback tests write such placeholders).
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    out_path = data_dir / 'zalmoxis_output.dat'
+    out_path.write_text('LINEAR GEOMETRY placeholder\n')
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), tf) is None
+
+    # Single row: no interpolable grid.
+    np.savetxt(out_path, np.array([[6.0e6, 1.4e12, 5500.0, 10.0, 6200.0]]))
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), tf) is None
+
+    # Non-monotone radii.
+    r, P = _write_structure_file(tmp_path)
+    data = np.loadtxt(out_path)
+    data[5, 0] = data[3, 0]  # duplicate radius breaks strict monotonicity
+    np.savetxt(out_path, data)
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), tf) is None
+
+    # Non-finite pressure.
+    _write_structure_file(tmp_path)
+    data = np.loadtxt(out_path)
+    data[5, 1] = np.nan
+    np.savetxt(out_path, data)
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), tf) is None
+
+    # Closure returning non-finite temperatures.
+    _write_structure_file(tmp_path)
+    assert _sample_adiabat_temperature_arrays(str(tmp_path), lambda r, P: float('nan')) is None
+
+
+def test_adiabat_solve_hands_sampled_arrays_alongside_callable(tmp_path):
+    """The adiabat solve passes both the closure and its r-indexed sampling.
+
+    With a numeric previous structure on disk, the solver receives the same
+    callable object plus temperature_arrays sampled from it on the previous
+    (r, P) grid, so zalmoxis_solver's temperature-source dispatch decides the
+    JAX-vs-numpy question exactly as it does for evolved re-solves (#719).
+    """
+    r_file, p_file = _write_structure_file(tmp_path)
+    tf = _adiabat_closure()
+    config = _config()
+    hf_row = _linear_hf_row()
+    M_target = hf_row['M_int_target']
+
+    received = {}
+
+    def fake_solver(
+        cfg,
+        outdir,
+        row,
+        num_spider_nodes=0,
+        temperature_function=None,
+        temperature_arrays=None,
+        **kw,
+    ):
+        received['tf'] = temperature_function
+        received['arrays'] = temperature_arrays
+        row['R_int'] = 1.2746e7
+        row['M_int'] = M_target
+        return 6.0e6, str(tmp_path / 'adiabat_mesh.dat')
+
+    with patch('proteus.interior_struct.zalmoxis.zalmoxis_solver', side_effect=fake_solver):
+        _mesh, ok = _solve_structure_with_adiabat_or_rollback(
+            config,
+            str(tmp_path),
+            hf_row,
+            num_spider_nodes=0,
+            temperature_function=tf,
+        )
+
+    assert ok is True
+    # The callable still reaches the solver unmodified (non-JAX-viable
+    # configurations keep consuming it on the numpy path).
+    assert received['tf'] is tf
+    # The arrays ride alongside: previous r grid, closure-sampled T.
+    r_arr, t_arr = received['arrays']
+    np.testing.assert_allclose(r_arr, r_file, rtol=0, atol=0)
+    expected = np.array([tf(r, P) for r, P in zip(r_file, p_file)])
+    np.testing.assert_allclose(t_arr, expected, rtol=1e-12)
+
+
+def test_adiabat_solve_degrades_to_callable_only_without_previous_structure(tmp_path):
+    """Without a usable previous structure the solve carries the callable alone.
+
+    temperature_arrays arrives as None, which reproduces the pre-#719 call
+    exactly: the solver-side dispatch sees no arrays and keeps the callable on
+    the numpy path.
+    """
+    tf = _adiabat_closure()
+    config = _config()
+    hf_row = _linear_hf_row()
+    M_target = hf_row['M_int_target']
+
+    received = {}
+
+    def fake_solver(
+        cfg,
+        outdir,
+        row,
+        num_spider_nodes=0,
+        temperature_function=None,
+        temperature_arrays=None,
+        **kw,
+    ):
+        received['tf'] = temperature_function
+        received['arrays'] = temperature_arrays
+        row['R_int'] = 1.2746e7
+        row['M_int'] = M_target
+        return 6.0e6, str(tmp_path / 'adiabat_mesh.dat')
+
+    with patch('proteus.interior_struct.zalmoxis.zalmoxis_solver', side_effect=fake_solver):
+        _mesh, ok = _solve_structure_with_adiabat_or_rollback(
+            config,
+            str(tmp_path),
+            hf_row,
+            num_spider_nodes=0,
+            temperature_function=tf,
+        )
+
+    assert ok is True
+    assert received['tf'] is tf
+    assert received['arrays'] is None
 
 
 def test_adiabat_resolve_falls_back_when_adiabat_unavailable():

--- a/tests/interior_struct/test_zalmoxis.py
+++ b/tests/interior_struct/test_zalmoxis.py
@@ -1390,6 +1390,60 @@ def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(
     assert 0.0 < cmb_radius < hf_row['R_int']
 
 
+def test_zalmoxis_solver_init_adiabat_arrays_take_jax_dispatch(tmp_path, monkeypatch):
+    """IC adiabat calls with sampled arrays dispatch like evolved re-solves.
+
+    The liquidus_super IC hand-off (issue #719) passes the P-indexed
+    adiabat closure together with its r-indexed sampling on the previous
+    structure's grid. On a JAX-viable EOS the hoisted dispatch must make
+    the same decision it makes for evolved Aragog re-solves: withhold
+    the callable, feed the arrays to the JAX path, and run the
+    post-solve rebuild against them. The internal-mode init case (no
+    callable, no arrays) is pinned separately by
+    test_zalmoxis_solver_init_call_keeps_internal_mode_dispatch.
+    """
+    model_for_arrays = _plausible_model_results()
+    radii = np.asarray(model_for_arrays['radii'])
+    pressure = np.asarray(model_for_arrays['pressure'])
+    n = len(radii)
+    cmb_index = n // 3
+
+    # P-indexed adiabat closure: ignores r, monotone in P, the shape
+    # _build_superliquidus_adiabat_tp produces. The slope keeps the
+    # deep-mantle sample several hundred K away from the mocked solver
+    # column so the rebuilt-column assertion below discriminates.
+    def tf(r, P):
+        return 4000.0 + 4.0e-9 * float(P)
+
+    # Arrays sampled from the closure on the previous structure's mantle
+    # grid, the _sample_adiabat_temperature_arrays convention.
+    r_arr = radii[cmb_index:]
+    t_arr = np.array([tf(r, P) for r, P in zip(r_arr, pressure[cmb_index:])])
+
+    main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
+        tmp_path, monkeypatch, 'PALEOS:MgSiO3', (r_arr, t_arr), tf
+    )
+
+    # Same dispatch outcome as the evolved re-solve: callable withheld,
+    # arrays through, dry rebuild against the arrays.
+    kwargs = main_mock.call_args.kwargs
+    assert kwargs['temperature_function'] is None
+    passed_r, passed_t = kwargs['temperature_arrays']
+    np.testing.assert_allclose(passed_r, r_arr, rtol=0, atol=0)
+    np.testing.assert_allclose(passed_t, t_arr, rtol=0, atol=0)
+    assert rho_mock.call_count == len(model_results['radii'])
+    assert mixed_mock.call_count == 0
+
+    # The written temperature column carries the adiabat samples: the CMB
+    # row reads the sampled deep-mantle T, not the mocked solver column.
+    data = np.loadtxt(tmp_path / 'data' / 'zalmoxis_output.dat')
+    assert data[:, 4][0] == pytest.approx(float(t_arr[0]), rel=1e-6)
+    assert abs(float(t_arr[0]) - float(model_results['temperature'][cmb_index])) > 100.0
+
+    assert 0.0 < hf_row['M_core'] < hf_row['M_int']
+    assert 0.0 < cmb_radius < hf_row['R_int']
+
+
 def test_zalmoxis_solver_withholds_callable_on_wet_in_envelope_profile(tmp_path, monkeypatch):
     """In-envelope wet solves feed the arrays to the JAX path.
 

--- a/tests/interior_struct/test_zalmoxis.py
+++ b/tests/interior_struct/test_zalmoxis.py
@@ -1183,6 +1183,12 @@ def _cooled_mantle_arrays(model_results: dict) -> tuple[np.ndarray, np.ndarray]:
     return r_arr, t_arr
 
 
+# Constant offset between the fake blended density and the fake bare
+# density at equal (P, T): lets the gate tests discriminate which
+# evaluator wrote the rebuilt density column.
+_MIXED_DENSITY_OFFSET = 250.0
+
+
 def _run_gate_solver(
     tmp_path,
     monkeypatch,
@@ -1197,8 +1203,13 @@ def _run_gate_solver(
 
     Patches the EOS registry to the on-disk synthetic one, the melting
     curves to plausible constants, the Zalmoxis ``main`` solve to a
-    converged Earth-like result, and the EOS density dispatch used by
-    the post-solve column rebuild. Returns the mocks and the hf_row.
+    converged Earth-like result, and both density evaluators used by
+    the post-solve column rebuild: the bare EOS dispatch
+    (``calculate_density``, dry mantle and core nodes) and the blended
+    evaluator (``calculate_mixed_density``, wet mantle nodes). The two
+    fakes differ by a constant ``_MIXED_DENSITY_OFFSET`` at equal
+    (P, T), so a written column discriminates which evaluator produced
+    it. Returns the mocks and the hf_row.
 
     Parameters
     ----------
@@ -1242,6 +1253,11 @@ def _run_gate_solver(
         # Plausible monotone-in-P, decreasing-in-T condensed density.
         return 3300.0 + 2.0e-8 * float(P) - 0.1 * (float(T) - 3000.0)
 
+    def _fake_mixed_density(P, T, mixture, mats, sol, liq, interp, **kwargs):
+        # Bare fake plus a constant blend offset: distinguishable from
+        # _fake_density at the same (P, T).
+        return _fake_density(P, mats, None, T, sol, liq) + _MIXED_DENSITY_OFFSET
+
     with (
         patch.object(
             zalmoxis_wrapper,
@@ -1255,6 +1271,9 @@ def _run_gate_solver(
         ),
         patch.object(zalmoxis_wrapper, 'main', **main_patch_kwargs) as main_mock,
         patch('zalmoxis.eos.dispatch.calculate_density', side_effect=_fake_density) as rho_mock,
+        patch(
+            'zalmoxis.mixing.calculate_mixed_density', side_effect=_fake_mixed_density
+        ) as mixed_mock,
     ):
         cmb_radius, mesh_file = zalmoxis_wrapper.zalmoxis_solver(
             config,
@@ -1265,7 +1284,7 @@ def _run_gate_solver(
             temperature_arrays=temperature_arrays,
         )
 
-    return main_mock, rho_mock, hf_row, model_results, cmb_radius, mesh_file
+    return main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, mesh_file
 
 
 def test_zalmoxis_solver_passes_callable_when_jax_path_not_viable(tmp_path, monkeypatch):
@@ -1288,8 +1307,8 @@ def test_zalmoxis_solver_passes_callable_when_jax_path_not_viable(tmp_path, monk
             return float(t_arr[0])
         return float(np.interp(r, r_arr, t_arr))
 
-    main_mock, rho_mock, hf_row, model_results, cmb_radius, mesh_file = _run_gate_solver(
-        tmp_path, monkeypatch, 'Seager2007:silicate', (r_arr, t_arr), tf
+    main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, mesh_file = (
+        _run_gate_solver(tmp_path, monkeypatch, 'Seager2007:silicate', (r_arr, t_arr), tf)
     )
 
     # The callable passes through identically; the arrays ride along for
@@ -1336,7 +1355,7 @@ def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(
             return float(t_arr[0])
         return float(np.interp(r, r_arr, t_arr))
 
-    main_mock, rho_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
+    main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
         tmp_path, monkeypatch, mantle_eos, (r_arr, t_arr), tf
     )
 
@@ -1347,8 +1366,10 @@ def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(
     np.testing.assert_allclose(passed_r, r_arr, rtol=0, atol=0)
     np.testing.assert_allclose(passed_t, t_arr, rtol=0, atol=0)
 
-    # The rebuild ran: one EOS density evaluation per radial node.
+    # The rebuild ran: one bare EOS density evaluation per radial node,
+    # and no blended evaluation on a dry solve.
     assert rho_mock.call_count == len(model_results['radii'])
+    assert mixed_mock.call_count == 0
 
     # The written hand-off file carries the rebuilt (cooled) temperature
     # column: its surface value tracks the arrays, not the mocked solve
@@ -1376,9 +1397,12 @@ def test_zalmoxis_solver_withholds_callable_on_wet_in_envelope_profile(tmp_path,
     the ``VolatileProfile`` matches the Zalmoxis JAX wet envelope
     (one paleos_unified volatile blended into the mantle), so the
     external callable is withheld and the JAX RHS integrates against
-    the hand-off arrays. The dry-EOS post-solve rebuild must NOT run:
-    it evaluates the bare dry mantle EOS and would overwrite the
-    volatile-blended density column, so the solver's own columns stand.
+    the hand-off arrays. The post-solve rebuild must run
+    profile-aware: mantle nodes go through the blended evaluator
+    (``calculate_mixed_density`` with the profile), core nodes through
+    the bare EOS dispatch, and the written columns carry the hand-off
+    temperature and the blended density, matching what a
+    callable-driven numpy solve would have written.
     """
     model_for_arrays = _plausible_model_results()
     r_arr, t_arr = _cooled_mantle_arrays(model_for_arrays)
@@ -1395,7 +1419,7 @@ def test_zalmoxis_solver_withholds_callable_on_wet_in_envelope_profile(tmp_path,
         'M_mantle_solid': 1.0e24,
         'H2O_kg_liquid': 8.0e22,
     }
-    main_mock, rho_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
+    main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
         tmp_path,
         monkeypatch,
         'PALEOS-2phase:MgSiO3',
@@ -1413,19 +1437,34 @@ def test_zalmoxis_solver_withholds_callable_on_wet_in_envelope_profile(tmp_path,
     np.testing.assert_allclose(passed_r, r_arr, rtol=0, atol=0)
     np.testing.assert_allclose(passed_t, t_arr, rtol=0, atol=0)
 
-    # The dry-EOS rebuild must not run on a wet solve: the solver's
-    # volatile-blended density column stands.
-    assert rho_mock.call_count == 0
-
-    # The written hand-off file carries the solver's own temperature
-    # column, not a rebuilt one: the CMB row reads the mocked solver
-    # value (~5500 K at node 0), far from the 7740 K hand-off value the
-    # dry rebuild would have written.
-    data = np.loadtxt(tmp_path / 'data' / 'zalmoxis_output.dat')
+    # The rebuild ran profile-aware: every mantle node through the
+    # blended evaluator with this solve's profile, every core node
+    # through the bare EOS dispatch.
     n = len(model_results['radii'])
-    t_solver_cmb = float(model_results['temperature'][n // 3])
-    assert data[:, 4][0] == pytest.approx(t_solver_cmb, rel=1e-6)
-    assert abs(7740.0 - t_solver_cmb) > 3000.0
+    cmb_index = n // 3
+    assert mixed_mock.call_count == n - cmb_index
+    assert rho_mock.call_count == cmb_index
+    for call in mixed_mock.call_args_list:
+        assert call.kwargs['volatile_profile'] is kwargs['volatile_profile']
+        # The blend evaluates the extended mantle mixture, so the
+        # dissolved species is available to the per-shell fractions.
+        assert 'PALEOS:H2O' in call.args[2].components
+
+    # The written hand-off file carries the rebuilt columns. The CMB row
+    # temperature is the 7740 K hand-off value (the mocked solver column
+    # reads ~4500 K there, so the assertion cannot pass un-rebuilt), and
+    # the CMB row density is the blended fake at that (P, T), a constant
+    # _MIXED_DENSITY_OFFSET above the bare fake (the bare recompute
+    # cannot produce it).
+    data = np.loadtxt(tmp_path / 'data' / 'zalmoxis_output.dat')
+    t_column = data[:, 4]
+    assert t_column[0] == pytest.approx(7740.0, rel=1e-6)
+    t_mock_cmb = float(model_results['temperature'][cmb_index])
+    assert abs(7740.0 - t_mock_cmb) > 3000.0
+    p_cmb_row = float(data[:, 1][0])
+    rho_bare = 3300.0 + 2.0e-8 * p_cmb_row - 0.1 * (7740.0 - 3000.0)
+    assert data[:, 2][0] == pytest.approx(rho_bare + _MIXED_DENSITY_OFFSET, rel=1e-9)
+    assert abs(float(data[:, 2][0]) - rho_bare) > 0.5 * _MIXED_DENSITY_OFFSET
 
     # Vacuous-pass guard: the profile was actually built and handed to
     # the solve (a None profile would satisfy the dispatch trivially),
@@ -1474,7 +1513,7 @@ def test_zalmoxis_solver_keeps_callable_on_wet_out_of_envelope_profile(tmp_path,
         'M_mantle_solid': 1.0e24,
         'H2_kg_liquid': 4.0e22,
     }
-    main_mock, rho_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
+    main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
         tmp_path,
         monkeypatch,
         'PALEOS-2phase:MgSiO3',
@@ -1492,8 +1531,9 @@ def test_zalmoxis_solver_keeps_callable_on_wet_out_of_envelope_profile(tmp_path,
     np.testing.assert_allclose(passed_r, r_arr, rtol=0, atol=0)
     np.testing.assert_allclose(passed_t, t_arr, rtol=0, atol=0)
 
-    # No rebuild on the honored-callable path.
+    # No rebuild on the honored-callable path, bare or blended.
     assert rho_mock.call_count == 0
+    assert mixed_mock.call_count == 0
 
     # Vacuous-pass guard: the profile was actually built and carries the
     # rejected volatile.
@@ -1517,7 +1557,7 @@ def test_zalmoxis_solver_init_call_keeps_internal_mode_dispatch(tmp_path, monkey
     pins the limit-input behavior of the gate: the dispatch fix applies
     only to re-solves that actually carry an evolved profile.
     """
-    main_mock, rho_mock, hf_row, model_results, _, _ = _run_gate_solver(
+    main_mock, rho_mock, _mixed_mock, hf_row, model_results, _, _ = _run_gate_solver(
         tmp_path, monkeypatch, 'PALEOS-2phase:MgSiO3', None, None
     )
 
@@ -1567,7 +1607,7 @@ def test_zalmoxis_solver_retry_replaces_density_and_gravity(tmp_path, monkeypatc
             return float(t_arr[0])
         return float(np.interp(r, r_arr, t_arr))
 
-    main_mock, rho_mock, hf_row, _, cmb_radius, _ = _run_gate_solver(
+    main_mock, rho_mock, _mixed_mock, hf_row, _, cmb_radius, _ = _run_gate_solver(
         tmp_path,
         monkeypatch,
         'Seager2007:silicate',

--- a/tests/interior_struct/test_zalmoxis.py
+++ b/tests/interior_struct/test_zalmoxis.py
@@ -1198,6 +1198,7 @@ def _run_gate_solver(
     main_results=None,
     dry_mantle=True,
     hf_extra=None,
+    mixed_side_effect=None,
 ):
     """Invoke zalmoxis_solver with the heavy solve mocked out.
 
@@ -1224,6 +1225,10 @@ def _run_gate_solver(
     hf_extra : dict, optional
         Extra hf_row keys merged over the default surface-pressure row
         (e.g. mantle phase masses and dissolved volatile masses).
+    mixed_side_effect : callable, optional
+        Replacement side effect for the blended evaluator, e.g. to make
+        selected nodes return non-finite densities. Defaults to the
+        offset fake.
     """
     from proteus.interior_struct import zalmoxis as zalmoxis_wrapper
 
@@ -1272,7 +1277,8 @@ def _run_gate_solver(
         patch.object(zalmoxis_wrapper, 'main', **main_patch_kwargs) as main_mock,
         patch('zalmoxis.eos.dispatch.calculate_density', side_effect=_fake_density) as rho_mock,
         patch(
-            'zalmoxis.mixing.calculate_mixed_density', side_effect=_fake_mixed_density
+            'zalmoxis.mixing.calculate_mixed_density',
+            side_effect=mixed_side_effect or _fake_mixed_density,
         ) as mixed_mock,
     ):
         cmb_radius, mesh_file = zalmoxis_wrapper.zalmoxis_solver(
@@ -1531,6 +1537,70 @@ def test_zalmoxis_solver_withholds_callable_on_wet_in_envelope_profile(tmp_path,
     # Structure scalars from the converged solve stay bounded either way.
     assert 0.0 < hf_row['M_core'] < hf_row['M_int']
     assert 0.0 < cmb_radius < hf_row['R_int']
+
+
+def test_wet_rebuild_falls_back_to_solver_density_on_non_finite_blend(tmp_path, monkeypatch):
+    """A non-finite blended density falls back to the solver's column value.
+
+    Near the edge of a volatile EOS table the blend can return NaN for a
+    node the solver itself filled through its own out-of-range handling,
+    so the rebuild must keep that node's solver density instead of
+    writing NaN into the hand-off file Aragog reads. Discrimination: the
+    poisoned node carries the solver column value (which the offset fake
+    cannot produce at that (P, T)), every other mantle node carries the
+    blended fake, and no NaN reaches the written file.
+    """
+    model_for_arrays = _plausible_model_results()
+    r_arr, t_arr = _cooled_mantle_arrays(model_for_arrays)
+
+    def tf(r, P):
+        if r <= r_arr[0]:
+            return float(t_arr[0])
+        return float(np.interp(r, r_arr, t_arr))
+
+    calls = {'n': 0}
+
+    def _nan_first_blend(P, T, mixture, mats, sol, liq, interp, **kwargs):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            return float('nan')
+        return 3300.0 + 2.0e-8 * float(P) - 0.1 * (float(T) - 3000.0) + _MIXED_DENSITY_OFFSET
+
+    hf_extra = {
+        'M_mantle_liquid': 4.0e24,
+        'M_mantle_solid': 1.0e24,
+        'H2O_kg_liquid': 8.0e22,
+    }
+    main_mock, rho_mock, mixed_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
+        tmp_path,
+        monkeypatch,
+        'PALEOS-2phase:MgSiO3',
+        (r_arr, t_arr),
+        tf,
+        dry_mantle=False,
+        hf_extra=hf_extra,
+        mixed_side_effect=_nan_first_blend,
+    )
+
+    n = len(model_results['radii'])
+    cmb_index = n // 3
+    assert mixed_mock.call_count == n - cmb_index
+
+    data = np.loadtxt(tmp_path / 'data' / 'zalmoxis_output.dat')
+    rho_column = data[:, 2]
+    assert np.all(np.isfinite(rho_column))
+    # The poisoned first mantle node keeps the solver's column density.
+    solver_rho_cmb = float(model_results['density'][cmb_index])
+    assert rho_column[0] == pytest.approx(solver_rho_cmb, rel=1e-9)
+    # The next node carries the blended fake at the hand-off temperature,
+    # so the fallback is per node, not a whole-column bailout.
+    p_next = float(data[1, 1])
+    t_next = float(data[1, 4])
+    rho_blend_next = 3300.0 + 2.0e-8 * p_next - 0.1 * (t_next - 3000.0) + _MIXED_DENSITY_OFFSET
+    assert rho_column[1] == pytest.approx(rho_blend_next, rel=1e-9)
+    # Discrimination: the solver density and the blended fake differ by
+    # far more than the tolerances above at the poisoned node.
+    assert abs(solver_rho_cmb - rho_blend_next) > 0.5 * _MIXED_DENSITY_OFFSET
 
 
 def test_zalmoxis_solver_keeps_callable_on_wet_out_of_envelope_profile(tmp_path, monkeypatch):

--- a/tests/interior_struct/test_zalmoxis.py
+++ b/tests/interior_struct/test_zalmoxis.py
@@ -771,17 +771,25 @@ def _gate_registry(tmp_path) -> dict:
     sol = tmp_path / 'mgsio3_solid.dat'
     liq = tmp_path / 'mgsio3_liquid.dat'
     water = tmp_path / 'h2o_unified.dat'
-    for f in (iron, unified, sol, liq, water):
+    hydrogen = tmp_path / 'chabrier_h.dat'
+    seager_sil = tmp_path / 'seager_silicate.txt'
+    for f in (iron, unified, sol, liq, water, hydrogen, seager_sil):
         f.write_text('eos table stub')
     return {
         'PALEOS:iron': {'eos_file': str(iron), 'format': 'paleos_unified'},
         'PALEOS:MgSiO3': {'eos_file': str(unified), 'format': 'paleos_unified'},
         'PALEOS:H2O': {'eos_file': str(water), 'format': 'paleos_unified'},
+        # Same shape as the production registry entry: unified format, but
+        # the JAX wet path rejects it by name (binodal suppression).
+        'Chabrier:H': {'eos_file': str(hydrogen), 'format': 'paleos_unified'},
         'PALEOS-2phase:MgSiO3': {
             'core': {'eos_file': str(iron)},
             'melted_mantle': {'eos_file': str(liq), 'format': 'paleos'},
             'solid_mantle': {'eos_file': str(sol), 'format': 'paleos'},
         },
+        # Flat entry with neither the unified format nor phase sub-tables:
+        # no JAX representation, the numpy ODE handles it.
+        'Seager2007:silicate': {'eos_file': str(seager_sil)},
     }
 
 
@@ -789,24 +797,40 @@ def test_jax_structure_viability_predicate(tmp_path):
     """JAX-path viability tracks the registry layout, not the config flags.
 
     The predicate must reproduce the precondition outcome of Zalmoxis'
-    JAX dispatch: True only for a 2-phase mantle (both phase sub-tables)
-    paired with a core that resolves to the unified PALEOS format.
-    Edge cases: unknown registry keys (conservative False, keeping the
-    temperature callable in play), a ``paleos_api`` core (resolves in
-    place to ``paleos_unified``, so True), and a volatile-extended
-    mantle string whose fraction token must be stripped before lookup.
+    JAX dispatch: True for a unified PALEOS mantle (flat entry, format
+    ``paleos_unified`` with an ``eos_file``) or a 2-phase mantle (both
+    phase sub-tables), paired with a core that resolves to the unified
+    PALEOS format. Edge cases: unknown registry keys (conservative
+    False, keeping the temperature callable in play), ``paleos_api``
+    entries (resolve in place to ``paleos_unified``, so True), a
+    unified entry without an ``eos_file`` (the wrapper raises, so
+    False), and a volatile-extended mantle string whose fraction token
+    must be stripped before lookup.
     """
     from proteus.interior_struct.zalmoxis import _zalmoxis_jax_structure_viable
 
     registry = _gate_registry(tmp_path)
 
-    # Unified mantle has no phase sub-tables: the JAX dispatch raises and
-    # the numpy ODE runs, so the predicate must be False.
-    assert _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'PALEOS:MgSiO3') is False
+    # Unified mantle (flat paleos_unified entry): the JAX path can run.
+    assert _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'PALEOS:MgSiO3') is True
 
     # 2-phase mantle + unified core: the JAX path can run.
     assert (
         _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'PALEOS-2phase:MgSiO3') is True
+    )
+
+    # Flat mantle entry with neither the unified format nor phase
+    # sub-tables: the JAX dispatch raises and the numpy ODE runs.
+    assert (
+        _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'Seager2007:silicate') is False
+    )
+
+    # A unified mantle entry without an eos_file cannot be cached by the
+    # wrapper (it raises), so the predicate must be False.
+    registry_nofile = dict(registry)
+    registry_nofile['PALEOS:MgSiO3'] = {'format': 'paleos_unified'}
+    assert (
+        _zalmoxis_jax_structure_viable(registry_nofile, 'PALEOS:iron', 'PALEOS:MgSiO3') is False
     )
 
     # Missing registry entries (mantle or core): conservative False.
@@ -816,13 +840,17 @@ def test_jax_structure_viability_predicate(tmp_path):
     )
     assert _zalmoxis_jax_structure_viable({}, 'PALEOS:iron', 'PALEOS-2phase:MgSiO3') is False
 
-    # A paleos_api core materialises to paleos_unified before the JAX
-    # dispatch checks it, so it qualifies.
+    # paleos_api entries materialise to paleos_unified before the JAX
+    # dispatch checks them, so they qualify on either layer.
     registry_api = dict(registry)
     registry_api['PALEOS-API:iron'] = {'format': 'paleos_api', 'material': 'iron'}
+    registry_api['PALEOS-API:MgSiO3'] = {'format': 'paleos_api', 'material': 'mgsio3'}
     assert (
         _zalmoxis_jax_structure_viable(registry_api, 'PALEOS-API:iron', 'PALEOS-2phase:MgSiO3')
         is True
+    )
+    assert (
+        _zalmoxis_jax_structure_viable(registry_api, 'PALEOS:iron', 'PALEOS-API:MgSiO3') is True
     )
 
     # A non-unified core (Seager nested layout, no top-level format)
@@ -841,6 +869,9 @@ def test_jax_structure_viability_predicate(tmp_path):
     assert (
         _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'PALEOS-2phase:MgSiO3:0.9800')
         is True
+    )
+    assert (
+        _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'PALEOS:MgSiO3:0.9800') is True
     )
 
 
@@ -1019,14 +1050,15 @@ def _run_gate_solver(
 
 
 def test_zalmoxis_solver_passes_callable_when_jax_path_not_viable(tmp_path, monkeypatch):
-    """Unified-mantle re-solves hand the evolved T(r) callable to the solve.
+    """Non-viable-mantle re-solves hand the evolved T(r) callable to the solve.
 
-    With ``use_jax=True``, ``temperature_arrays`` supplied, and a unified
-    PALEOS mantle (no phase sub-tables), the JAX dispatch cannot run and
-    the numpy ODE consumes only ``temperature_function``. The callable
-    must therefore reach the solve unmodified; nulling it would make
-    every re-solve rebuild the internal hot-anchor profile and freeze
-    the interior radius across the entire crystallization sequence.
+    With ``use_jax=True``, ``temperature_arrays`` supplied, and a mantle
+    whose registry entry is neither unified PALEOS nor 2-phase PALEOS,
+    the JAX dispatch cannot run and the numpy ODE consumes only
+    ``temperature_function``. The callable must therefore reach the
+    solve unmodified; nulling it would make every re-solve rebuild the
+    internal hot-anchor profile and freeze the interior radius across
+    the entire crystallization sequence.
     """
     model_for_arrays = _plausible_model_results()
     r_arr, t_arr = _cooled_mantle_arrays(model_for_arrays)
@@ -1038,7 +1070,7 @@ def test_zalmoxis_solver_passes_callable_when_jax_path_not_viable(tmp_path, monk
         return float(np.interp(r, r_arr, t_arr))
 
     main_mock, rho_mock, hf_row, model_results, cmb_radius, mesh_file = _run_gate_solver(
-        tmp_path, monkeypatch, 'PALEOS:MgSiO3', (r_arr, t_arr), tf
+        tmp_path, monkeypatch, 'Seager2007:silicate', (r_arr, t_arr), tf
     )
 
     # The callable passes through identically; the arrays ride along for
@@ -1063,10 +1095,14 @@ def test_zalmoxis_solver_passes_callable_when_jax_path_not_viable(tmp_path, monk
     assert mesh_file is None  # num_spider_nodes=0 requests no SPIDER mesh
 
 
-def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(tmp_path, monkeypatch):
-    """2-phase-mantle re-solves feed the arrays to the JAX path instead.
+@pytest.mark.parametrize('mantle_eos', ['PALEOS-2phase:MgSiO3', 'PALEOS:MgSiO3'])
+def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(
+    tmp_path, monkeypatch, mantle_eos
+):
+    """JAX-viable-mantle re-solves feed the arrays to the JAX path instead.
 
-    With a 2-phase PALEOS mantle the JAX dispatch consumes
+    With a JAX-capable mantle layout (2-phase PALEOS sub-tables or the
+    unified PALEOS table) the JAX dispatch consumes
     ``temperature_arrays``, so the external callable is withheld (the
     inner Picard converges on the internal linear-T profile) and the
     post-solve rebuild rewrites the density and temperature columns
@@ -1082,7 +1118,7 @@ def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(tmp_path, monkeypa
         return float(np.interp(r, r_arr, t_arr))
 
     main_mock, rho_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
-        tmp_path, monkeypatch, 'PALEOS-2phase:MgSiO3', (r_arr, t_arr), tf
+        tmp_path, monkeypatch, mantle_eos, (r_arr, t_arr), tf
     )
 
     # Callable withheld, arrays passed through.
@@ -1227,6 +1263,8 @@ def test_zalmoxis_solver_retry_replaces_density_and_gravity(tmp_path, monkeypatc
     Aragog reads from zalmoxis_output.dat for its cell masses) must then
     reflect the retry solution, not the failed primary's. Self-consistency
     of the written structure (rho, g, M from one solve) is the invariant.
+    The mantle layout is not JAX-viable, so the callable is honored on
+    both the primary and the retry (the gate applies to each unchanged).
     """
     retry_results = _plausible_model_results()
     primary_results = _plausible_model_results()
@@ -1247,7 +1285,7 @@ def test_zalmoxis_solver_retry_replaces_density_and_gravity(tmp_path, monkeypatc
     main_mock, rho_mock, hf_row, _, cmb_radius, _ = _run_gate_solver(
         tmp_path,
         monkeypatch,
-        'PALEOS:MgSiO3',
+        'Seager2007:silicate',
         (r_arr, t_arr),
         tf,
         main_results=[primary_results, retry_results],

--- a/tests/interior_struct/test_zalmoxis.py
+++ b/tests/interior_struct/test_zalmoxis.py
@@ -875,6 +875,225 @@ def test_jax_structure_viability_predicate(tmp_path):
     )
 
 
+_WET_GATE_REGISTRY = {
+    'PALEOS:H2O': {'eos_file': 'h2o_unified.dat', 'format': 'paleos_unified'},
+    # Same shape as the production entry; the wet envelope rejects it by
+    # name, not by format.
+    'Chabrier:H': {'eos_file': 'chabrier_h.dat', 'format': 'paleos_unified'},
+    # Live-tabulated entry: materialises to paleos_unified in place.
+    'PALEOS-API:H2O': {'format': 'paleos_api', 'material': 'h2o'},
+    # 2-phase style format: the JAX wet path has no reader for it.
+    'WolfBower2018:H2O': {'eos_file': 'wb_h2o.dat', 'format': 'paleos'},
+}
+
+_WET_GATE_MANTLE = 'PALEOS:MgSiO3:0.9800+PALEOS:H2O:0.0200'
+
+
+def _make_profile(**overrides):
+    """Real Zalmoxis VolatileProfile, default in-envelope (H2O in melt)."""
+    from zalmoxis.mixing import VolatileProfile
+
+    kwargs = {
+        'w_liquid': {'PALEOS:H2O': 0.02},
+        'w_solid': {},
+        'primary_component': 'PALEOS:MgSiO3',
+    }
+    kwargs.update(overrides)
+    return VolatileProfile(**kwargs)
+
+
+def test_volatile_profile_jax_viable_accepts_in_envelope_profiles():
+    """The wet-envelope predicate accepts what the Zalmoxis JAX path runs.
+
+    In-envelope means a single active paleos_unified volatile blended
+    into the mantle through the profile, with no binodal or miscibility
+    physics. Melt-only and solid-only weights both count as active, a
+    zero-weight primary entry contributes nothing and is tolerated, and
+    a paleos_api volatile qualifies because it materialises to
+    paleos_unified in place.
+    """
+    from proteus.interior_struct.zalmoxis import _volatile_profile_jax_viable
+
+    # Single H2O volatile in the melt: the canonical wet solve.
+    assert (
+        _volatile_profile_jax_viable(_make_profile(), _WET_GATE_REGISTRY, _WET_GATE_MANTLE)
+        is True
+    )
+
+    # Solid-phase weight alone also makes the volatile active.
+    solid_only = _make_profile(w_liquid={}, w_solid={'PALEOS:H2O': 0.005})
+    assert (
+        _volatile_profile_jax_viable(solid_only, _WET_GATE_REGISTRY, _WET_GATE_MANTLE) is True
+    )
+
+    # A zero-weight primary entry contributes nothing in the blend and
+    # is tolerated by the wrapper.
+    zero_primary = _make_profile(w_liquid={'PALEOS:H2O': 0.02, 'PALEOS:MgSiO3': 0.0})
+    assert (
+        _volatile_profile_jax_viable(zero_primary, _WET_GATE_REGISTRY, _WET_GATE_MANTLE) is True
+    )
+
+    # A paleos_api volatile materialises to paleos_unified in place.
+    api_vol = _make_profile(w_liquid={'PALEOS-API:H2O': 0.02})
+    assert (
+        _volatile_profile_jax_viable(
+            api_vol, _WET_GATE_REGISTRY, 'PALEOS:MgSiO3:0.9800+PALEOS-API:H2O:0.0200'
+        )
+        is True
+    )
+
+
+def test_volatile_profile_jax_viable_rejects_out_of_envelope_profiles():
+    """The wet-envelope predicate is False for every wrapper rejection.
+
+    Each case mirrors one ValueError branch of the Zalmoxis wet-mantle
+    validation (or of the volatile cache load that follows it): the
+    numpy fallback fires inside Zalmoxis, so the callable must stay in
+    play. Unknown or malformed input also reads False, the conservative
+    answer.
+    """
+    from proteus.interior_struct.zalmoxis import _volatile_profile_jax_viable
+
+    reg = _WET_GATE_REGISTRY
+    mantle = _WET_GATE_MANTLE
+
+    # No profile: nothing to blend (callers gate the dry case separately).
+    assert _volatile_profile_jax_viable(None, reg, mantle) is False
+
+    # Binodal-controlled profiles: global miscibility or x_interior.
+    assert (
+        _volatile_profile_jax_viable(_make_profile(global_miscibility=True), reg, mantle)
+        is False
+    )
+    assert (
+        _volatile_profile_jax_viable(_make_profile(x_interior={'Chabrier:H': 0.1}), reg, mantle)
+        is False
+    )
+
+    # Nonzero weight on the primary silicate (either phase).
+    assert (
+        _volatile_profile_jax_viable(
+            _make_profile(w_liquid={'PALEOS:H2O': 0.02, 'PALEOS:MgSiO3': 0.5}), reg, mantle
+        )
+        is False
+    )
+    assert (
+        _volatile_profile_jax_viable(_make_profile(w_solid={'PALEOS:MgSiO3': 0.5}), reg, mantle)
+        is False
+    )
+
+    # Primary component absent from the mantle mixture string.
+    assert (
+        _volatile_profile_jax_viable(
+            _make_profile(primary_component='RTPress100TPa:MgSiO3'), reg, mantle
+        )
+        is False
+    )
+
+    # No active volatile: zero weights, or a volatile that is not a
+    # component of the mantle mixture.
+    assert (
+        _volatile_profile_jax_viable(_make_profile(w_liquid={'PALEOS:H2O': 0.0}), reg, mantle)
+        is False
+    )
+    assert _volatile_profile_jax_viable(_make_profile(), reg, 'PALEOS:MgSiO3') is False
+
+    # More than one active volatile in the mixture.
+    two_vols = _make_profile(w_liquid={'PALEOS:H2O': 0.02, 'Chabrier:H': 0.01})
+    assert (
+        _volatile_profile_jax_viable(
+            two_vols, reg, 'PALEOS:MgSiO3:0.9700+PALEOS:H2O:0.0200+Chabrier:H:0.0100'
+        )
+        is False
+    )
+
+    # An unmanaged extra mixture component keeps its fraction only on
+    # the numpy path.
+    assert (
+        _volatile_profile_jax_viable(
+            _make_profile(), reg, 'PALEOS:MgSiO3:0.9600+PALEOS:H2O:0.0200+PALEOS:iron:0.0200'
+        )
+        is False
+    )
+
+    # Chabrier:H as the single active volatile: rejected by name (its
+    # binodal suppression factor is not ported to the JAX RHS).
+    h2 = _make_profile(w_liquid={'Chabrier:H': 0.02})
+    assert (
+        _volatile_profile_jax_viable(h2, reg, 'PALEOS:MgSiO3:0.9800+Chabrier:H:0.0200') is False
+    )
+
+    # Volatile registry entry missing, non-unified, or without eos_file.
+    assert _volatile_profile_jax_viable(_make_profile(), {}, mantle) is False
+    wb = _make_profile(w_liquid={'WolfBower2018:H2O': 0.02})
+    assert (
+        _volatile_profile_jax_viable(wb, reg, 'PALEOS:MgSiO3:0.9800+WolfBower2018:H2O:0.0200')
+        is False
+    )
+    reg_nofile = dict(reg)
+    reg_nofile['PALEOS:H2O'] = {'format': 'paleos_unified'}
+    assert _volatile_profile_jax_viable(_make_profile(), reg_nofile, mantle) is False
+
+    # Malformed profile object: conservative False, not an exception.
+    assert _volatile_profile_jax_viable(object(), reg, mantle) is False
+
+
+@pytest.mark.reference_pinned
+def test_volatile_profile_predicate_matches_zalmoxis_wet_envelope():
+    """Cross-check the PROTEUS wet-envelope predicate against Zalmoxis.
+
+    Pins ``_volatile_profile_jax_viable`` to the accept/reject behavior
+    of ``zalmoxis.jax_eos.wrapper._validate_wet_mantle`` (fwl-zalmoxis
+    >= 26.07.13), the authoritative envelope check the Zalmoxis JAX
+    dispatch runs on the same profiles. A drift between the two would
+    either drop the callable on a solve that falls back to numpy (the
+    hot-anchor physics bug) or keep JAX-viable solves on the slow numpy
+    path, so the two implementations must agree on every profile whose
+    registry entry passes the format check both sides share.
+    """
+    wrapper = pytest.importorskip('zalmoxis.jax_eos.wrapper')
+    mixing = pytest.importorskip('zalmoxis.mixing')
+    from proteus.interior_struct.zalmoxis import _volatile_profile_jax_viable
+
+    validate = getattr(wrapper, '_validate_wet_mantle', None)
+    if validate is None:
+        pytest.skip('installed zalmoxis does not expose _validate_wet_mantle')
+
+    def zalmoxis_accepts(profile, mantle_string):
+        mixture = mixing.parse_layer_components(mantle_string)
+        try:
+            validate(profile, mixture, _WET_GATE_REGISTRY)
+        except ValueError:
+            return False
+        return True
+
+    cases = [
+        # (profile, extended mantle EOS string, expected viability)
+        (_make_profile(), _WET_GATE_MANTLE, True),
+        (
+            _make_profile(w_liquid={'Chabrier:H': 0.02}),
+            'PALEOS:MgSiO3:0.9800+Chabrier:H:0.0200',
+            False,
+        ),
+        (_make_profile(global_miscibility=True), _WET_GATE_MANTLE, False),
+        (
+            _make_profile(w_liquid={'PALEOS:H2O': 0.02, 'PALEOS:MgSiO3': 0.5}),
+            _WET_GATE_MANTLE,
+            False,
+        ),
+        (
+            _make_profile(w_liquid={'PALEOS:H2O': 0.02, 'Chabrier:H': 0.01}),
+            'PALEOS:MgSiO3:0.9700+PALEOS:H2O:0.0200+Chabrier:H:0.0100',
+            False,
+        ),
+    ]
+    for profile, mantle_string, expected in cases:
+        assert zalmoxis_accepts(profile, mantle_string) is expected
+        assert (
+            _volatile_profile_jax_viable(profile, _WET_GATE_REGISTRY, mantle_string) is expected
+        )
+
+
 def _gate_config(mantle_eos: str):
     """MagicMock config for the temperature-source dispatch tests.
 
@@ -1150,17 +1369,86 @@ def test_zalmoxis_solver_withholds_callable_on_jax_viable_eos(
     assert 0.0 < cmb_radius < hf_row['R_int']
 
 
-def test_zalmoxis_solver_keeps_callable_on_wet_jax_viable_eos(tmp_path, monkeypatch):
-    """Wet solves keep the evolved T(r) callable even on a JAX-viable EOS.
+def test_zalmoxis_solver_withholds_callable_on_wet_in_envelope_profile(tmp_path, monkeypatch):
+    """In-envelope wet solves feed the arrays to the JAX path.
 
-    With ``dry_mantle = false`` and a dissolved inventory, the solve
-    carries a ``VolatileProfile`` and must consume the callable on the
-    numpy path: the arrays hand-off and the post-solve rebuild recompute
-    density from the bare dry mantle EOS, which would overwrite the
-    volatile-blended density column. The EOS pair here is identical to
-    the dry withhold test above, so the retained callable and skipped
-    rebuild discriminate exactly the ``volatile_profile`` conjunct of
-    the dispatch.
+    With ``dry_mantle = false`` and a single dissolved H2O inventory,
+    the ``VolatileProfile`` matches the Zalmoxis JAX wet envelope
+    (one paleos_unified volatile blended into the mantle), so the
+    external callable is withheld and the JAX RHS integrates against
+    the hand-off arrays. The dry-EOS post-solve rebuild must NOT run:
+    it evaluates the bare dry mantle EOS and would overwrite the
+    volatile-blended density column, so the solver's own columns stand.
+    """
+    model_for_arrays = _plausible_model_results()
+    r_arr, t_arr = _cooled_mantle_arrays(model_for_arrays)
+
+    def tf(r, P):
+        if r <= r_arr[0]:
+            return float(t_arr[0])
+        return float(np.interp(r, r_arr, t_arr))
+
+    # Dissolved inventory: 2% of the liquid mantle mass as H2O, so
+    # build_volatile_profile returns a profile instead of None.
+    hf_extra = {
+        'M_mantle_liquid': 4.0e24,
+        'M_mantle_solid': 1.0e24,
+        'H2O_kg_liquid': 8.0e22,
+    }
+    main_mock, rho_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
+        tmp_path,
+        monkeypatch,
+        'PALEOS-2phase:MgSiO3',
+        (r_arr, t_arr),
+        tf,
+        dry_mantle=False,
+        hf_extra=hf_extra,
+    )
+
+    # Callable withheld, arrays passed through: the wet JAX envelope
+    # accepts the single-H2O profile.
+    kwargs = main_mock.call_args.kwargs
+    assert kwargs['temperature_function'] is None
+    passed_r, passed_t = kwargs['temperature_arrays']
+    np.testing.assert_allclose(passed_r, r_arr, rtol=0, atol=0)
+    np.testing.assert_allclose(passed_t, t_arr, rtol=0, atol=0)
+
+    # The dry-EOS rebuild must not run on a wet solve: the solver's
+    # volatile-blended density column stands.
+    assert rho_mock.call_count == 0
+
+    # The written hand-off file carries the solver's own temperature
+    # column, not a rebuilt one: the CMB row reads the mocked solver
+    # value (~5500 K at node 0), far from the 7740 K hand-off value the
+    # dry rebuild would have written.
+    data = np.loadtxt(tmp_path / 'data' / 'zalmoxis_output.dat')
+    n = len(model_results['radii'])
+    t_solver_cmb = float(model_results['temperature'][n // 3])
+    assert data[:, 4][0] == pytest.approx(t_solver_cmb, rel=1e-6)
+    assert abs(7740.0 - t_solver_cmb) > 3000.0
+
+    # Vacuous-pass guard: the profile was actually built and handed to
+    # the solve (a None profile would satisfy the dispatch trivially),
+    # and the mantle EOS string was extended with the dissolved species
+    # so the per-shell blend has the volatile component available.
+    assert kwargs['volatile_profile'] is not None
+    solver_params = main_mock.call_args.args[0]
+    assert '+PALEOS:H2O:' in solver_params['layer_eos_config']['mantle']
+
+    # Structure scalars from the converged solve stay bounded either way.
+    assert 0.0 < hf_row['M_core'] < hf_row['M_int']
+    assert 0.0 < cmb_radius < hf_row['R_int']
+
+
+def test_zalmoxis_solver_keeps_callable_on_wet_out_of_envelope_profile(tmp_path, monkeypatch):
+    """Out-of-envelope wet solves keep the evolved T(r) callable.
+
+    A dissolved H2 inventory builds a ``VolatileProfile`` carrying
+    ``Chabrier:H``, which the Zalmoxis JAX wet path rejects (the binodal
+    suppression factor is not ported), so the solve must consume the
+    callable on the numpy path. The EOS pair is identical to the
+    in-envelope test above, so the retained callable discriminates
+    exactly the wet-envelope conjunct of the dispatch.
     """
     from proteus.interior_struct.zalmoxis import _zalmoxis_jax_structure_viable
 
@@ -1172,19 +1460,19 @@ def test_zalmoxis_solver_keeps_callable_on_wet_jax_viable_eos(tmp_path, monkeypa
             return float(t_arr[0])
         return float(np.interp(r, r_arr, t_arr))
 
-    # Discrimination guard: this EOS pair is JAX-viable, so only the wet
-    # conjunct can keep the callable in play below.
+    # Discrimination guard: this EOS pair is JAX-viable, so only the
+    # wet-envelope conjunct can keep the callable in play below.
     registry = _gate_registry(tmp_path)
     assert (
         _zalmoxis_jax_structure_viable(registry, 'PALEOS:iron', 'PALEOS-2phase:MgSiO3') is True
     )
 
-    # Dissolved inventory: 2% of the liquid mantle mass as H2O, so
-    # build_volatile_profile returns a profile instead of None.
+    # Dissolved inventory: H2 only, so the profile's single active
+    # volatile is Chabrier:H and the wet envelope rejects it.
     hf_extra = {
         'M_mantle_liquid': 4.0e24,
         'M_mantle_solid': 1.0e24,
-        'H2O_kg_liquid': 8.0e22,
+        'H2_kg_liquid': 4.0e22,
     }
     main_mock, rho_mock, hf_row, model_results, cmb_radius, _ = _run_gate_solver(
         tmp_path,
@@ -1204,17 +1492,14 @@ def test_zalmoxis_solver_keeps_callable_on_wet_jax_viable_eos(tmp_path, monkeypa
     np.testing.assert_allclose(passed_r, r_arr, rtol=0, atol=0)
     np.testing.assert_allclose(passed_t, t_arr, rtol=0, atol=0)
 
-    # The dry-EOS rebuild must not run: the solver's volatile-blended
-    # density column stands.
+    # No rebuild on the honored-callable path.
     assert rho_mock.call_count == 0
 
-    # Vacuous-pass guard: the profile was actually built and handed to
-    # the solve (a None profile would satisfy the dispatch trivially),
-    # and the mantle EOS string was extended with the dissolved species
-    # so the per-shell blend has the volatile component available.
+    # Vacuous-pass guard: the profile was actually built and carries the
+    # rejected volatile.
     assert kwargs['volatile_profile'] is not None
     solver_params = main_mock.call_args.args[0]
-    assert '+PALEOS:H2O:' in solver_params['layer_eos_config']['mantle']
+    assert '+Chabrier:H:' in solver_params['layer_eos_config']['mantle']
 
     # Structure scalars from the converged solve stay bounded either way.
     assert 0.0 < hf_row['M_core'] < hf_row['M_int']


### PR DESCRIPTION
## Description

Raises the fwl-zalmoxis pin to 26.07.13, which carries [Zalmoxis #78](https://github.com/FormingWorlds/Zalmoxis/pull/78) (wet and unified mantles on the JAX structure path), and makes the PROTEUS-side dispatch capability-aware so the coupled model actually reaches those paths, at the evolved re-solves and at initialization. Closes #737. Closes #719.

* The pin moves from 26.07.03 to 26.07.13. The release ships exactly [Zalmoxis #78](https://github.com/FormingWorlds/Zalmoxis/pull/78) on top of the previous pin: the production-default unified PALEOS mantle no longer forces the numpy fallback, and the JAX RHS can blend one paleos_unified volatile into the mantle through the per-shell `VolatileProfile`.
* `_zalmoxis_jax_structure_viable` accepts the unified PALEOS mantle layout (flat `paleos_unified` entry), matching the pinned release; the 2-phase precondition remains for 2-phase configurations and the core precondition is unchanged.
* Wet solves dispatch to the JAX path when the volatile profile fits the Zalmoxis JAX envelope, decided by a new `_volatile_profile_jax_viable` predicate that mirrors the release's own wrapper checks (exactly one active volatile resolving to a `paleos_unified` entry, no global miscibility, no `x_interior` state, zero-weight primary silicate, no unmanaged mixture components; a dissolved H2 profile is rejected by name). The predicate is conservative by construction: anything unknown or out of envelope keeps the external temperature callable and the numpy path, because dropping the callable for a solve that internally falls back to numpy would silently replace the evolved temperature profile with the internal hot-anchor one.
* The post-solve column rebuild is now profile-aware. For wet JAX solves the mantle density is rebuilt through `zalmoxis.mixing.calculate_mixed_density` with the solve's own profile and melting curves, so the written columns carry the hand-off temperature and the volatile-blended density; the dry rebuild is byte-identical to before. Without this the written temperature column is the Picard-internal profile and downstream consumers read a spuriously frozen deep mantle (measured: 11 percent temperature error at the CMB and a dissolved-water closure of -5.7 percent; see validation).
* The molten-IC adiabat reaches the JAX path (#719). The initial and equilibration structure solves receive the super-liquidus adiabat only as a callable, which the JAX dispatch cannot consume, so they always ran the numpy Picard; the adiabat is now also sampled into r-indexed `temperature_arrays` (using the r-to-P map of the immediately preceding converged structure, the same hand-off convention the evolved re-solves use) and the unchanged dispatch routes them exactly as it does for evolved re-solves. Sampling degrades to the previous callable-only behavior on any malformed input, and the first structure solve of a run, which has no temperature source at all, keeps the internal dispatch by necessity.
* The slow Zalmoxis-Aragog-CALLIOPE integration test runs on Linux again: the numpy-fallback skip is lifted since the unified mantle now takes the JAX path on the forced baseline re-solve and, with the sampled arrays, on the initialization adiabat solves as well. Only the first structure solve of a run, which has no temperature source, keeps the internal numpy dispatch.

## Validation of changes

Linux x86-64, Python 3.12, conda environment on the pinned release.

* Unit tier: `tests/interior_struct/`, `tests/interior_energetics/`, and `tests/config/` pass (847 tests). The adiabat sampler has its own suite (row-by-row agreement with the closure, domain coverage, conservative degradation to the callable-only call on malformed input). The envelope predicate has per-rejection-reason unit tests plus a reference-pinned cross-check that pins its accept and reject decisions against the pinned Zalmoxis release's own wet-mantle validation, so a future envelope change in Zalmoxis fails a test here instead of silently mis-dispatching. The wet dispatch tests discriminate in-envelope (callable withheld, rebuild runs through the blend, hand-off temperature lands in the written column) from out-of-envelope (callable kept, no rebuild). `ruff check` and `ruff format --check` are clean.
* Coupled wet parity (1 Earth mass, 8.3 wt percent dissolved H2O, Zalmoxis structure with Aragog energetics at 150 levels, three iterations, both evolved re-solves confirmed on the JAX path in the debug log): against the numpy-path reference run, the dissolved-water conservation residual is -0.120 percent (numpy reference: -0.157 percent, both at the integration-noise level), interior radius agrees to 3.4e-5 relative. Written columns: temperature, pressure, and gravity agree to 2.9e-4, 2.5e-4, and 6.8e-5 maximum relative difference; density agrees to 2.0e-4 over the interior 76 of 79 nodes, while the outermost three nodes (below 2 GPa, at the edge of the water EOS table where the batch evaluator's out-of-range fill and the rebuild's fallback-to-solver-column convention differ) reach 9.3e-2 at identical (P, T). The mass-weighted effect of those three near-surface shells is already contained in the conservation residuals above. An earlier revision of this description quoted the 6.8e-5 figure as the density agreement; that number is the gravity column, corrected here. The same comparison run without the profile-aware rebuild is what produced the -5.7 percent closure failure quoted above, which is why the rebuild ships in this PR rather than as a follow-up.
* The numpy path is untouched: a wet coupled run with `use_jax = false` on this branch reproduces the pre-PR reference at the same -0.157 percent conservation residual with the interior radius agreeing to better than 1e-6 relative (measured on the dispatch commits; the rebuild commit does not alter any code the numpy path executes).
* Initialization A/B (#719's landing condition; same 1 Earth mass molten-IC configuration, `liquidus_super`, 150 levels, run on both code states): the converged initial structure is equivalent to solver tolerance (interior radius 3.3e-4 relative against an outer tolerance of 3e-3, mass 1.6e-5, CMB pressure 1.7e-3, final written pressure, density, and temperature columns within 6e-5), and the initialization wall time drops accordingly: 55.7 minutes total on the baseline against 51.5 minutes with the arrays (both legs run concurrently on the same machine), with the timeline decomposition attributing the whole difference to the adiabat re-solve, about 5 minutes on the numpy Picard against seconds on the JAX path (run start to P-S table completion: 49.6 versus 44.8 minutes; both legs then spend under 3 minutes on the two coupled rows). The remaining first-row cost on the benchmark machine is the one-time P-S lookup table generation itself, roughly 40 minutes for the four 1350 x 280 tables, which the shared table cache introduced in #706 already amortizes across runs of the same configuration; a separate issue will be opened on reducing that generation cost at the source.

* Honest runtime note: short verification runs show only a few minutes of total gain on the benchmark machine (the wet three-iteration runs land at 53 and 55 minutes on the numpy and JAX paths, the initialization A/B at 55.7 against 51.5), because their wall time is dominated by the shared fixed initialization cost (P-S table generation plus the source-less first solve), not by the solves this PR accelerates. The per-solve gain is where the JAX path engages: the initialization adiabat re-solve (minutes to seconds, measured above) and every evolved re-solve, which is what accumulates on evolution runs.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required


