### PR TITLE
Fix nightly macOS setup by not pinning USER to a fake account

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -127,6 +127,13 @@ runs:
     # successfully" warning. The packages themselves are functional,
     # so verify each is on the prefix list before accepting the
     # failure.
+    #
+    # Calling workflows must leave USER at the runner default and must
+    # not set it in any env block. ``brew install`` runs a preinstall
+    # check that looks the active account up by name in the passwd
+    # database, so a USER naming an account that does not exist aborts
+    # this step with "user <name> doesn't exist" before any package is
+    # installed. ``tests/tools/test_install_scripts.py`` enforces this.
     - name: Install system packages (macOS)
       if: runner.os == 'macOS'
       shell: bash

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -57,7 +57,6 @@ jobs:
     timeout-minutes: 30
     env:
       COVERAGE_FILE: .coverage.unit.${{ matrix.os }}
-      USER: "ci-runner"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -143,7 +142,6 @@ jobs:
     timeout-minutes: 45
     env:
       COVERAGE_FILE: .coverage.integration.${{ matrix.os }}
-      USER: "ci-runner"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -282,7 +280,6 @@ jobs:
     timeout-minutes: 210   # job cap for the slow-tier matrix, sized by its longest shard (zalmoxis-coupled/ubuntu, ~137 min plus ~11 min setup); above the 180 min per-test pytest-timeout so a hung single test trips pytest-timeout's per-test timer before the job is cancelled.
     env:
       COVERAGE_FILE: .coverage.slow.${{ matrix.shard }}.${{ matrix.os }}
-      USER: "ci-runner"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -1059,3 +1059,72 @@ def test_socrates_rebuild_warns_to_regenerate_agni_wrappers(tmp_path):
     res_absent = _run_agni_rebuild_note(without_agni, has_agni=False)
     assert res_absent.returncode == 0, res_absent.stderr
     assert 'get_agni.sh' not in res_absent.stdout
+
+
+# ---------------------------------------------------------------------------
+# CI must not pin USER (breaks the macOS Homebrew install)
+# ---------------------------------------------------------------------------
+# A USER pin reaches the job environment as a block-mapping key, as a flow-
+# mapping entry, or as a dynamic export out of a run step. All three are
+# forbidden, so the scan matches all three rather than only the block form.
+_USER_PINS = (
+    re.compile(r'^\s*["\']?USER["\']?\s*:'),
+    re.compile(r'[{,]\s*["\']?USER["\']?\s*:'),
+    re.compile(r'\bUSER\s*=.*GITHUB_ENV'),
+)
+
+
+def _pins_user(line: str) -> bool:
+    """Return True when a CI config line pins USER into the job environment."""
+    # Drop trailing comments so prose naming USER cannot trip the scan.
+    text = line.split('#', 1)[0]
+    return any(pattern.search(text) for pattern in _USER_PINS)
+
+
+@pytest.mark.unit
+def test_ci_config_never_pins_user():
+    """CI config must leave USER at the runner default.
+
+    Several jobs share the macOS leg of the ``setup-proteus`` composite action,
+    which runs ``brew install``. Its preinstall check resolves the active
+    account by name, so a USER naming an account that does not exist on the
+    runner aborts the setup step before a single package is installed and every
+    macOS job fails before reaching its tests. Pinning even a real account name
+    is fragile, because it breaks whenever the runner account is renamed or the
+    jobs move back into a container. The invariant is pinned here, for every
+    workflow at once, rather than by a comment in whichever one was edited last.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow_dir = repo_root / '.github/workflows'
+    workflows = sorted(workflow_dir.glob('*.yml')) + sorted(workflow_dir.glob('*.yaml'))
+    action = repo_root / '.github/actions/setup-proteus/action.yml'
+
+    # Guard the guard: an empty or mis-rooted glob, or a renamed action, would
+    # make the scan below pass by finding nothing to check.
+    assert workflows, f'no workflow files resolved under {workflow_dir}'
+    assert action.is_file(), f'{action} is missing; the USER guard cannot check CI setup'
+    targets = workflows + [action]
+
+    # Discrimination: the matcher must fire on every shape that reaches the job
+    # environment and stay quiet on unrelated keys, prose, and same-suffix
+    # variables, so a broken pattern cannot make this test pass vacuously.
+    assert _pins_user('      USER: "ci-runner"')
+    assert _pins_user("      'USER': ci-runner")
+    assert _pins_user('    env: {USER: ci-runner}')
+    assert _pins_user('        echo "USER=ci-runner" >> "$GITHUB_ENV"')
+    assert not _pins_user('  COVERAGE_FILE: .coverage.unit.macos-latest')
+    assert not _pins_user('  # Leave USER at the runner default')
+    assert not _pins_user('        echo "FWL_USER=someone" >> "$GITHUB_ENV"')
+
+    offenders = []
+    for path in targets:
+        for lineno, raw in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):
+            if _pins_user(raw):
+                offenders.append(f'{path.relative_to(repo_root)}:{lineno}: {raw.strip()}')
+
+    assert not offenders, (
+        'CI config must leave USER at the runner default. A USER naming an '
+        'account that does not exist aborts the macOS brew install shared by '
+        'several jobs, and pinning a real account name breaks on the next '
+        f'runner rename. Remove these: {offenders}'
+    )

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -1,7 +1,8 @@
 """
