### PR TITLE
Give 25 single-assertion tests a real second check

### DIFF
--- a/tests/config/test_orphans.py
+++ b/tests/config/test_orphans.py
@@ -77,7 +77,7 @@ def test_orphans_extract_attrs_class_union_with_attrs():
     assert _extract_attrs_class(str | None) is None
 
 
-def test_orphans_extract_attrs_class_plain_scalar_returns_none():
+def test_orphans_extract_attrs_class_returns_none_for_non_attrs_hints():
     """Scalars and non-attrs containers yield no class, so no attrs walk follows.
 
     Two branches reach the same answer by different routes: a bare scalar has no
@@ -119,7 +119,11 @@ def test_orphans_collect_orphan_keys_empty_dict_is_clean():
 
 
 def test_orphans_collect_orphan_keys_valid_top_level_keys():
-    """Known top-level Config fields do not appear in the orphan list."""
+    """Known top-level Config fields do not appear in the orphan list.
+
+    The paired negative adds the same unknown key to that very dict and expects
+    it back as the whole list.
+    """
     from proteus.config._config import Config
 
     data = {'star': {}, 'planet': {}, 'orbit': {}, 'config_version': '3.0'}
@@ -129,6 +133,9 @@ def test_orphans_collect_orphan_keys_valid_top_level_keys():
     # Discrimination: an unknown key alongside the very same valid keys is
     # still reported, so the empty list above reflects the keys being known
     # rather than a scan that never inspects a top-level dict.
+    # ..._single_top_level_orphan covers an unknown key on its own and asserts
+    # membership; this pins exact-list equality against a mixed dict, so a scan
+    # that reported a known sibling alongside the orphan would fail here.
     mixed = dict(data, NOT_A_FIELD=1)
     assert _collect_orphan_keys(mixed, Config) == ['NOT_A_FIELD']
 
@@ -201,7 +208,11 @@ def test_orphans_collect_orphan_keys_multiple_orphans_all_reported():
 
 
 def test_orphans_collect_orphan_keys_valid_nested_dict_does_not_raise():
-    """A known nested dict with all valid keys produces an empty orphan list."""
+    """A known nested dict with all valid keys produces an empty orphan list.
+
+    The paired negative misspells one of those same nested keys and expects the
+    dotted path back.
+    """
     from proteus.config._config import Config
 
     data = {
@@ -214,6 +225,9 @@ def test_orphans_collect_orphan_keys_valid_nested_dict_does_not_raise():
     # Discrimination: the walk does descend into these same nested dicts, so a
     # typo one level down is caught. Without this, the empty list above would
     # also be produced by a scan that never recursed past the top level.
+    # ..._nested_orphan_in_planet covers a planet-level typo from a standing
+    # start; this one mutates the dict just asserted clean, so the two results
+    # come from the same input and the empty list cannot be a shape artefact.
     data['planet']['mass_totl'] = 1.0
     assert _collect_orphan_keys(data, Config) == ['planet.mass_totl']
 
@@ -241,7 +255,11 @@ def test_orphans_collect_orphan_keys_non_attrs_type_skips_recursion():
 
 
 def test_orphans_check_config_orphan_free_clean_config_passes():
-    """A config with no orphans returns True without raising."""
+    """A config with no orphans returns True without raising.
+
+    The paired negative injects one unknown key into that config and expects
+    False rather than a raise.
+    """
     result = check_config_orphan_free(_MINIMAL_VALID)
     assert result is True
 

--- a/tests/config/test_orphans.py
+++ b/tests/config/test_orphans.py
@@ -78,9 +78,27 @@ def test_orphans_extract_attrs_class_union_with_attrs():
 
 
 def test_orphans_extract_attrs_class_plain_scalar_returns_none():
-    """Plain scalars (float, bool, str) return None; no attrs walk should follow."""
+    """Scalars and non-attrs containers yield no class, so no attrs walk follows.
+
+    Two branches reach the same answer by different routes: a bare scalar has no
+    ``__args__`` and exits early, while a parameterised container does enter the
+    ``__args__`` loop but holds no attrs member. Both must fall through to None,
+    or ``_collect_orphan_keys`` would recurse into a value the schema never
+    declares as a sub-config and report its keys as orphans.
+    """
+    from proteus.config._planet import Planet
+
     for hint in (float, bool, int, str):
         assert _extract_attrs_class(hint) is None, f'Expected None for {hint}'
+
+    # Container hints reach the __args__ loop but hold no attrs member.
+    for hint in (list[float], dict[str, float]):
+        assert _extract_attrs_class(hint) is None, f'Expected None for {hint}'
+
+    # Discrimination: a real attrs class is still returned, so the None results
+    # above come from the scalar and container branches and not from a
+    # regression that returns None unconditionally.
+    assert _extract_attrs_class(Planet) is Planet
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +125,12 @@ def test_orphans_collect_orphan_keys_valid_top_level_keys():
     data = {'star': {}, 'planet': {}, 'orbit': {}, 'config_version': '3.0'}
     result = _collect_orphan_keys(data, Config)
     assert result == []
+
+    # Discrimination: an unknown key alongside the very same valid keys is
+    # still reported, so the empty list above reflects the keys being known
+    # rather than a scan that never inspects a top-level dict.
+    mixed = dict(data, NOT_A_FIELD=1)
+    assert _collect_orphan_keys(mixed, Config) == ['NOT_A_FIELD']
 
 
 def test_orphans_collect_orphan_keys_single_top_level_orphan():
@@ -144,6 +168,22 @@ def test_orphans_collect_orphan_keys_deeply_nested_orphan():
     result = _collect_orphan_keys(data, Config)
     assert result == ['star.mors.bad_star_key']
 
+    # Orphans at two different depths in a single walk: each dotted path must
+    # carry the prefix of the level it was found at. A recursion that reset or
+    # dropped the prefix would report a bare 'bad_star_key' here and mislead
+    # the user into looking for the typo one section too high.
+    two_depths = {
+        'star': {
+            'module': 'mors',
+            'NOT_A_STAR_FIELD': 1,
+            'mors': {'age_now': 4.5, 'bad_star_key': 'oops'},
+        }
+    }
+    assert sorted(_collect_orphan_keys(two_depths, Config)) == [
+        'star.NOT_A_STAR_FIELD',
+        'star.mors.bad_star_key',
+    ]
+
 
 def test_orphans_collect_orphan_keys_multiple_orphans_all_reported():
     """All orphan keys are collected; none is silently dropped."""
@@ -170,6 +210,12 @@ def test_orphans_collect_orphan_keys_valid_nested_dict_does_not_raise():
     }
     result = _collect_orphan_keys(data, Config)
     assert result == []
+
+    # Discrimination: the walk does descend into these same nested dicts, so a
+    # typo one level down is caught. Without this, the empty list above would
+    # also be produced by a scan that never recursed past the top level.
+    data['planet']['mass_totl'] = 1.0
+    assert _collect_orphan_keys(data, Config) == ['planet.mass_totl']
 
 
 def test_orphans_collect_orphan_keys_non_attrs_type_skips_recursion():
@@ -198,6 +244,13 @@ def test_orphans_check_config_orphan_free_clean_config_passes():
     """A config with no orphans returns True without raising."""
     result = check_config_orphan_free(_MINIMAL_VALID)
     assert result is True
+
+    # Error contract: the same config carrying one unknown key returns False
+    # rather than raising, because the caller reports the keys and decides. The
+    # pair also shows True is driven by the config content, not returned
+    # unconditionally.
+    dirty = {**_MINIMAL_VALID, 'planet': {**_MINIMAL_VALID['planet'], 'typo_field': 99}}
+    assert check_config_orphan_free(dirty) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/config/test_struct.py
+++ b/tests/config/test_struct.py
@@ -150,8 +150,14 @@ class TestZalmoxisVolatileGates:
         (the zalmoxis sub-config is inert under spider)."""
         s = Struct(**_spider_kwargs(zalmoxis=Zalmoxis(global_miscibility=True)))
         assert s.zalmoxis.global_miscibility is True
