### PR TITLE
Fix dummy output path and mobile version rendering

### DIFF
--- a/docs/How-to/installation.md
+++ b/docs/How-to/installation.md
@@ -155,9 +155,8 @@ conda activate proteus
 proteus start --offline -c input/dummy.toml
 ```
 
-If this produces output in `output/dummy/`, your installation is working.
-See the [Quick start tutorial](../Tutorials/quick_start_dummy.md) for
-a guided walkthrough.
+If this produces output in `output/run_<timestamp>_xxxx/`, your installation is working.
+See the [Quick start tutorial](../Tutorials/quick_start_dummy.md) for a guided walkthrough.
 
 !!! note "SPIDER (optional)"
     The installer does not include SPIDER or PETSc. If you need SPIDER

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@ hide:
   - navigation
 ---
 
-<div style="padding-left: 1em" markdown="1">
+<div class = "proteus-getstarted" markdown="1">
 
 # Get started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ hide:
   - navigation
 ---
 
-<div class="proteus-index" markdown=1>
+<div class="proteus-index; proteus-index-img">
 
-<h1 align="center" markdown="0"><a href="https://proteus-framework.org"><img src="assets/PROTEUS_white.png#only-light" alt="PROTEUS" width="60%"/><img src="assets/PROTEUS_black_nobkg.png#only-dark" alt="PROTEUS" width="60%"/></a></h1>
+<h1 align="center" markdown="0"><a href="https://proteus-framework.org"><img src="assets/PROTEUS_white.png#only-light" alt="PROTEUS" width="90%"/><img src="assets/PROTEUS_black_nobkg.png#only-dark" alt="PROTEUS" width="90%"/></a></h1>
 
 <p align="center">
   <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/coverage-baseline.yml" target="_blank" rel="noopener">
@@ -31,6 +31,10 @@ hide:
   </a>
 </p>
 
+</div>
+
+<div class="proteus-index" markdown=1>
+
 **PROTEUS** is a modular Python framework that simulates the coupled evolution
 of rocky planet atmospheres and interiors. It connects interior thermal
 evolution, volatile outgassing, atmospheric radiative transfer, atmospheric
@@ -38,11 +42,14 @@ escape, and stellar evolution into a self-consistent time-stepping loop,
 tracking the planet from a molten magma ocean to a solidified surface over
 billions of years.
 
-<div align="center" style="max-width: 70%; margin: 0 auto;">
+</div>
+
+<div align="center" class="proteus-index; proteus-index-img">
   <object type="image/svg+xml" data="assets/proteus_modules_schematic.svg" class="mod-diagram mod-diagram--light" aria-label="PROTEUS module schematic (light mode)">PROTEUS module schematic (light mode)</object>
   <object type="image/svg+xml" data="assets/proteus_modules_schematic_darkmode.svg" class="mod-diagram mod-diagram--dark" aria-label="PROTEUS module schematic (dark mode)">PROTEUS module schematic (dark mode)</object>
 </div>
 
+<div class="proteus-index" markdown=1>
 <p style="text-align: center;"><strong>Schematic of PROTEUS components and corresponding modules.</strong></p>
 
 ## Key features

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ billions of years.
 
 </div>
 
-<div align="center" class="proteus-index; proteus-index-img">
+<div align="center" class="proteus-index proteus-index-img">
   <object type="image/svg+xml" data="assets/proteus_modules_schematic.svg" class="mod-diagram mod-diagram--light" aria-label="PROTEUS module schematic (light mode)">PROTEUS module schematic (light mode)</object>
   <object type="image/svg+xml" data="assets/proteus_modules_schematic_darkmode.svg" class="mod-diagram mod-diagram--dark" aria-label="PROTEUS module schematic (dark mode)">PROTEUS module schematic (dark mode)</object>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ hide:
   - navigation
 ---
 
-<div class="proteus-index; proteus-index-img">
+<div class="proteus-index proteus-index-img">
 
 <h1 align="center" markdown="0"><a href="https://proteus-framework.org"><img src="assets/PROTEUS_white.png#only-light" alt="PROTEUS" width="90%"/><img src="assets/PROTEUS_black_nobkg.png#only-dark" alt="PROTEUS" width="90%"/></a></h1>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,14 +5,9 @@ hide:
   - navigation
 ---
 
-<h1 align="center">
-    <a href="https://proteus-framework.org">
-    <div>
-        <img src="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/PROTEUS_white.png#gh-light-mode-only" style="vertical-align: middle;" width="40%"/>
-        <img src="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/PROTEUS_black_nobkg.png#gh-dark-mode-only" style="vertical-align: middle;" width="40%"/>
-    </div>
-    </a>
-</h1>
+<div class="proteus-index" markdown=1>
+
+<h1 align="center" markdown="0"><a href="https://proteus-framework.org"><img src="assets/PROTEUS_white.png#only-light" alt="PROTEUS" width="60%"/><img src="assets/PROTEUS_black_nobkg.png#only-dark" alt="PROTEUS" width="60%"/></a></h1>
 
 <p align="center">
   <a href="https://github.com/FormingWorlds/PROTEUS/actions/workflows/coverage-baseline.yml" target="_blank" rel="noopener">
@@ -36,7 +31,6 @@ hide:
   </a>
 </p>
 
-<div class="home-text" markdown>
 **PROTEUS** is a modular Python framework that simulates the coupled evolution
 of rocky planet atmospheres and interiors. It connects interior thermal
 evolution, volatile outgassing, atmospheric radiative transfer, atmospheric

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -71,10 +71,3 @@
 .md-typeset .grid.cards > ul > li > p:last-child {
   margin-top: auto;
 }
-
-/* Narrow and center the homepage intro tagline */
-.md-typeset .home-text {
-  max-width: 85%;
-  margin: 1.5rem auto;
-  text-align: left;
-}

--- a/docs/stylesheets/widths.css
+++ b/docs/stylesheets/widths.css
@@ -13,6 +13,11 @@
   .proteus-getstarted {
     margin-left: 1em;
   }
+
+  .proteus-index-img {
+    max-width: 50em;
+    margin: 0 auto;
+  }
 }
 
 

--- a/docs/stylesheets/widths.css
+++ b/docs/stylesheets/widths.css
@@ -1,0 +1,18 @@
+@media screen and (min-width: 769px) {
+  .proteus-index {
+    max-width: 70em;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .proteus-submodules {
+    max-width: 50em;
+    margin-right: auto;
+  }
+
+  .proteus-getstarted {
+    margin-left: 1em;
+  }
+}
+
+

--- a/docs/submodules.md
+++ b/docs/submodules.md
@@ -6,13 +6,13 @@ hide:
 
 # PROTEUS submodules
 
-<div style="max-width: 80%">
+<div class = "proteus-submodules">
 PROTEUS is a modular simulation framework: the physics is split across several submodules, shown in the schematic below.
 Click any module in the diagram to open its documentation, or navigate to it from the sidebar.
 </div>
 
 
-<div style="max-width: 80%">
+<div class = "proteus-submodules">
   <object type="image/svg+xml" data="assets/proteus_modules_schematic.svg" class="mod-diagram mod-diagram--light" aria-label="PROTEUS module schematic (light mode)">PROTEUS module schematic (light mode)</object>
   <object type="image/svg+xml" data="assets/proteus_modules_schematic_darkmode.svg" class="mod-diagram mod-diagram--dark" aria-label="PROTEUS module schematic (dark mode)">PROTEUS module schematic (dark mode)</object>
   <p style="text-align: center;"><strong>Schematic of PROTEUS components and corresponding modules.</strong></p>

--- a/docs/submodules.md
+++ b/docs/submodules.md
@@ -11,8 +11,7 @@ PROTEUS is a modular simulation framework: the physics is split across several s
 Click any module in the diagram to open its documentation, or navigate to it from the sidebar.
 </div>
 
-
-<div class = "proteus-submodules">
+<div class = "proteus-submodules" style = "margin-top: 1rem">
   <object type="image/svg+xml" data="assets/proteus_modules_schematic.svg" class="mod-diagram mod-diagram--light" aria-label="PROTEUS module schematic (light mode)">PROTEUS module schematic (light mode)</object>
   <object type="image/svg+xml" data="assets/proteus_modules_schematic_darkmode.svg" class="mod-diagram mod-diagram--dark" aria-label="PROTEUS module schematic (dark mode)">PROTEUS module schematic (dark mode)</object>
   <p style="text-align: center;"><strong>Schematic of PROTEUS components and corresponding modules.</strong></p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ extra_javascript:
 
 extra_css:
   - stylesheets/extra.css
+  - stylesheets/widths.css
   - stylesheets/proteus_theme.css
   - stylesheets/footnotes.css
 


### PR DESCRIPTION
## Description
This PR fixes the wrong output path mentioned for the dummy tutorial in the quick installation guide, closing #748 .

It also updates some CSS rules that configure page widths on pages with missing nav/toc or both, adding the new `widths.css`. The widths are now only adjusted for screens above a certain size, so that the mobile version always shows everything at full-width. 

## Validation of changes
I built the documentation locally on firefox, safari and chrome, and tested the mobile version via [https://mobileviewer.github.io](https://mobileviewer.github.io/#viewer). 


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