-Unit tests for PETSc/SPIDER installation shell scripts.
+Unit tests for the installation shell scripts and the repository and CI
+configuration invariants they depend on.
 
-Tests the reusable shell logic extracted from ``tools/get_petsc.sh`` and
+Reusable shell logic replicated inline from ``tools/get_petsc.sh`` and
 ``tools/get_spider.sh``:
 - ``portable_realpath()``: cross-platform path resolution
 - ERR trap: exit-code and step-name capture
@@ -10,8 +11,25 @@ Tests the reusable shell logic extracted from ``tools/get_petsc.sh`` and
 - Workpath argument handling: ``$1`` override vs default
 - PETSc library detection: versioned ``.so``, ``.dylib``, missing
 
-Each test runs an isolated bash snippet via ``subprocess.run()``, with no
-network access and no real builds.
+Blocks lifted out of the shipped scripts at run time, so that rewording a
+script re-runs its cases against the new text:
+- ``tools/get_aragog.sh``: the dirty-checkout guard shared across ``get_*.sh``
+- ``tools/get_socrates.sh``: the portable-flag rewrite, its post-build flag
+  check, and the conditional AGNI-wrapper rebuild note
+
+Also pins invariants that live in checked-in configuration and documentation
+rather than in shell, each of which fails silently when its counterpart moves:
+- ``pyproject.toml`` module pins and optional-dependency extras, which the
+  scripts resolve through ``tools/_module_pins.py``
+- the extras the ``setup-proteus`` composite action installs, against the
+  extra keys pyproject declares
+- the installation docs' guidance on editable installs, against those pins
+- CI config leaving USER at the runner default, which the action's macOS
+  ``brew install`` step requires
+
+Each shell test runs an isolated bash snippet via ``subprocess.run()``, with
+no network access and no real builds; the configuration tests read the
+checked-in files directly.
 
 See also:
 - docs/test_infrastructure.md
@@ -1097,13 +1115,18 @@ def test_ci_config_never_pins_user():
     repo_root = Path(__file__).resolve().parents[2]
     workflow_dir = repo_root / '.github/workflows'
     workflows = sorted(workflow_dir.glob('*.yml')) + sorted(workflow_dir.glob('*.yaml'))
-    action = repo_root / '.github/actions/setup-proteus/action.yml'
+    # Every composite action is scanned, not just the one that installs the
+    # macOS packages today: any action calling brew is a place where a USER
+    # pin would break the setup.
+    actions = sorted(repo_root.glob('.github/actions/*/action.yml')) + sorted(
+        repo_root.glob('.github/actions/*/action.yaml')
+    )
 