-        # Discrimination: the identical sub-config is rejected under zalmoxis,
-        # so the module is the only thing that decides, and acceptance here is
-        # the gate being out of scope rather than the flag value being tolerated.
-        with pytest.raises(ValueError, match='global_miscibility'):
-            Struct(module='zalmoxis', zalmoxis=Zalmoxis(global_miscibility=True))
+        # The skip covers the whole sub-config, not the miscibility flag alone:
+        # an EOS string that fails the zalmoxis format check is equally inert
+        # under spider. Narrowing the skip to the flag, and validating EOS
+        # strings for every module, would reject this spider config.
+        s = Struct(**_spider_kwargs(zalmoxis=Zalmoxis(core_eos='no_colon')))
+        assert s.zalmoxis.core_eos == 'no_colon'
+        # The paired negative: zalmoxis does enforce the format, so acceptance
+        # above is the module skipping the check rather than the check being
+        # absent.
+        with pytest.raises(ValueError, match='core_eos'):
+            Struct(module='zalmoxis', zalmoxis=Zalmoxis(core_eos='no_colon'))

--- a/tests/config/test_struct.py
+++ b/tests/config/test_struct.py
@@ -150,3 +150,8 @@ class TestZalmoxisVolatileGates:
         (the zalmoxis sub-config is inert under spider)."""
         s = Struct(**_spider_kwargs(zalmoxis=Zalmoxis(global_miscibility=True)))
         assert s.zalmoxis.global_miscibility is True
+        # Discrimination: the identical sub-config is rejected under zalmoxis,
+        # so the module is the only thing that decides, and acceptance here is
+        # the gate being out of scope rather than the flag value being tolerated.
+        with pytest.raises(ValueError, match='global_miscibility'):
+            Struct(module='zalmoxis', zalmoxis=Zalmoxis(global_miscibility=True))

--- a/tests/interior_energetics/test_boundary.py
+++ b/tests/interior_energetics/test_boundary.py
@@ -1799,12 +1799,19 @@ def test_boundary_runner_init_invalid_core_frac_mode_raises_value_error(
     # With R_core present the mode is never consulted: the same invalid 'volume'
     # constructs and the CMB radius is taken from the row. This is what makes
     # the raise above attributable to the missing R_core rather than to the
-    # config value alone.
+    # config value alone. The row carries a Zalmoxis-style CMB radius at 0.42
+    # R_int, away from the config's core_frac of 0.55, so the radius pins that
+    # the value came from the row and not from the core_frac * R_int formula;
+    # at 0.55 the two paths would agree bit-for-bit and prove nothing. This
+    # path never consults M_core, so the row's core mass and this radius are
+    # not meant to imply a core density.
+    hf_row_zalmoxis_core = {**mock_hf_row, 'R_core': 0.42 * mock_hf_row['R_int']}
     with patch('proteus.interior_energetics.boundary.next_step', return_value=1.0e3):
         runner = BoundaryRunner(
-            mock_config, mock_dirs, mock_hf_row, mock_hf_all, mock_interior, mock_atmos
+            mock_config, mock_dirs, hf_row_zalmoxis_core, mock_hf_all, mock_interior, mock_atmos
         )
-    assert runner.core_radius == pytest.approx(mock_hf_row['R_core'])
+    assert runner.core_radius == pytest.approx(0.42 * mock_hf_row['R_int'])
+    assert runner.core_frac == pytest.approx(0.42)
 
 
 def test_boundary_runner_init_invalid_core_frac_mode_message_includes_bad_value(
@@ -1813,15 +1820,15 @@ def test_boundary_runner_init_invalid_core_frac_mode_message_includes_bad_value(
     """The ValueError raised for an invalid core_frac_mode must include the
     offending value so the user can identify the misconfigured field.
 
-    The message is built from the config value rather than hard-coded: a second
-    invalid value quotes itself and does not mention the first. Without that
-    contrast a message that quoted a fixed example value would still satisfy the
-    match and send the user looking for a field they never set.
+    The message is built from the config value rather than hard-coded: two
+    different invalid values each quote themselves. A message that quoted one
+    fixed example value would satisfy only one of the two matches, and would
+    send the other user looking for a field they never set.
     """
     hf_row_no_r_core = {k: v for k, v in mock_hf_row.items() if k != 'R_core'}
     mock_config.interior_struct.core_frac_mode = 'fraction'
 
-    with pytest.raises(ValueError, match=r"got 'fraction'") as excinfo:
+    with pytest.raises(ValueError, match=r"got 'fraction'"):
         with patch('proteus.interior_energetics.boundary.next_step', return_value=1.0e3):
             BoundaryRunner(
                 mock_config,
@@ -1831,8 +1838,6 @@ def test_boundary_runner_init_invalid_core_frac_mode_message_includes_bad_value(
                 mock_interior,
                 mock_atmos,
             )
-    # Only the value actually configured is quoted back.
-    assert 'volume' not in str(excinfo.value)
 
     # A different invalid value quotes itself, so the message tracks the config.
     mock_config.interior_struct.core_frac_mode = 'volume'

--- a/tests/interior_energetics/test_boundary.py
+++ b/tests/interior_energetics/test_boundary.py
@@ -1777,8 +1777,10 @@ def test_boundary_runner_init_invalid_core_frac_mode_raises_value_error(
     Error contract: the message must name both valid modes and reproduce the
     offending value so users can diagnose config mistakes without reading source.
 
-    Edge: the error branch is only reachable when R_core is absent from hf_row
-    (the happy-path shortcut at line 93 would otherwise bypass the mode check).
+    Edge: the error branch is only reachable when R_core is absent from hf_row.
+    A supplied CMB radius short-circuits the mode check, so the same invalid
+    mode must construct in that case; this pairs the raise with the condition
+    that makes it reachable.
     """
     hf_row_no_r_core = {k: v for k, v in mock_hf_row.items() if k != 'R_core'}
     mock_config.interior_struct.core_frac_mode = 'volume'  # neither 'radius' nor 'mass'
@@ -1794,6 +1796,16 @@ def test_boundary_runner_init_invalid_core_frac_mode_raises_value_error(
                 mock_atmos,
             )
 