-    # Guard the guard: an empty or mis-rooted glob, or a renamed action, would
-    # make the scan below pass by finding nothing to check.
+    # Guard the guard: an empty or mis-rooted glob would make the scan below
+    # pass by finding nothing to check.
     assert workflows, f'no workflow files resolved under {workflow_dir}'
-    assert action.is_file(), f'{action} is missing; the USER guard cannot check CI setup'
-    targets = workflows + [action]
+    assert actions, f'no composite actions resolved under {repo_root}/.github/actions'
+    targets = workflows + actions
 
     # Discrimination: the matcher must fire on every shape that reaches the job
     # environment and stay quiet on unrelated keys, prose, and same-suffix


### PR DESCRIPTION
## Description

The macOS nightly jobs fail in the environment setup step before any test runs, so every macOS tier is lost on any given night. All three nightly jobs pinned `USER` to `"ci-runner"`, which is not a real account on the runner. The hosted macOS image picked up a Homebrew release whose `brew install` runs a preinstall check that resolves the active account by name, and with `USER` naming an account that does not exist that lookup raises `user ci-runner doesn't exist` and aborts the whole setup step. The same tree passed the night before, so the trigger was the image updating Homebrew underneath us rather than anything we changed.

The override dates from when these jobs ran inside a container as root, which is where a deterministic username was worth setting. They now run directly on the hosted runners, so nothing needs it. I dropped it on all three jobs instead of pinning a real-looking name, because hardcoding `runner` would recreate this same failure the day the runner account is renamed or the jobs move back into a container.

Two places read `$USER` and dropping the override changes neither result. `tools/postprocess.jl` stamps it into a NetCDF metadata attribute. `grid/manage.py` feeds it into a Slurm queue log line through `getpass.getuser()`, which reads `LOGNAME` ahead of `USER`, so the override was already inert there. The system-configuration log resolves the username through `os.getlogin()` with a `pwd.getpwuid` fallback, which never read `$USER` in the first place, and the PR-check macOS job already runs this same setup with no override.

Five workflows call the `setup-proteus` action, so the note explaining why `USER` has to stay at the runner default sits with the macOS brew step they all share rather than in whichever workflow was edited last. A unit test now fails if any workflow or the action pins `USER` back into the job environment, whether as an env key or an export into `$GITHUB_ENV`.

## Validation of changes

Same-day A/B on the same workflow, which isolates the change:

- `6f3bf638` with the override, scheduled nightly run 29558039418 at 05:42 UTC: setup step FAILS at ~35 s, `user ci-runner doesn't exist`, no test executed.
- `d5426bde` without it, run 29565730445: setup step SUCCEEDS. Unit tier macOS green in 11m38s, unit tier Ubuntu green, and both integration tiers green.

The mechanism is confirmed from the failing run's own traceback, which walks `brew install` -> `perform_preinstall_checks` -> `Diagnostic.checks` -> `check_untrusted_taps` -> `Trust.trust_file` -> `Dir.home` at `trust.rb:27`, where the signature is `def self.trust_file(home: Dir.home(ENV.fetch("USER")))`. It also reproduces locally on Homebrew 6.0.10 with matching trace lines: `USER=ci-runner brew doctor` raises the same error, and the same command with a real `$USER` is clean.

The new guard test was checked against re-introduction: putting `USER: "ci-runner"` back into `ci-nightly.yml` makes it fail and name the offending line, and it covers all four shapes that reach the job environment (block key, quoted key, flow mapping, and an export into `$GITHUB_ENV`).

One caveat on the evidence: the runner image's Homebrew version was not controlled between the two runs, so the A/B is same-day but not a controlled experiment. The deterministic mechanism above is the stronger evidence.

Test configuration: macOS and Ubuntu hosted runners, Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