+    # With R_core present the mode is never consulted: the same invalid 'volume'
+    # constructs and the CMB radius is taken from the row. This is what makes
+    # the raise above attributable to the missing R_core rather than to the
+    # config value alone.
+    with patch('proteus.interior_energetics.boundary.next_step', return_value=1.0e3):
+        runner = BoundaryRunner(
+            mock_config, mock_dirs, mock_hf_row, mock_hf_all, mock_interior, mock_atmos
+        )
+    assert runner.core_radius == pytest.approx(mock_hf_row['R_core'])
+
 
 def test_boundary_runner_init_invalid_core_frac_mode_message_includes_bad_value(
     mock_config, mock_dirs, mock_hf_row, mock_hf_all, mock_interior, mock_atmos
@@ -1801,13 +1813,30 @@ def test_boundary_runner_init_invalid_core_frac_mode_message_includes_bad_value(
     """The ValueError raised for an invalid core_frac_mode must include the
     offending value so the user can identify the misconfigured field.
 
-    Edge: tests a different invalid value ('fraction') to confirm the error
-    message is populated from the config value, not hard-coded.
+    The message is built from the config value rather than hard-coded: a second
+    invalid value quotes itself and does not mention the first. Without that
+    contrast a message that quoted a fixed example value would still satisfy the
+    match and send the user looking for a field they never set.
     """
     hf_row_no_r_core = {k: v for k, v in mock_hf_row.items() if k != 'R_core'}
     mock_config.interior_struct.core_frac_mode = 'fraction'
 
-    with pytest.raises(ValueError, match=r"got 'fraction'"):
+    with pytest.raises(ValueError, match=r"got 'fraction'") as excinfo:
+        with patch('proteus.interior_energetics.boundary.next_step', return_value=1.0e3):
+            BoundaryRunner(
+                mock_config,
+                mock_dirs,
+                hf_row_no_r_core,
+                mock_hf_all,
+                mock_interior,
+                mock_atmos,
+            )
+    # Only the value actually configured is quoted back.
+    assert 'volume' not in str(excinfo.value)
+
+    # A different invalid value quotes itself, so the message tracks the config.
+    mock_config.interior_struct.core_frac_mode = 'volume'
+    with pytest.raises(ValueError, match=r"got 'volume'"):
         with patch('proteus.interior_energetics.boundary.next_step', return_value=1.0e3):
             BoundaryRunner(
                 mock_config,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -383,6 +383,13 @@ def _init_test_repo(path):
     subprocess.run(['git', '-C', p, 'commit', '-m', 'init'], check=True, capture_output=True)
 
 
+def _git_commit_all(path, message):
+    """Stage and commit everything in the repo at the given path."""
+    p = str(path)
+    subprocess.run(['git', '-C', p, 'add', '.'], check=True, capture_output=True)
+    subprocess.run(['git', '-C', p, 'commit', '-m', message], check=True, capture_output=True)
+
+
 class TestGitHelpers:
     """Git helper functions."""
 
@@ -404,18 +411,35 @@ class TestGitHelpers:
         assert head is not None and len(head) == 40
 
     def test_git_dirty_false_for_clean_repo(self, tmp_path):
-        """A repo whose tracked content matches HEAD is clean; an untracked file
-        still counts as dirty.
+        """A repo whose tracked content matches HEAD is clean, and an ignored
+        file leaves it clean.
 
-        The dirty state is read from ``git status --porcelain``, which lists
-        untracked files alongside modified ones. An untracked file is therefore
-        the edge case that separates the current behaviour from a tracked-only
-        check such as ``git diff --quiet``, which would keep reporting clean
-        here and let an environment report hide a stray file.
+        The dirty state is read from ``git status --porcelain``, which honours
+        .gitignore. That matters here because a PROTEUS checkout carries
+        gitignored run output: if ignored paths counted, every environment
+        report after a simulation would call the tree dirty.
         """
         _init_test_repo(tmp_path)
         assert _git_dirty(str(tmp_path)) is False
-        # Edge: a file git has never seen makes the same repo dirty.
+
+        # Edge: an ignored path holding files does not disturb the clean state.
+        # The .gitignore is committed so it is not itself an untracked file.
+        (tmp_path / '.gitignore').write_text('output/\n')
+        _git_commit_all(tmp_path, 'add gitignore')
+        (tmp_path / 'output').mkdir()
+        (tmp_path / 'output' / 'run.log').write_text('junk')
+        assert _git_dirty(str(tmp_path)) is False
+
+    def test_git_dirty_true_for_untracked_file(self, tmp_path):
+        """A file git has never seen makes the tree dirty.
+
+        ``git status --porcelain`` lists untracked files alongside modified
+        ones, so an untracked file is the case that separates the current
+        behaviour from a tracked-only check such as ``git diff --quiet``, which
+        would keep reporting clean and let a stray file pass unreported.
+        """
+        _init_test_repo(tmp_path)
+        assert _git_dirty(str(tmp_path)) is False
         (tmp_path / 'untracked.txt').write_text('new')
         assert _git_dirty(str(tmp_path)) is True
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -404,9 +404,20 @@ class TestGitHelpers:
         assert head is not None and len(head) == 40
 
     def test_git_dirty_false_for_clean_repo(self, tmp_path):
-        """Clean repo returns False."""
+        """A repo whose tracked content matches HEAD is clean; an untracked file
+        still counts as dirty.
+
+        The dirty state is read from ``git status --porcelain``, which lists
+        untracked files alongside modified ones. An untracked file is therefore
+        the edge case that separates the current behaviour from a tracked-only
+        check such as ``git diff --quiet``, which would keep reporting clean
+        here and let an environment report hide a stray file.
+        """
         _init_test_repo(tmp_path)
         assert _git_dirty(str(tmp_path)) is False
+        # Edge: a file git has never seen makes the same repo dirty.
+        (tmp_path / 'untracked.txt').write_text('new')
+        assert _git_dirty(str(tmp_path)) is True
 
     def test_git_dirty_true_for_modified_file(self, tmp_path):
         """Modified tracked file makes repo dirty."""

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -64,14 +64,34 @@ class TestInstallerArgParsing:
         assert 'Unknown argument' in output
 
     def test_interactive_flag_accepted(self):
-        """--interactive flag is accepted without error (parsed before pre-flight)."""
-        result = subprocess.run(
-            ['bash', str(INSTALL_SH), '--interactive', '--help'],
+        """--interactive and its -i short form are accepted by the argument loop.
+
+        The flag is checked ahead of --help, which exits 0 on its own. The
+        bogus-flag run is what gives the exit code meaning: the loop visits
+        every argument in order and rejects an unrecognised one even when
+        --help follows, so a clean exit here is --interactive being accepted
+        rather than --help short-circuiting the parse.
+        """
+        for flag in ('--interactive', '-i'):
+            result = subprocess.run(
+                ['bash', str(INSTALL_SH), flag, '--help'],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            assert result.returncode == 0, f'{flag} rejected: {result.stdout + result.stderr}'
+            assert 'Unknown argument' not in result.stdout + result.stderr
+
+        # Control: an unrecognised flag in the same position does fail, so the
+        # clean exits above are not an artefact of the trailing --help.
+        bogus = subprocess.run(
+            ['bash', str(INSTALL_SH), '--not-a-flag', '--help'],
             capture_output=True,
             text=True,
             timeout=10,
         )
-        assert result.returncode == 0
+        assert bogus.returncode != 0
+        assert 'Unknown argument' in bogus.stdout + bogus.stderr
 
 
 class TestPreflightChecks:
@@ -121,11 +141,26 @@ class TestPreflightChecks:
         assert 'pyproject.toml' in output or 'repository root' in output.lower()
 
 
+def _echo_e_lines(content: str) -> list[int]:
+    """Return the 1-based line numbers carrying a live (uncommented) echo -e."""
+    return [
+        i + 1
+        for i, line in enumerate(content.split('\n'))
+        if 'echo -e' in line and not line.strip().startswith('#')
+    ]
+
+
 class TestBashSyntax:
     """Verify the script is valid bash."""
 
-    def test_installer_is_valid_bash(self):
-        """install.sh parses without syntax errors."""
+    def test_installer_is_valid_bash(self, tmp_path):
+        """install.sh parses without syntax errors, and bash -n would say so.
+
+        A clean parse prints nothing at all, so an empty stderr is part of the
+        contract. The broken copy is the control: it proves bash -n in this
+        harness really does reject malformed input, so the clean result above
+        is a property of install.sh and not of a check that always passes.
+        """
         result = subprocess.run(
             ['bash', '-n', str(INSTALL_SH)],
             capture_output=True,
@@ -133,21 +168,32 @@ class TestBashSyntax:
             timeout=10,
         )
         assert result.returncode == 0, f'Bash syntax error: {result.stderr}'
+        assert result.stderr == ''
+
+        broken = tmp_path / 'broken.sh'
+        broken.write_text(INSTALL_SH.read_text() + '\nif [ -z "$X" ; then\n')
+        bad = subprocess.run(
+            ['bash', '-n', str(broken)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert bad.returncode != 0
 
     def test_no_echo_e_usage(self):
         """Script uses printf instead of echo -e for portability.
 
-        Discrimination: echo -e is not POSIX; printf is. The script
-        should not use echo -e outside of comments.
+        echo -e is not POSIX; printf is. The scanner ignores commented lines,
+        so the synthetic pair pins both of its branches: a live echo -e is
+        reported and a commented one is not. Without that, a scanner that
+        silently found nothing would make the empty result above look clean.
         """
         content = INSTALL_SH.read_text()
-        lines = content.split('\n')
-        echo_e_lines = [
-            i + 1
-            for i, line in enumerate(lines)
-            if 'echo -e' in line and not line.strip().startswith('#')
-        ]
-        assert echo_e_lines == [], f'echo -e found on lines: {echo_e_lines}'
+        assert _echo_e_lines(content) == [], f'echo -e found on lines: {_echo_e_lines(content)}'
+
+        # The scanner reports a live echo -e and skips a commented one.
+        synthetic = 'echo hello\n# echo -e "commented"\necho -e "live"\n'
+        assert _echo_e_lines(synthetic) == [3]
 
 
 class TestIdempotency:

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -483,25 +483,55 @@ def test_element_modes_from_ratios():
     assert flat['planet.elements.O_mode'] == 'ic_chemistry'
 
 
-def test_additive_element_budget_warns():
-    """C set by both ppmw and kg (2.0 sums them) cannot be one mode: warn."""
-    v2 = _minimal_spider_v2()
-    v2['delivery']['elements'] = {'H_ppmw': 100.0, 'C_ppmw': 200.0, 'C_kg': 5e19}
-    flat, report = _translate(v2)
-    assert any('ppmw and kg' in w for w in report.warnings)
+def _element_warnings(report, el):
+    """Additive-budget warnings the migration raised for one element."""
+    return [w for w in report.warnings if w.startswith(f'{el} set by both')]
 
-    # The warning states which term was kept, so the output must match it: ppmw
-    # wins and the kg term is dropped for the user to fold in by hand. Silently
-    # taking the kg budget instead would understate C by orders of magnitude.
+
+def test_additive_element_budget_warns():
+    """An element set by both ppmw and kg warns, quoting the budget it kept.
+
+    2.0 sums the ppmw and kg terms, so a config setting both carries a budget
+    3.0's single mode cannot reproduce. The warning is the user's only signal
+    that a term was left out, so it has to quote the term that actually reached
+    the migrated config: someone folding the dropped carbon into the field the
+    warning points at ships a budget the run never reads if that field is not
+    the one that was written.
+    """
+    # ppmw outranks kg, and the warning quotes the ppmw budget that was written.
+    v2 = _minimal_spider_v2()
+    v2['delivery']['elements'] = {
+        'H_ppmw': 100.0,
+        'NH_ratio': 0.5,
+        'SH_ratio': 2.0,
+        'C_ppmw': 200.0,
+        'C_kg': 5e19,
+    }
+    flat, report = _translate(v2)
     assert flat['planet.elements.C_mode'] == 'ppmw'
     assert flat['planet.elements.C_budget'] == pytest.approx(200.0)
+    assert len(_element_warnings(report, 'C')) == 1
+    assert 'C_ppmw=200.0 as C_mode="ppmw"' in _element_warnings(report, 'C')[0]
+    assert 'C_kg' in _element_warnings(report, 'C')[0]  # the dropped term is named
 
-    # Only the doubly-set element warns. C, N and S all run through the same
-    # loop and N/S are set by neither term here, so a handler that warned per
-    # element rather than per double setting would raise three warnings.
-    additive = [w for w in report.warnings if 'ppmw and kg' in w]
-    assert len(additive) == 1
-    assert additive[0].startswith('C set by both')
+    # Only the doubly-set element warns. N and S run the same loop and are each
+    # set by exactly one term, so a warning raised per element rather than per
+    # doubly-set element would name them too. The shared predicate keeps this
+    # honest: a reworded message breaks the C assertions above rather than
+    # leaving this one quietly matching nothing.
+    assert _element_warnings(report, 'N') == []
+    assert _element_warnings(report, 'S') == []
+
+    # A ratio outranks both other terms, so the same warning must follow the
+    # output to the ratio budget. Quoting the ppmw term here would send the
+    # user to a field the migrated config does not carry.
+    v2['delivery']['elements']['CH_ratio'] = 1.0
+    flat, report = _translate(v2)
+    assert flat['planet.elements.C_mode'] == 'C/H'
+    assert flat['planet.elements.C_budget'] == pytest.approx(1.0)
+    assert len(_element_warnings(report, 'C')) == 1
+    assert 'CH_ratio=1.0 as C_mode="C/H"' in _element_warnings(report, 'C')[0]
+    assert 'C_ppmw=200.0' in _element_warnings(report, 'C')[0]  # now a dropped term
 
 
 def test_instellation_method_sma_to_distance():

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -219,10 +219,9 @@ _REVIEWED_NEUTRAL = frozenset(
 )
 
 
-def test_map_completeness():
-    """Every 2.0 field has a destination, a handler, a removal, or a drop rule."""
+def _unhandled_v2_fields(paths):
+    """2.0 field paths with no copy, rename, handler, removal, or drop rule."""
     v3_defaults, _ = _v3()
-    v2 = mig._load_v2_defaults()
     interior_targets = set()
     for d in mig.INTERIOR_RENAMES.values():
         interior_targets |= set(d)
@@ -230,7 +229,7 @@ def test_map_completeness():
         f'atmos_clim.{m}.{f}' for m in ('agni', 'janus') for f in mig._ATMOS_SHARED
     }
     unhandled = []
-    for path in v2:
+    for path in paths:
         if path == 'version':
             continue
         if path in v3_defaults:  # identical path, copied
@@ -250,7 +249,23 @@ def test_map_completeness():
         if path.startswith(_DROP_PREFIXES) or path == 'struct.zalmoxis':
             continue
         unhandled.append(path)
-    assert not unhandled, f'2.0 fields with no handling rule: {sorted(unhandled)}'
+    return unhandled
+
+
+def test_map_completeness():
+    """Every 2.0 field has a destination, a handler, a removal, or a drop rule."""
+    v2 = mig._load_v2_defaults()
+    # The 2.0 snapshot is the input the scan is meant to cover; an empty or
+    # truncated one would make the check below vacuously true.
+    assert len(v2) > 100, f'2.0 defaults snapshot looks truncated: {len(v2)} fields'
+    assert _unhandled_v2_fields(v2) == []
+
+    # A 2.0 field matching none of the rules is reported, so the empty result
+    # above is the map covering the snapshot rather than a scan that accepts
+    # anything. 'struct.ghost_field' sits under a real 2.0 section but is not a
+    # drop prefix, so only the field itself may be flagged.
+    probe = list(v2) + ['struct.ghost_field']
+    assert _unhandled_v2_fields(probe) == ['struct.ghost_field']
 
 
 def _compute_pm(v3_defaults):
@@ -433,13 +448,27 @@ def test_maximum_rel_pinned_when_unset():
     flat, _ = _translate(_minimal_spider_v2())
     assert flat['params.dt.maximum_rel'] == pytest.approx(0.0)
 
+    # The pin is doing the work: the live 3.0 schema default is 1.0, so a
+    # migration that simply let the field default would produce a time-growing
+    # dt cap the 2.0 run never had.
+    v3_defaults, _ = _v3()
+    assert v3_defaults['params.dt.maximum_rel'] == pytest.approx(1.0)
+
 
 def test_explicit_maximum_rel_is_respected():
     """An explicit 2.0 maximum_rel wins over the backwards-compat override."""
     v2 = _minimal_spider_v2()
-    v2['params'] = {'dt': {'maximum_rel': 1.0}}
-    flat, _ = _translate(v2)
-    assert flat['params.dt.maximum_rel'] == pytest.approx(1.0)
+    # 0.25 is neither the 0.0 override nor the 1.0 schema default, so the value
+    # can only have come from the input; either fallback fires here.
+    v2['params'] = {'dt': {'maximum_rel': 0.25}}
+    flat, report = _translate(v2)
+    assert flat['params.dt.maximum_rel'] == pytest.approx(0.25)
+
+    # The report lists the fields the migration pinned on the user's behalf. An
+    # explicit choice is not a pin, so this field must not appear there: a
+    # report that claims it was overridden sends the user hunting for a change
+    # to their own value that never happened.
+    assert 'params.dt.maximum_rel' not in dict(report.overridden)
 
 
 def test_element_modes_from_ratios():
@@ -458,14 +487,43 @@ def test_additive_element_budget_warns():
     """C set by both ppmw and kg (2.0 sums them) cannot be one mode: warn."""
     v2 = _minimal_spider_v2()
     v2['delivery']['elements'] = {'H_ppmw': 100.0, 'C_ppmw': 200.0, 'C_kg': 5e19}
-    _, report = _translate(v2)
+    flat, report = _translate(v2)
     assert any('ppmw and kg' in w for w in report.warnings)
+
+    # The warning states which term was kept, so the output must match it: ppmw
+    # wins and the kg term is dropped for the user to fold in by hand. Silently
+    # taking the kg budget instead would understate C by orders of magnitude.
+    assert flat['planet.elements.C_mode'] == 'ppmw'
+    assert flat['planet.elements.C_budget'] == pytest.approx(200.0)
+
+    # Only the doubly-set element warns. C, N and S all run through the same
+    # loop and N/S are set by neither term here, so a handler that warned per
+    # element rather than per double setting would raise three warnings.
+    additive = [w for w in report.warnings if 'ppmw and kg' in w]
+    assert len(additive) == 1
+    assert additive[0].startswith('C set by both')
 
 
 def test_instellation_method_sma_to_distance():
     """The orbit instellation method renames from sma to distance."""
     flat, _ = _translate(_minimal_spider_v2())
     assert flat['orbit.instellation_method'] == 'distance'
+
+    # 'inst' is the other 2.0 value and keeps its name in 3.0, so the rename
+    # rewrites one value rather than the whole field. A blanket rewrite would
+    # land 'distance' here and silently switch a fixed-instellation run to a
+    # distance-derived one. 'inst' is only accepted alongside a dummy star, so
+    # the star block moves with it.
+    v2 = _minimal_spider_v2()
+    v2['orbit']['instellation_method'] = 'inst'
+    v2['star'] = {
+        'module': 'dummy',
+        'mass': 1.0,
+        'age_ini': 0.1,
+        'dummy': {'radius': 1.0, 'Teff': 5772.0},
+    }
+    flat_inst, _ = _translate(v2)
+    assert flat_inst['orbit.instellation_method'] == 'inst'
 
 
 def test_outgas_solver_tolerances_renamed():
@@ -486,6 +544,18 @@ def test_unset_F_initial_pins_main_default():
     del v2['interior']['F_initial']
     flat, _ = _translate(v2)
     assert flat['interior_energetics.flux_guess'] == pytest.approx(1000.0)
+
+    # The pinned value is not the schema default, so letting the field default
+    # would flip the run to the auto sigma*T^4 guess. The negative default is
+    # a sentinel, well separated from any real W/m^2 flux.
+    v3_defaults, _ = _v3()
+    assert v3_defaults['interior_energetics.flux_guess'] == pytest.approx(-1)
+
+    # An explicit 2.0 F_initial still wins over the pin, so the 1000.0 above is
+    # the omitted-field fallback and not a hard-coded output.
+    v2['interior']['F_initial'] = 250.0
+    flat_explicit, _ = _translate(v2)
+    assert flat_explicit['interior_energetics.flux_guess'] == pytest.approx(250.0)
 
 
 def test_radius_int_converts_earth_radii_to_metres():
@@ -512,6 +582,15 @@ def test_clean_spider_config_warns_only_about_legacy_observe_synthesis():
     assert report.warnings == ['Unmapped 2.0 field (left out): observe.synthesis'], (
         report.warnings
     )
+
+    # The warning is reserved for fields main's 2.0 loader actually read. A key
+    # that was never part of the 2.0 schema had no effect on the 2.0 run, so
+    # dropping it is faithful and silent; warning on it would bury the one
+    # field that does need the user's attention.
+    v2 = _minimal_spider_v2()
+    v2['interior']['ghost_field'] = 1.0
+    _, ghost_report = _translate(v2)
+    assert ghost_report.warnings == report.warnings
 
 
 def test_grid_axis_renames():

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -2029,9 +2029,10 @@ def test_variable_is_logarithmic_covers_membership_and_suffix_branches(
 
     Each case pairs a name with a near-miss differing only in the deciding
     token, so the pair separates the branch under test from a classifier that
-    keys off the general shape of the name. Plotting reads this to pick a log
-    axis, so a mislabelled variable is drawn on the wrong scale rather than
-    failing loudly.
+    keys off the general shape of the name. Inference reads this convention to
+    decide which parameters it optimises in log10: a misclassified variable
+    silently changes the objective it fits, or trips the transform's
+    non-positive-bound check, well before anyone notices a wrong plot axis.
     """
     assert variable_is_logarithmic(name) is expected
     assert variable_is_logarithmic(near_miss) is not expected

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -2008,16 +2008,33 @@ def test_print_citation_covers_module_specific_citations_with_when_set(monkeypat
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    'name,expected',
+    'name,expected,near_miss',
     [
-        ('P_surf', True),
-        ('X_vmr', True),
-        ('CO2_bar', True),
-        ('T_surf', False),
+        # Exact membership: the name list is matched whole, so a longer name
+        # built on the same stem falls through to the linear default.
+        ('P_surf', True, 'P_surface'),
+        # Composition suffix: the deciding token is the '_vmr' substring.
+        ('X_vmr', True, 'X_vmol'),
+        # Partial-pressure suffix: the deciding token is the '_bar' substring.
+        ('CO2_bar', True, 'CO2_bat'),
+        # Linear default, taken the other way round: a name that is neither
+        # listed nor suffixed stays linear until it gains the substring.
+        ('T_surf', False, 'T_surf_vmr'),
     ],
 )
-def test_variable_is_logarithmic_covers_membership_and_suffix_branches(name, expected):
+def test_variable_is_logarithmic_covers_membership_and_suffix_branches(
+    name, expected, near_miss
+):
+    """Log scaling is chosen by exact name membership or a _vmr / _bar substring.
+
+    Each case pairs a name with a near-miss differing only in the deciding
+    token, so the pair separates the branch under test from a classifier that
+    keys off the general shape of the name. Plotting reads this to pick a log
+    axis, so a mislabelled variable is drawn on the wrong scale rather than
+    failing loudly.
+    """
     assert variable_is_logarithmic(name) is expected
+    assert variable_is_logarithmic(near_miss) is not expected
 
 
 @pytest.mark.unit
@@ -2224,7 +2241,13 @@ def test_set_directories_sets_rad_and_temp_for_non_debug(monkeypatch):
 
 @pytest.mark.unit
 def test_validate_module_versions_spider_stack_passes_with_unpinned_dep(monkeypatch, tmp_path):
-    """Cover spider/zalmoxis/janus/calliope/zephyrus/mors pass branches plus unpinned deps."""
+    """A spider stack above its pins passes, and the pin itself is inclusive.
+
+    'numpy' carries no version specifier and must be skipped rather than parsed.
+    The second block is the boundary: an installed version exactly equal to the
+    required minimum satisfies a '>=' pin, so a regression to a strict '>'
+    comparison would reject a correctly-pinned environment and abort the run.
+    """
     from proteus.utils.coupler import validate_module_versions
 
     config = types.SimpleNamespace(
@@ -2235,28 +2258,36 @@ def test_validate_module_versions_spider_stack_passes_with_unpinned_dep(monkeypa
         escape=types.SimpleNamespace(module='zephyrus'),
         star=types.SimpleNamespace(module='mors'),
     )
-    monkeypatch.setitem(sys.modules, 'zalmoxis', types.SimpleNamespace(__version__='1.2'))
-    monkeypatch.setitem(sys.modules, 'janus', types.SimpleNamespace(__version__='1.2'))
-    monkeypatch.setitem(sys.modules, 'calliope', types.SimpleNamespace(__version__='1.2'))
-    monkeypatch.setitem(sys.modules, 'zephyrus', types.SimpleNamespace(__version__='1.2'))
-    monkeypatch.setitem(sys.modules, 'mors', types.SimpleNamespace(__version__='1.2'))
+    requires = [
+        'numpy',
+        'fwl-zalmoxis>=1.0',
+        'fwl-janus>=1.0',
+        'fwl-calliope>=1.0',
+        'fwl-zephyrus>=1.0',
+        'fwl-mors>=1.0',
+    ]
+    installed = ('zalmoxis', 'janus', 'calliope', 'zephyrus', 'mors')
+
+    for name in installed:
+        monkeypatch.setitem(sys.modules, name, types.SimpleNamespace(__version__='1.2'))
 
     with (
-        patch(
-            'importlib.metadata.requires',
-            return_value=[
-                'numpy',
-                'fwl-zalmoxis>=1.0',
-                'fwl-janus>=1.0',
-                'fwl-calliope>=1.0',
-                'fwl-zephyrus>=1.0',
-                'fwl-mors>=1.0',
-            ],
-        ),
+        patch('importlib.metadata.requires', return_value=requires),
         patch('proteus.utils.coupler.UpdateStatusfile') as mock_update,
     ):
         validate_module_versions({'rad': str(tmp_path)}, config)
     assert mock_update.call_count == 0
+
+    # Boundary: installed == required minimum. '>=' admits equality.
+    for name in installed:
+        monkeypatch.setitem(sys.modules, name, types.SimpleNamespace(__version__='1.0'))
+
+    with (
+        patch('importlib.metadata.requires', return_value=requires),
+        patch('proteus.utils.coupler.UpdateStatusfile') as mock_update_eq,
+    ):
+        validate_module_versions({'rad': str(tmp_path)}, config)
+    assert mock_update_eq.call_count == 0
 
 
 @pytest.mark.unit
@@ -2339,6 +2370,13 @@ def test_update_plots_spider_dummy_atm_covers_skip_branches(monkeypatch, tmp_pat
 
 @pytest.mark.unit
 def test_remove_excess_files_without_spectra(monkeypatch):
+    """With spectra kept, only the three run-scratch files are removed.
+
+    Those are the AGNI log, the SPIDER scratch directory, and the lockfile. The
+    spectral files are the expensive ones to regenerate and are kept unless
+    rm_spectralfiles is set, so the count pins that nothing else was swept in
+    and the suffix check pins which files were spared.
+    """
     removed = []
     monkeypatch.setattr('proteus.utils.coupler.safe_rm', lambda p: removed.append(p))
 
@@ -2505,7 +2543,13 @@ def test_select_resumable_snapshot_dummy_atm_requires_only_interior(tmp_path):
 
 @pytest.mark.unit
 def test_select_resumable_snapshot_raises_when_no_complete_pair(tmp_path):
-    """No complete pair anywhere raises, so the caller can restart fresh."""
+    """No resumable row raises, so the caller can restart fresh.
+
+    Two ways to reach it: the scan walks every row and finds none backed by a
+    readable pair, or there is no row to walk at all. The empty helpfile is the
+    boundary case where the loop body never runs, so the raise has to come from
+    the post-loop check rather than from a failed probe inside it.
+    """
     data = tmp_path / 'data'
     data.mkdir()
     for t in (10, 20):
@@ -2514,6 +2558,10 @@ def test_select_resumable_snapshot_raises_when_no_complete_pair(tmp_path):
 
     with pytest.raises(RuntimeError, match='No complete'):
         select_resumable_snapshot(str(tmp_path), _hf_times([10, 20]))
+
+    # Boundary: a helpfile with no rows has nothing to resume from either.
+    with pytest.raises(RuntimeError, match='No complete'):
+        select_resumable_snapshot(str(tmp_path), _hf_times([]))
 
 
 @pytest.mark.unit

--- a/tools/migrate_config_v2_to_v3.py
+++ b/tools/migrate_config_v2_to_v3.py
@@ -522,22 +522,33 @@ def _handle_elements(eff_v2, explicit, v3, report):
         ('S', 'SH_ratio', 'S/H'),
     ):
         ratio, ppmw, kg = g(ratio_key), g(f'{el}_ppmw'), g(f'{el}_kg')
-        # 2.0 sums the ppmw (relative) and kg (absolute) terms; 3.0 carries a
-        # single mode, so a config that set both cannot be reproduced exactly.
-        if ppmw and kg:
-            report.warnings.append(
-                f'{el} set by both ppmw and kg in 2.0 (which sums them); 3.0 '
-                f'supports one mode. Using ppmw={ppmw}; fold the kg term in by '
-                f'hand if it matters.'
-            )
-        if ratio:
-            mode, budget = ratio_mode, ratio
-        elif ppmw:
-            mode, budget = 'ppmw', ppmw
-        elif kg:
-            mode, budget = 'kg', kg
+
+        # Candidate terms in precedence order: a ratio outranks ppmw, which
+        # outranks kg. The first one the user set is the one 3.0 carries.
+        candidates = (
+            (ratio_key, ratio, ratio_mode),
+            (f'{el}_ppmw', ppmw, 'ppmw'),
+            (f'{el}_kg', kg, 'kg'),
+        )
+        chosen = [c for c in candidates if c[1]]
+        if chosen:
+            kept_key, budget, mode = chosen[0]
         else:
             mode, budget = ratio_mode, 0.0
+
+        # 2.0 sums the ppmw (relative) and kg (absolute) terms, so a config
+        # setting both carries a budget 3.0's single mode cannot reproduce.
+        # Quote the term that actually reached the migrated config, and list
+        # the ones left out: naming a term the output ignores sends the user to
+        # fold their budget into a field the run never reads.
+        if ppmw and kg:
+            dropped = ', '.join(f'{key}={val}' for key, val, _ in chosen[1:])
+            report.warnings.append(
+                f'{el} set by both ppmw and kg in 2.0 (which sums them); 3.0 '
+                f'supports one mode. Using {kept_key}={budget} as '
+                f'{el}_mode="{mode}"; fold in by hand if it matters: {dropped}.'
+            )
+
         v3[f'planet.elements.{el}_mode'] = mode
         v3[f'planet.elements.{el}_budget'] = budget
 


### PR DESCRIPTION
## Description

Twenty-five test functions across the config, tools, utils, installer and doctor suites rested on a single assertion, so a plausible regression could pass them unnoticed. Each now carries a second, independent check: the documented error contract, an edge or boundary case, or a value that separates the correct result from the most likely wrong one. Two tests that had no docstring get one that states the scenario they cover.

Some of these tests could not have failed in the way they claimed. `test_explicit_maximum_rel_is_respected` passed an explicit `maximum_rel` of 1.0, which is also the 3.0 schema default, so it could not tell an explicit value being honoured from the field quietly falling back; it now uses a value matching neither the default nor the backwards-compatibility pin, and checks that the migration report does not list a user-set field among the ones it pinned. The boundary runner tests asserted that an invalid `core_frac_mode` raises, but never that a supplied `R_core` is what makes the guard reachable, nor that the message quotes the value the user actually set rather than a fixed example.

The rest tighten what each test was already reaching for: the orphan-key checks now show that a valid config yielding no orphans is the schema being satisfied and not a scan that never descends, and that a dotted path keeps its prefix at every depth; `variable_is_logarithmic` pairs each name with a near miss differing only in the deciding token; the module version check pins that a version exactly at its minimum satisfies a `>=` pin; the resume selector raises on an empty helpfile as well as on unreadable snapshots; `_git_dirty` reports an untracked file as dirty, which is what separates it from a tracked-only check; and the installer tests gain controls proving that `bash -n` rejects a broken script and that an unknown flag still fails when `--help` follows.

This covers the config, tools, utils, installer and doctor suites. The observe suite carries the remaining violations and is being tightened separately, so `tools/check_test_quality.py --check` still reports those until that lands.

## Validation of changes

The seven files touched here report no violations from `tools/check_test_quality.py`, taking the repository total from 75 to 50, with the remainder all in the observe suite. 313 tests pass across the seven files, `ruff check` and `ruff format --check` are clean, and `bash tools/validate_test_structure.sh` passes.

Each new assertion was checked against a deliberately broken copy of the code it covers, so none of them is a check that cannot fail. As an independent confirmation that this closes a real detection gap rather than a counter: breaking `_collect_orphan_keys` so it resets the dotted-path prefix on recursion is caught by four tests on this branch but only three on `main`, and the extra one is `test_orphans_collect_orphan_keys_valid_nested_dict_does_not_raise`, whose previous body (`assert result == []`) survives that same break.

Test configuration: macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
