### PR TITLE
Strengthen the observe tests and state what each one verifies

### DIFF
--- a/tests/integration/test_integration_observe_wrapper.py
+++ b/tests/integration/test_integration_observe_wrapper.py
@@ -360,9 +360,15 @@ def test_observe_files_persist(dummy_run_with_observe):
 
 @pytest.mark.integration
 def test_wrapper_invalid_module(dummy_run_with_observe):
-    """Test that wrapper raises error when config has unknown observe module.
+    """A misspelled synthesis module is refused by name rather than falling back to the
+    only module that exists, and the refusal happens before any other config is read.
 
-    Validates error handling for invalid configuration.
+    The message has to carry the offending name, since that is what tells the reader
+    which config line to correct. The second call supplies a config holding nothing but
+    the module name: it must still fail on the module rather than on the attributes it
+    lacks, which pins the dispatch as the first thing the function does. That ordering is
+    what makes the error survive a config that is broken in more than one way, instead of
+    surfacing whichever problem the reader happens to reach first.
     """
     runner, _, hf_row = dummy_run_with_observe
 
@@ -379,8 +385,17 @@ def test_wrapper_invalid_module(dummy_run_with_observe):
     bad_config.atmos_clim.module = runner.config.atmos_clim.module
     bad_config.atmos_chem.module = runner.config.atmos_chem.module
 
-    with pytest.raises(ValueError, match='Unknown synthesis module'):
+    with pytest.raises(ValueError, match='Unknown synthesis module') as excinfo:
         calc_synthetic_spectra(hf_row, bad_config, runner.directories)
+    assert 'invalid_module' in str(excinfo.value)
+
+    # A config carrying only the module name still fails on the module, so the dispatch
+    # runs before the source and spectrum-type lookups touch the other sections.
+    bare_config = _Obj()
+    bare_config.observe = _Obj()
+    bare_config.observe.module = 'invalid_module'
+    with pytest.raises(ValueError, match='Unknown synthesis module'):
+        calc_synthetic_spectra(hf_row, bare_config, runner.directories)
 
 
 @pytest.mark.integration

--- a/tests/observe/test_petitRADTRANS.py
+++ b/tests/observe/test_petitRADTRANS.py
@@ -201,16 +201,14 @@ def test_vmrs_to_mass_fractions_normalizes_remaining_species(monkeypatch):
     np.testing.assert_allclose(mass_fractions['H2'], np.array([1.0 / 3.0, 0.6]), rtol=1e-12)
     np.testing.assert_allclose(mass_fractions['He'], np.array([2.0 / 3.0, 0.4]), rtol=1e-12)
     # Carries the VMR scale, so this is the pin that sees the renormalization: skipping
-    # it gives 0.6 and 1.0. petitRADTRANS wants amu (g mol-1), so the kg mol-1 masses are
-    # scaled by 1e3; dropping that conversion lands three decades away at 3.0e-3.
+    # it gives 0.6 and 1.0, factors of 5 and 2.5 away. petitRADTRANS wants amu (g mol-1),
+    # so the kg mol-1 masses are scaled by 1e3; dropping that lands three decades off, at
+    # 3.0e-3.
     np.testing.assert_allclose(mean_molar_masses, np.array([3.0, 2.5]), rtol=1e-12)
 
-    # Every gas in the mix reaches the output: the returned fractions account for all of
-    # the mass. This is closure over the dict, not over the arithmetic, so it fails if a
-    # contributing gas is filtered out of the result rather than merely mis-weighted.
-    np.testing.assert_allclose(sum(mass_fractions.values()), np.ones(2), rtol=1e-12)
-    # Boundedness: a single species can neither carry none of the mass nor all of it in a
-    # two-gas mix, so a sign slip in either contribution escapes the interval.
+    # Sign and scale guard for the pins above: in a two-gas mix neither species can carry
+    # none of the mass nor all of it, so a negative contribution or a swapped denominator
+    # leaves the interval.
     for gas in gases:
         assert np.all((mass_fractions[gas] > 0.0) & (mass_fractions[gas] < 1.0))
 
@@ -251,8 +249,10 @@ def test_get_input_data_path_prefers_fwl_data_directory(monkeypatch, tmp_path):
 
     The nested directory is created but its parents are not otherwise populated, so the
     returned path has to be the nested one rather than the FWL root itself. The second
-    check confirms the helper hands back a path that actually exists on disk instead of
-    a plausible string it assembled without probing.
+    case pins that the probe asks whether the candidate is a directory and not merely
+    whether something sits at that name: a plain file called input_data is not an opacity
+    tree, and accepting it would move the failure into petitRADTRANS, where it surfaces
+    as a far less obvious error.
     """
     mod = _import_backend(monkeypatch)
 
@@ -261,7 +261,12 @@ def test_get_input_data_path_prefers_fwl_data_directory(monkeypatch, tmp_path):
 
     result = mod._get_input_data_path({'fwl': str(tmp_path)})
     assert result == str(data_path)
-    assert Path(result).is_dir()
+
+    file_root = tmp_path / 'file_root'
+    (file_root / 'prt').mkdir(parents=True)
+    (file_root / 'prt' / 'input_data').write_text('a file, not an opacity tree')
+    with pytest.raises(FileNotFoundError):
+        mod._get_input_data_path({'fwl': str(file_root)})
 
 
 def test_get_input_data_path_raises_when_missing_everywhere(monkeypatch, tmp_path):
@@ -289,12 +294,15 @@ def test_get_input_data_path_raises_when_dirs_missing_fwl(monkeypatch, tmp_path)
     error would mislead: a missing key means the run started without FWL_DATA resolved,
     while a present key with no prt/input_data underneath means the reference data was
     never fetched. The second call supplies the key but points it at a directory that
-    does not exist, and must surface FileNotFoundError instead of KeyError. A guard
-    that probed the filesystem before checking the key would report the wrong one.
+    does not exist, and must surface FileNotFoundError instead of KeyError.
+
+    The guard raises with its own wording, and that wording is what the match keys off.
+    A bare lookup of a key a dictionary lacks raises KeyError('fwl') on its own, so the
+    message is the only thing separating the deliberate check from the subscript.
     """
     mod = _import_backend(monkeypatch)
 
-    with pytest.raises(KeyError, match='fwl'):
+    with pytest.raises(KeyError, match='Missing required'):
         mod._get_input_data_path({})
 
     with pytest.raises(FileNotFoundError):
@@ -629,11 +637,12 @@ def test_get_ptr_reverses_without_vmrs_when_descending(monkeypatch):
     """A descending profile is reordered even when the caller supplies no VMRs, and the
     reordered temperatures are pulled inside the range the opacity tables cover.
 
-    The coldest level sits at 100 K, just under the 100.5 K floor petitRADTRANS
-    supports, so the clamp is observable: without it that entry stays at 100 K and the
-    lower-bound assertion fails. Choosing a temperature only half a kelvin below the
-    floor also keeps the clamp from masking a failed reversal, since the reversal is
-    checked on pressure and radius, which are not clamped.
+    The profile straddles both limits: the coldest level sits at 100 K, half a kelvin
+    under the floor, and the hottest at 5000 K, a kilokelvin over the ceiling, so each
+    clamp is observable and a profile that skipped either end keeps a value the pin
+    rejects. The middle level is left well inside the range, so the clamp cannot disguise
+    a failed reversal, which is in any case checked on pressure and radius, neither of
+    which is clamped.
 
     This is the branch where passing no VMRs matters: the reordering block is entered,
     so the guard in front of the VMR rewrite is what keeps the helper from iterating
@@ -644,7 +653,7 @@ def test_get_ptr_reverses_without_vmrs_when_descending(monkeypatch):
 
     atm = {
         'pl': np.array([1.0e5, 1.0e4, 1.0e3]),
-        'tmpl': np.array([100.0, 200.0, 300.0]),
+        'tmpl': np.array([100.0, 200.0, 5000.0]),
         'rl': np.array([1.0, 2.0, 3.0]),
     }
 
@@ -652,7 +661,12 @@ def test_get_ptr_reverses_without_vmrs_when_descending(monkeypatch):
 
     assert np.array_equal(prs, np.array([1.0e3, 1.0e4, 1.0e5]))
     assert np.array_equal(rad, np.array([3.0, 2.0, 1.0]))
-    assert np.all(tmp >= mod.petitRADTRANS_TLIMS[0])
+    # petitRADTRANS covers 100 to 4000 K and the helper insets each end by half a kelvin,
+    # so a clamped profile lies within [100.5, 3999.5]. The bounds are written out here as
+    # values in their own right: the outer levels both fall outside them and come back
+    # clamped, while the middle level passes through, so the reversal and both limits are
+    # pinned in one comparison.
+    np.testing.assert_allclose(tmp, np.array([3999.5, 200.0, 100.5]), rtol=1e-12)
     assert vmrs_sorted is None
 
 
@@ -861,10 +875,9 @@ def test_transit_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_p
     as one of them: no branch binds an atmosphere, so the call fails on the unbound name
     rather than synthesising a spectrum from whatever happens to be lying around.
 
-    The contrast call is what makes the test discriminate: it repeats the call with a
-    recognised source and an unreadable profile, and that one leaves through the
-    ordinary guard with None, showing the failure belongs to the unknown source rather
-    than to the stubs. This pins the behaviour of a source name the module does not
+    The failure lands on the guard that reads the atmosphere, before any opacity is set
+    up, which is what the Radtrans count pins: an unrecognised source costs nothing more
+    than the reference read. This pins the behaviour of a source name the module does not
     validate, so it will need revisiting if an explicit check is added upstream.
     """
     mod = _import_backend(monkeypatch)
@@ -880,8 +893,7 @@ def test_transit_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_p
     with pytest.raises(UnboundLocalError):
         mod.transit_depth({'Time': 1, 'R_star': 1.0}, config, 'unknown_source', dirs)
 
-    monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
-    assert mod.transit_depth({'Time': 1, 'R_star': 1.0}, config, 'profile', dirs) is None
+    assert sys.modules['petitRADTRANS.radtrans'].Radtrans.call_count == 0
 
 
 def test_eclipse_depth_returns_none_when_atmosphere_missing(monkeypatch, tmp_path):
@@ -951,11 +963,9 @@ def test_eclipse_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_p
     same reason it fails the transit path, so neither spectrum is quietly produced from
     an unintended source.
 
-    The contrast call repeats the call with a recognised source and an unreadable
-    profile and returns None through the ordinary guard, which shows the failure tracks
-    the source name rather than the stubs. This pins the behaviour of a source name the
-    module does not validate, so it will need revisiting if an explicit check is added
-    upstream.
+    The failure lands on the guard that reads the atmosphere, before any opacity is set
+    up, which the Radtrans count pins. This pins the behaviour of a source name the module
+    does not validate, so it will need revisiting if an explicit check is added upstream.
     """
     mod = _import_backend(monkeypatch)
 
@@ -971,8 +981,7 @@ def test_eclipse_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_p
     with pytest.raises(UnboundLocalError):
         mod.eclipse_depth(hf_row, config, 'unknown_source', dirs)
 
-    monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
-    assert mod.eclipse_depth(hf_row, config, 'profile', dirs) is None
+    assert sys.modules['petitRADTRANS.radtrans'].Radtrans.call_count == 0
 
 
 def test_transit_depth_prioritizes_broadest_coverage_and_writes_output(monkeypatch, tmp_path):
@@ -1081,8 +1090,9 @@ def test_eclipse_depth_offchem_uses_latest_sflux_and_writes_output(monkeypatch, 
     Both spectra are tabulated only out to 600 nm while the stand-in transfer reports
     micron-scale wavelengths, so the interpolation runs off the end of the table and
     holds the last value, which is why the denominator is flat. The depths are pinned
-    absolutely to catch the wrong spectrum being read, and the counterfactual sits a
-    decade away, far outside the tolerance.
+    absolutely, which keeps the ppm conversion and the squared radius ratio under check,
+    and the run is then repeated with the later spectrum removed so the ratio of the two
+    identifies which spectrum was read.
     """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2O', 'CH4', 'H2'))
@@ -1162,28 +1172,30 @@ def test_eclipse_depth_offchem_uses_latest_sflux_and_writes_output(monkeypatch, 
         'Time': 1,
         'R_star': 7.0e8,
         'T_star': 1000.0,
-        'separation': 1.0e11,
+        # Equal to the stellar radius. The stand-in transfer never reads the separation,
+        # and holding the two equal makes the depth the same whether the geometric factor
+        # is taken against the stellar radius or against the orbital distance, so the pin
+        # below covers the ppm conversion and the squared radius ratio while staying clear
+        # of which distance belongs in the denominator.
+        'separation': 7.0e8,
         'R_int': 7.0e6,
     }
 
-    result = mod.eclipse_depth(
-        hf_row,
-        config,
-        'offchem',
-        {'fwl': str(tmp_path), 'output': str(tmp_path)},
-    )
+    dirs = {'fwl': str(tmp_path), 'output': str(tmp_path)}
+    result = mod.eclipse_depth(hf_row, config, 'offchem', dirs)
 
     assert result.shape == (2, 2)
     assert FakeRadtrans.init_calls[0]['line_species'][0] == 'CH4'
 
-    # Planet fluxes of 1 and 2 over the 42.sflux plateau of 30 erg cm-2 s-1 nm-1, which
-    # is 3e8 erg cm-2 s-1 cm-1 after conversion, scaled by (R_p / R_star)^2 =
-    # (7.0e8 / 7.0e10)^2 and expressed in ppm.
+    # Planet fluxes of 1 and 2 over the 42.sflux plateau of 30 erg cm-2 s-1 nm-1, which is
+    # 3e8 erg cm-2 s-1 cm-1 once converted, times the squared radius ratio (7.0e8/7.0e10)^2,
+    # in ppm.
     np.testing.assert_allclose(
         result[:, 1], np.array([3.3333333e-07, 6.6666667e-07]), rtol=1e-6
     )
-    # Scale guard: 1.sflux would put the depths at 3.3e-6 and 6.7e-6, a decade higher.
-    assert np.all(result[:, 1] < 1.0e-6)
+    # Scale guard: without the ppm factor these land six decades lower, and a cubed radius
+    # ratio two decades lower again.
+    assert np.all((result[:, 1] > 1.0e-8) & (result[:, 1] < 1.0e-6))
 
     assert Path(tmp_path / 'observe' / 'eclipse_offchem_synthesis.csv').is_file()
     content = (tmp_path / 'observe' / 'eclipse_offchem_synthesis.csv').read_text()
@@ -1196,6 +1208,14 @@ def test_eclipse_depth_offchem_uses_latest_sflux_and_writes_output(monkeypatch, 
         'CH4_removed/ppm',
         'H2_removed/ppm',
     ]
+
+    # The two runs differ only in which spectrum is on disk, so their ratio names the one
+    # that was read. The later spectrum is ten times the brighter, so it gives depths a
+    # tenth the size. This is checked after the written output, so the file inspected
+    # above belongs to the run the rest of the test describes.
+    (data_dir / '42.sflux').unlink()
+    older = mod.eclipse_depth(hf_row, config, 'offchem', dirs)
+    np.testing.assert_allclose(result[:, 1] / older[:, 1], np.full(2, 0.1), rtol=1e-6)
 
 
 def test_transit_depth_disables_removed_species_columns(monkeypatch, tmp_path):

--- a/tests/observe/test_petitRADTRANS.py
+++ b/tests/observe/test_petitRADTRANS.py
@@ -108,6 +108,15 @@ def _make_config(
 
 
 def test_get_reference_prt_values_uses_closest_config_pressure(monkeypatch):
+    """Reference values are taken from the atmospheric layer sitting closest to the
+    configured reference pressure, converted into the units petitRADTRANS expects.
+
+    The configured reference of 11.5 bar is compared against decade-spaced layers at
+    1, 10, 100 and 1000 bar, so the 10 bar layer wins. Decade spacing means picking a
+    neighbouring layer moves the answer by a factor of ten, far outside the tolerance.
+    The radius and gravity pins sit a factor of 100 above their SI inputs, so a missing
+    metre-to-centimetre conversion fails them too.
+    """
     mod = _import_backend(monkeypatch)
 
     atm = {
@@ -128,6 +137,16 @@ def test_get_reference_prt_values_uses_closest_config_pressure(monkeypatch):
 
 
 def test_get_ptr_reverses_vmrs_with_descending_pressure(monkeypatch):
+    """A profile stored from the surface upwards runs from high to low pressure, and
+    petitRADTRANS needs it the other way round, so pressure, temperature, radius and
+    every VMR array must be reversed together.
+
+    Each array is strictly monotonic with distinct entries, so a reversal that silently
+    skips one of them leaves that array's values attached to the wrong pressure and the
+    corresponding assertion fails. The two VMR arrays are complementary at every layer,
+    which is why they are compared element by element rather than by their sum: a
+    per-layer sum stays at one whether or not the reversal happened.
+    """
     mod = _import_backend(monkeypatch)
 
     atm = {
@@ -150,30 +169,62 @@ def test_get_ptr_reverses_vmrs_with_descending_pressure(monkeypatch):
     assert np.array_equal(vmrs_sorted[1], np.array([0.70, 0.80, 0.90]))
 
 
+@pytest.mark.physics_invariant
 def test_vmrs_to_mass_fractions_normalizes_remaining_species(monkeypatch):
+    """Clipping trace gases leaves the surviving VMRs summing to less than one, so the
+    conversion renormalizes them before weighting by molar mass.
+
+    The renormalization is observable only in the mean molar mass. A mass fraction is
+    the ratio v_i M_i / sum_j(v_j M_j), which is unchanged when every VMR in a layer is
+    scaled by the same constant, so the mass-fraction pins here hold with or without the
+    step. The mean molar mass is an absolute quantity and does carry the scale: with the
+    raw VMRs summing to 0.2 and 0.4 it would come back as 0.6 and 1.0 g/mol rather than
+    3.0 and 2.5, so that pin is the one discriminating the renormalization.
+
+    The two layers are asymmetric so that a swapped species index is visible: layer 0 is
+    an equal H2/He mix and layer 1 is three parts H2 to one part He. With H2 at 2 g/mol
+    and He at 4 g/mol the mass fractions follow by hand as 1/3 and 2/3 in layer 0 and
+    0.6 and 0.4 in layer 1. An equal-parts mixture in both layers would be symmetric
+    under an H2/He swap and would not discriminate one from the other.
+    """
     mod = _import_backend(monkeypatch)
 
     gases = ['H2', 'He']
     vmrs = [
-        np.array([0.10, 0.30]),
-        np.array([0.10, 0.10]),
+        np.array([0.10, 0.30]),  # H2; the per-layer VMR sums are 0.2 and 0.4, not 1.0
+        np.array([0.10, 0.10]),  # He
     ]
 
     mass_fractions, mean_molar_masses = mod._vmrs_to_mass_fractions(gases, vmrs)
 
-    vmr_arr = np.array(vmrs, dtype=float)
-    vmr_norm = vmr_arr / np.sum(vmr_arr, axis=0)
-    molar_masses = np.array([mod.eval_gas_mmw(gas) for gas in gases], dtype=float)
-    mass_contrib = vmr_norm * molar_masses[:, None]
-    total_mass = np.sum(mass_contrib, axis=0)
+    # Hand-computed from the VMR ratios and the 2 / 4 g mol-1 molar masses.
+    np.testing.assert_allclose(mass_fractions['H2'], np.array([1.0 / 3.0, 0.6]), rtol=1e-12)
+    np.testing.assert_allclose(mass_fractions['He'], np.array([2.0 / 3.0, 0.4]), rtol=1e-12)
+    # Carries the VMR scale, so this is the pin that sees the renormalization: skipping
+    # it gives 0.6 and 1.0. petitRADTRANS wants amu (g mol-1), so the kg mol-1 masses are
+    # scaled by 1e3; dropping that conversion lands three decades away at 3.0e-3.
+    np.testing.assert_allclose(mean_molar_masses, np.array([3.0, 2.5]), rtol=1e-12)
 
-    assert np.allclose(mass_fractions['H2'], mass_contrib[0] / total_mass)
-    assert np.allclose(mass_fractions['He'], mass_contrib[1] / total_mass)
-    assert np.allclose(mean_molar_masses, total_mass / 1.0e-3)
-    assert np.allclose(np.sum(vmr_norm, axis=0), 1.0)
+    # Every gas in the mix reaches the output: the returned fractions account for all of
+    # the mass. This is closure over the dict, not over the arithmetic, so it fails if a
+    # contributing gas is filtered out of the result rather than merely mis-weighted.
+    np.testing.assert_allclose(sum(mass_fractions.values()), np.ones(2), rtol=1e-12)
+    # Boundedness: a single species can neither carry none of the mass nor all of it in a
+    # two-gas mix, so a sign slip in either contribution escapes the interval.
+    for gas in gases:
+        assert np.all((mass_fractions[gas] > 0.0) & (mass_fractions[gas] < 1.0))
 
 
 def test_load_stellar_toa_flux_reads_saved_sflux_and_interpolates(monkeypatch, tmp_path):
+    """The stellar spectrum PROTEUS wrote alongside the run is read back and resampled
+    onto the wavelength grid the eclipse-depth denominator is evaluated on.
+
+    The tabulated flux doubles between successive wavelengths (1, 2 and 4 at 400, 500
+    and 600 nm) and the two targets sit at the midpoints, so linear interpolation gives
+    1.5 and 3.0 whereas interpolating in log space would give about 1.41 and 2.83. The
+    trailing factor of 1e7 converts erg cm-2 s-1 nm-1 into erg cm-2 s-1 cm-1, so a
+    dropped unit conversion moves the answer by seven decades.
+    """
     mod = _import_backend(monkeypatch)
 
     data_dir = tmp_path / 'data'
@@ -190,10 +241,19 @@ def test_load_stellar_toa_flux_reads_saved_sflux_and_interpolates(monkeypatch, t
     flux = mod._load_stellar_toa_flux(str(tmp_path), {'Time': 42}, target_wavelength_nm)
 
     assert flux.shape == (2,)
-    assert np.allclose(flux, np.array([1.5e7, 3.0e7]))
+    # rtol well inside the 6% gap between the linear result and the log-space one.
+    np.testing.assert_allclose(flux, np.array([1.5e7, 3.0e7]), rtol=1e-9)
 
 
 def test_get_input_data_path_prefers_fwl_data_directory(monkeypatch, tmp_path):
+    """The petitRADTRANS opacity tree is resolved as prt/input_data underneath the FWL
+    data directory recorded in the startup dirs, and returned as a plain string.
+
+    The nested directory is created but its parents are not otherwise populated, so the
+    returned path has to be the nested one rather than the FWL root itself. The second
+    check confirms the helper hands back a path that actually exists on disk instead of
+    a plausible string it assembled without probing.
+    """
     mod = _import_backend(monkeypatch)
 
     data_path = tmp_path / 'prt' / 'input_data'
@@ -205,6 +265,14 @@ def test_get_input_data_path_prefers_fwl_data_directory(monkeypatch, tmp_path):
 
 
 def test_get_input_data_path_raises_when_missing_everywhere(monkeypatch, tmp_path):
+    """An FWL data directory that carries no petitRADTRANS opacity tree is a hard error
+    rather than a silent fallback, because synthesising a spectrum without opacities
+    would otherwise fail much later with an unrelated message.
+
+    The path handed in does not exist at all, which is the shape of the problem when
+    the reference data was never downloaded. The message has to name the directory it
+    probed so the reader can see which tree was expected.
+    """
     mod = _import_backend(monkeypatch)
 
     with pytest.raises(FileNotFoundError) as excinfo:
@@ -212,14 +280,39 @@ def test_get_input_data_path_raises_when_missing_everywhere(monkeypatch, tmp_pat
     assert 'input_data' in str(excinfo.value)
 
 
-def test_get_input_data_path_raises_when_dirs_missing_fwl(monkeypatch):
+def test_get_input_data_path_raises_when_dirs_missing_fwl(monkeypatch, tmp_path):
+    """A dirs dictionary carrying no 'fwl' entry is reported as a missing key, kept
+    distinct from the error raised when the entry is present but the tree behind it is
+    not.
+
+    The two misconfigurations have different remedies, so collapsing them into one
+    error would mislead: a missing key means the run started without FWL_DATA resolved,
+    while a present key with no prt/input_data underneath means the reference data was
+    never fetched. The second call supplies the key but points it at a directory that
+    does not exist, and must surface FileNotFoundError instead of KeyError. A guard
+    that probed the filesystem before checking the key would report the wrong one.
+    """
     mod = _import_backend(monkeypatch)
 
     with pytest.raises(KeyError, match='fwl'):
         mod._get_input_data_path({})
 
+    with pytest.raises(FileNotFoundError):
+        mod._get_input_data_path({'fwl': str(tmp_path / 'no_such_tree')})
+
 
 def test_supported_species_helpers_filter_and_include(monkeypatch, tmp_path):
+    """The three opacity-selection helpers each drop a gas for their own reason, and the
+    gas list is filtered rather than passed through wholesale.
+
+    The line-species list separates the three exclusion routes on purpose: 'skipme' is
+    excluded because it is an ignored gas, 'Ray' because it is handled as a Rayleigh
+    scatterer instead, and CO2 because no opacity directory exists for it even though it
+    is a perfectly ordinary gas. Rayleigh and CIA selection are each checked with the
+    switch both off and on, so a helper wired to ignore its flag fails one of the pair.
+    CIA offers 'H2--He' and 'H2--N2' while the mix holds no N2, which pins that every
+    component of a collision pair must be present rather than just one.
+    """
     mod = _import_backend(monkeypatch)
 
     input_data_path = tmp_path / 'input_data'
@@ -241,7 +334,15 @@ def test_supported_species_helpers_filter_and_include(monkeypatch, tmp_path):
     assert mod._get_supported_cia_species(['H2', 'He'], True) == ['H2--He']
 
 
-def test_supported_line_species_resolves_input_path_when_not_provided(monkeypatch, tmp_path):
+def test_supported_line_species_filters_by_provided_data_tree(monkeypatch, tmp_path):
+    """Opacity availability is resolved underneath the input-data path handed to the
+    helper, so pointing a run at a different data tree changes which gases survive.
+
+    The first tree holds an opacity directory for H2 but none for He, so only H2 comes
+    back. The second call passes the same gases against a separate, empty tree and must
+    return nothing: without that contrast a helper that ignored its argument and read
+    from a module-level default would still satisfy the first assertion.
+    """
     mod = _import_backend(monkeypatch)
 
     auto_path = tmp_path / 'auto_input_data'
@@ -249,8 +350,22 @@ def test_supported_line_species_resolves_input_path_when_not_provided(monkeypatc
     line_species = mod._get_supported_line_species(['H2', 'He'], str(auto_path))
     assert line_species == ['H2']
 
+    empty_path = tmp_path / 'empty_input_data'
+    empty_path.mkdir()
+    assert mod._get_supported_line_species(['H2', 'He'], str(empty_path)) == []
+
 
 def test_vmrs_to_mass_fractions_handles_empty_and_zero_total(monkeypatch):
+    """A composition with no gases left after clipping short-circuits to empty outputs,
+    and a mix whose molar masses all vanish is refused rather than divided by.
+
+    The empty case is the boundary reached when every gas falls below the clip
+    threshold; it must return empty containers instead of raising, because the callers
+    treat that as a legitimate no-op. The second case patches the molar-mass lookup to
+    zero so the total mass collapses while the VMR sum stays positive, which reaches the
+    mass guard without tripping the earlier VMR guard first and keeps the two error
+    paths separable.
+    """
     mod = _import_backend(monkeypatch)
 
     mass_fractions, mean_molar_masses = mod._vmrs_to_mass_fractions(['H2'], [])
@@ -263,13 +378,33 @@ def test_vmrs_to_mass_fractions_handles_empty_and_zero_total(monkeypatch):
 
 
 def test_vmrs_to_mass_fractions_raises_for_zero_total_vmr(monkeypatch):
+    """A layer holding no gas at all cannot be renormalized, so the conversion refuses
+    instead of dividing by zero and handing NaN mass fractions to petitRADTRANS.
+
+    The first case empties every layer. The second is the discriminating one: only the
+    upper layer is empty while the lower one holds an ordinary H2/He mix. The guard is
+    written over np.any, so one bad layer among good ones must still raise; a guard
+    written over np.all would accept this mix and let the NaN through.
+    """
     mod = _import_backend(monkeypatch)
 
     with pytest.raises(ValueError, match='zero total VMR'):
         mod._vmrs_to_mass_fractions(['H2', 'He'], [np.array([0.0, 0.0]), np.array([0.0, 0.0])])
 
+    with pytest.raises(ValueError, match='zero total VMR'):
+        mod._vmrs_to_mass_fractions(['H2', 'He'], [np.array([0.8, 0.0]), np.array([0.2, 0.0])])
+
 
 def test_prioritize_broadest_coverage_species_noop_paths(monkeypatch):
+    """When no coverage can be discovered the incoming order is left untouched, so an
+    undiscoverable opacity tree degrades to the caller's ordering instead of an error or
+    an empty list.
+
+    Both calls use a path that does not exist, which is what makes the coverage lookup
+    return nothing for every species. The empty-list case guards the boundary where
+    there is no species to promote at all, and the populated case pins that species with
+    no parseable coverage file keep their relative order rather than being dropped.
+    """
     mod = _import_backend(monkeypatch)
 
     assert mod._prioritize_broadest_coverage_species([], '/unused') == []
@@ -280,6 +415,18 @@ def test_prioritize_broadest_coverage_species_noop_paths(monkeypatch):
 
 
 def test_prioritize_broadest_coverage_species_uses_widest_file(monkeypatch, tmp_path):
+    """The line species with the widest wavelength coverage is moved to the front while
+    the rest keep the order they arrived in, because petitRADTRANS takes its output grid
+    from the first line species it is given.
+
+    Coverage is parsed out of the opacity filenames: CH4 spans 0.3 to 50 um (49.7 um
+    wide), H2O spans 0.5 to 5 um (4.5 um) and CO2 spans 1 to 2 um (1 um). The widths are
+    an order of magnitude apart so the winner is unambiguous. Feeding the same three
+    species twice in different orders separates promoting the widest from sorting the
+    whole list by width. The tables sit in isotopologue subdirectories, mirroring the
+    petitRADTRANS tree where files live one level below the species directory, so a
+    non-recursive search finds nothing and leaves the input order untouched.
+    """
     mod = _import_backend(monkeypatch)
 
     input_data_path = tmp_path / 'input_data'
@@ -292,13 +439,29 @@ def test_prioritize_broadest_coverage_species_uses_widest_file(monkeypatch, tmp_
         (species_dir / iso_dir).mkdir(parents=True)
         (species_dir / iso_dir / file_name).write_text('dummy')
 
-    species = ['CO2', 'H2O', 'CH4']
-    result = mod._prioritize_broadest_coverage_species(species, str(input_data_path))
-
+    result = mod._prioritize_broadest_coverage_species(
+        ['CO2', 'H2O', 'CH4'], str(input_data_path)
+    )
     assert result == ['CH4', 'CO2', 'H2O']
+
+    # Same species, permuted input. CH4 leads both times, but the trailing pair follows
+    # the input order rather than a fixed ranking, which is what separates the contract
+    # from a width sort: above, a sort would have put H2O (4.5 um) ahead of CO2 (1 um).
+    permuted = mod._prioritize_broadest_coverage_species(
+        ['H2O', 'CO2', 'CH4'], str(input_data_path)
+    )
+    assert permuted == ['CH4', 'H2O', 'CO2']
 
 
 def test_init_radtrans_suppresses_output_when_enabled(monkeypatch, capsys):
+    """With silencing switched on, the chatter petitRADTRANS prints while loading
+    opacities is captured instead of reaching the PROTEUS console.
+
+    The stand-in constructor writes to stdout and stderr both, because petitRADTRANS
+    uses both and a redirect covering only stdout would leave half the noise visible.
+    The companion test drives the same constructor with silencing off, which is what
+    rules out this test passing merely because the constructor never ran.
+    """
     mod = _import_backend(monkeypatch)
 
     class NoisyRadtrans:
@@ -315,6 +478,13 @@ def test_init_radtrans_suppresses_output_when_enabled(monkeypatch, capsys):
 
 
 def test_init_radtrans_keeps_output_when_silencing_disabled(monkeypatch, capsys):
+    """With silencing switched off the constructor's output reaches the console
+    untouched, so the redirect is applied only when it was asked for.
+
+    This is the counterpart to the suppression test: the same noisy constructor and the
+    same call, differing only in the config flag. Together the pair pins that the
+    suppression comes from the flag rather than from the constructor staying silent.
+    """
     mod = _import_backend(monkeypatch)
 
     class NoisyRadtrans:
@@ -331,6 +501,17 @@ def test_init_radtrans_keeps_output_when_silencing_disabled(monkeypatch, capsys)
 
 
 def test_get_mix_handles_outgas_profile_and_offchem(monkeypatch):
+    """Each composition source reads its VMRs from a different place and shapes them
+    differently, so the three routes are exercised against one another.
+
+    The helpfile carries a single surface VMR per gas, which becomes a column constant
+    with height; the climate profile carries per-level VMRs under '<gas>_vmr' keys and
+    is padded at the bottom, repeating the lowest level so the array matches the
+    level-edge grid; the chemistry output carries per-level VMRs under bare gas names.
+    The helpfile and profile values for the same gas are deliberately different (0.8
+    against 0.7 and 0.6), so a source mix-up produces the wrong column rather than a
+    coincidentally identical one.
+    """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2', 'CH4', 'He'))
 
@@ -361,6 +542,16 @@ def test_get_mix_handles_outgas_profile_and_offchem(monkeypatch):
 
 
 def test_get_mix_excludes_species_when_source_keys_missing_or_below_clip(monkeypatch):
+    """Gases too rare to matter for radiative transfer are dropped, whether they are
+    rare because the source reports a tiny abundance or absent from the source entirely.
+
+    The clip sits at 1e-5 and the cases straddle it. Outgas reports 1e-6, safely below,
+    so nothing survives. The profile peaks at exactly 1e-5, which is the boundary: the
+    comparison is inclusive, so H2 is kept, and an exclusive comparison would drop it.
+    Offchem reports 2e-5, clearly above. CH4 and He appear in no source, so they fall
+    back to zero and are dropped, which is the path a gas takes when the atmosphere
+    module never wrote it.
+    """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2', 'CH4', 'He'))
 
@@ -387,6 +578,16 @@ def test_get_mix_excludes_species_when_source_keys_missing_or_below_clip(monkeyp
 
 
 def test_get_mix_unknown_source_returns_empty_selection(monkeypatch):
+    """An unrecognised source name leaves every gas at its zero default, so nothing
+    clears the clip and the selection comes back empty rather than falling through to
+    one of the known sources.
+
+    The helpfile holds abundances that would comfortably clear the clip under 'outgas',
+    so a dispatch that quietly treated an unknown name as the default source would
+    return both gases here and fail the assertions. Selecting nothing is what lets the
+    callers surface the bad source name themselves rather than synthesising a spectrum
+    from an empty atmosphere.
+    """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2', 'CH4'))
 
@@ -399,6 +600,14 @@ def test_get_mix_unknown_source_returns_empty_selection(monkeypatch):
 
 
 def test_get_ptr_keeps_order_when_already_ascending_and_vmrs_none(monkeypatch):
+    """A profile that already runs from low to high pressure is handed back untouched,
+    and a caller that supplies no VMRs gets None back.
+
+    The reversal is conditional on the second pressure sitting below the first, so this
+    is the branch where none of the arrays are rewritten and the returned arrays must
+    equal the inputs element for element. The temperatures sit inside the supported
+    range, so this branch says nothing about the clamp; its companion covers that.
+    """
     mod = _import_backend(monkeypatch)
 
     atm = {
@@ -415,7 +624,22 @@ def test_get_ptr_keeps_order_when_already_ascending_and_vmrs_none(monkeypatch):
     assert vmrs_sorted is None
 
 
+@pytest.mark.physics_invariant
 def test_get_ptr_reverses_without_vmrs_when_descending(monkeypatch):
+    """A descending profile is reordered even when the caller supplies no VMRs, and the
+    reordered temperatures are pulled inside the range the opacity tables cover.
+
+    The coldest level sits at 100 K, just under the 100.5 K floor petitRADTRANS
+    supports, so the clamp is observable: without it that entry stays at 100 K and the
+    lower-bound assertion fails. Choosing a temperature only half a kelvin below the
+    floor also keeps the clamp from masking a failed reversal, since the reversal is
+    checked on pressure and radius, which are not clamped.
+
+    This is the branch where passing no VMRs matters: the reordering block is entered,
+    so the guard in front of the VMR rewrite is what keeps the helper from iterating
+    None. The transit and eclipse paths both call the helper this way when they want
+    pressure, temperature and radius alone.
+    """
     mod = _import_backend(monkeypatch)
 
     atm = {
@@ -433,6 +657,16 @@ def test_get_ptr_reverses_without_vmrs_when_descending(monkeypatch):
 
 
 def test_atm_profile_and_offchem_helpers(monkeypatch, tmp_path):
+    """The two profile readers hand back the current atmosphere in a common shape: the
+    climate reader returns the latest record, and the chemistry reader renames its
+    columns and converts height above the surface into planetary radius.
+
+    The chemistry output names its columns tmp, p and z while the rest of the backend
+    works in tmpl, pl and rl, so the rename is what lets one set of downstream helpers
+    serve both sources. The height offset is the substantive step: with the sample point
+    at z = 0 and the interior radius at 10 m, the radius has to come back as 10, whereas
+    a reader that forgot to add the interior radius would leave it at 0.
+    """
     mod = _import_backend(monkeypatch)
 
     fake_atmos_clim_common = types.ModuleType('proteus.atmos_clim.common')
@@ -463,6 +697,15 @@ def test_atm_profile_and_offchem_helpers(monkeypatch, tmp_path):
 
 
 def test_get_atm_profile_returns_none_when_no_data(monkeypatch):
+    """A run whose climate output holds no record for the requested time is reported by
+    returning None, not by raising, because the callers treat a missing profile as a
+    reason to skip synthesis rather than to abort the simulation.
+
+    The reader is stubbed to return an empty list, which is the shape it takes when the
+    output directory holds no snapshot at that time. The call count pins that the empty
+    result came from a read that was actually attempted, rather than from a short-circuit
+    that never consulted the output directory at all.
+    """
     mod = _import_backend(monkeypatch)
 
     fake_atmos_clim_common = types.ModuleType('proteus.atmos_clim.common')
@@ -478,6 +721,14 @@ def test_get_atm_profile_returns_none_when_no_data(monkeypatch):
 
 
 def test_get_atm_offchem_returns_none_when_no_result(monkeypatch):
+    """A run whose chemistry output is absent is reported by returning None, mirroring
+    the climate reader so the callers can guard both sources the same way.
+
+    The reader is stubbed to return None, the shape it takes when the chemistry module
+    never wrote a result. The call count pins that the read was attempted, and the None
+    is returned before the column rename and the radius offset, both of which would
+    raise on a None result.
+    """
     mod = _import_backend(monkeypatch)
 
     fake_atmos_chem_common = types.ModuleType('proteus.atmos_chem.common')
@@ -493,6 +744,13 @@ def test_get_atm_offchem_returns_none_when_no_result(monkeypatch):
 
 
 def test_load_stellar_toa_flux_raises_when_missing_files(monkeypatch, tmp_path):
+    """A run with no stellar spectrum on disk is a hard error, because the eclipse depth
+    is a ratio against that spectrum and there is no sensible default to stand in for it.
+
+    The data directory is empty, which is the state before the star module has written
+    anything. The message has to name the directory that was searched, since the usual
+    cause is an output path pointing somewhere unexpected.
+    """
     mod = _import_backend(monkeypatch)
 
     with pytest.raises(FileNotFoundError) as excinfo:
@@ -500,19 +758,49 @@ def test_load_stellar_toa_flux_raises_when_missing_files(monkeypatch, tmp_path):
     assert 'No stellar spectrum files' in str(excinfo.value)
 
 
-def test_load_stellar_toa_flux_ignores_nonnumeric_stems(monkeypatch, tmp_path):
+def test_load_stellar_toa_flux_selects_latest_by_numeric_prefix(monkeypatch, tmp_path):
+    """The stellar spectrum is picked by the number in its filename, which is how the
+    most recent snapshot is identified, and files whose stem is not a number are ranked
+    below every numbered one instead of derailing the selection.
+
+    The first directory pairs an unnumbered file with a numbered one and the unnumbered
+    flux is an order of magnitude larger, so picking it would be obvious in the result.
+    The second directory is the discriminating case: it holds 7.sflux and 10.sflux, and
+    10 is the later snapshot numerically while '7' is the larger of the two as text, so
+    a selection that compared filenames as strings would read the earlier spectrum. Both
+    pins are checked after the erg nm-1 to erg cm-1 conversion.
+    """
     mod = _import_backend(monkeypatch)
 
-    data_dir = tmp_path / 'data'
-    data_dir.mkdir(parents=True)
-    (data_dir / 'abc.sflux').write_text('wl flux\n400 99\n500 99\n')
-    (data_dir / '7.sflux').write_text('wl flux\n400 1\n500 3\n')
+    mixed_dir = tmp_path / 'mixed'
+    (mixed_dir / 'data').mkdir(parents=True)
+    (mixed_dir / 'data' / 'abc.sflux').write_text('wl flux\n400 99\n500 99\n')
+    (mixed_dir / 'data' / '7.sflux').write_text('wl flux\n400 1\n500 3\n')
 
-    flux = mod._load_stellar_toa_flux(str(tmp_path), {'Time': 1}, np.array([450.0]))
-    assert np.allclose(flux, np.array([2.0e7]))
+    # 7.sflux interpolated at 450 nm gives 2, scaled to 2e7; abc.sflux would give 9.9e8.
+    flux = mod._load_stellar_toa_flux(str(mixed_dir), {'Time': 1}, np.array([450.0]))
+    np.testing.assert_allclose(flux, np.array([2.0e7]), rtol=1e-12)
+
+    numbered_dir = tmp_path / 'numbered'
+    (numbered_dir / 'data').mkdir(parents=True)
+    (numbered_dir / 'data' / '7.sflux').write_text('wl flux\n400 1\n500 3\n')
+    (numbered_dir / 'data' / '10.sflux').write_text('wl flux\n400 2\n500 6\n')
+
+    # 10.sflux interpolated at 450 nm gives 4, scaled to 4e7; 7.sflux would give 2e7.
+    latest = mod._load_stellar_toa_flux(str(numbered_dir), {'Time': 1}, np.array([450.0]))
+    np.testing.assert_allclose(latest, np.array([4.0e7]), rtol=1e-12)
 
 
 def test_transit_depth_returns_none_when_atmosphere_missing(monkeypatch, tmp_path):
+    """A time step whose atmosphere could not be read yields no transit spectrum, and
+    the bail-out happens before any opacity is loaded.
+
+    Returning None rather than raising is what lets the observation module run over a
+    time series where only some steps carry a written profile. The Radtrans count is the
+    substantive check: constructing one loads opacity tables from disk, so a guard
+    placed after that point would be slow and would fail on incomplete data instead of
+    skipping cleanly.
+    """
     mod = _import_backend(monkeypatch)
 
     monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
@@ -535,9 +823,21 @@ def test_transit_depth_returns_none_when_atmosphere_missing(monkeypatch, tmp_pat
 def test_transit_depth_offchem_returns_none_when_reference_profile_missing(
     monkeypatch, tmp_path
 ):
+    """The offchem source takes its composition from the chemistry output but still
+    needs the climate profile for the reference radius, pressure and gravity, so a
+    readable chemistry result is not on its own enough to produce a spectrum.
+
+    Only the climate read is stubbed away while the chemistry read succeeds, which
+    isolates the reference-profile guard from the composition guard: a chemistry result
+    is in hand, and the run still has to stand down. The call assertions pin that the
+    offchem branch was the one taken, without which this test would pass even if the
+    dispatch silently read the climate profile for composition too, since that read
+    returns None here as well.
+    """
     mod = _import_backend(monkeypatch)
 
-    monkeypatch.setattr(mod, '_get_atm_offchem', lambda *_a, **_k: {'pl': np.array([1.0e5])})
+    offchem_read = MagicMock(return_value={'pl': np.array([1.0e5])})
+    monkeypatch.setattr(mod, '_get_atm_offchem', offchem_read)
     monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
     monkeypatch.setattr(mod, '_get_input_data_path', lambda _dirs: str(tmp_path))
     fake_common = types.ModuleType('proteus.observe.common')
@@ -552,9 +852,21 @@ def test_transit_depth_offchem_returns_none_when_reference_profile_missing(
         {'fwl': str(tmp_path), 'output': str(tmp_path)},
     )
     assert result is None
+    offchem_read.assert_called_once()
+    assert sys.modules['petitRADTRANS.radtrans'].Radtrans.call_count == 0
 
 
 def test_transit_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_path):
+    """A source name outside the three the dispatch knows about is never quietly treated
+    as one of them: no branch binds an atmosphere, so the call fails on the unbound name
+    rather than synthesising a spectrum from whatever happens to be lying around.
+
+    The contrast call is what makes the test discriminate: it repeats the call with a
+    recognised source and an unreadable profile, and that one leaves through the
+    ordinary guard with None, showing the failure belongs to the unknown source rather
+    than to the stubs. This pins the behaviour of a source name the module does not
+    validate, so it will need revisiting if an explicit check is added upstream.
+    """
     mod = _import_backend(monkeypatch)
 
     monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: {'p': np.array([1.0e5])})
@@ -563,17 +875,24 @@ def test_transit_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_p
     fake_common.get_transit_fpath = lambda *_a, **_k: str(tmp_path / 'unused.csv')
     monkeypatch.setitem(sys.modules, 'proteus.observe.common', fake_common)
     config = _make_config()
+    dirs = {'fwl': str(tmp_path), 'output': str(tmp_path)}
 
     with pytest.raises(UnboundLocalError):
-        mod.transit_depth(
-            {'Time': 1, 'R_star': 1.0},
-            config,
-            'unknown_source',
-            {'fwl': str(tmp_path), 'output': str(tmp_path)},
-        )
+        mod.transit_depth({'Time': 1, 'R_star': 1.0}, config, 'unknown_source', dirs)
+
+    monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
+    assert mod.transit_depth({'Time': 1, 'R_star': 1.0}, config, 'profile', dirs) is None
 
 
 def test_eclipse_depth_returns_none_when_atmosphere_missing(monkeypatch, tmp_path):
+    """A time step whose atmosphere could not be read yields no eclipse spectrum, and
+    the bail-out precedes any opacity loading, mirroring the transit path.
+
+    The two spectra are produced from the same profile, so they have to agree on when a
+    step is skippable; a guard present on one path and missing on the other would abort
+    a time series that the other path walks over cleanly. The Radtrans count pins that
+    nothing expensive was set up first.
+    """
     mod = _import_backend(monkeypatch)
 
     monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
@@ -593,11 +912,22 @@ def test_eclipse_depth_returns_none_when_atmosphere_missing(monkeypatch, tmp_pat
     assert sys.modules['petitRADTRANS.radtrans'].Radtrans.call_count == 0
 
 
-def test_eclipse_depth_outgas_returns_none_when_reference_profile_missing(
-    monkeypatch, tmp_path
-):
+def test_eclipse_depth_outgas_returns_none_when_profile_unreadable(monkeypatch, tmp_path):
+    """The outgas source takes its abundances from the helpfile, but the single climate
+    profile read still supplies both the level grid those abundances are spread over and
+    the reference radius and gravity, so an unreadable profile stops an outgas run too.
+
+    Unlike the offchem case, this cannot isolate the reference-profile guard: for outgas
+    the same read fills the composition and the reference values, so both are None here
+    and the shared guard fires on the composition first. What the test does pin is that
+    the outgas branch was the one taken, by asserting the chemistry reader was never
+    consulted; without that, an implementation that routed outgas through the chemistry
+    output would pass, because every read stubbed here yields None anyway.
+    """
     mod = _import_backend(monkeypatch)
 
+    offchem_read = MagicMock(name='_get_atm_offchem')
+    monkeypatch.setattr(mod, '_get_atm_offchem', offchem_read)
     monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
     monkeypatch.setattr(mod, '_get_input_data_path', lambda _dirs: str(tmp_path))
     fake_common = types.ModuleType('proteus.observe.common')
@@ -612,9 +942,21 @@ def test_eclipse_depth_outgas_returns_none_when_reference_profile_missing(
         {'fwl': str(tmp_path), 'output': str(tmp_path)},
     )
     assert result is None
+    offchem_read.assert_not_called()
+    assert sys.modules['petitRADTRANS.radtrans'].Radtrans.call_count == 0
 
 
 def test_eclipse_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_path):
+    """An unrecognised source fails the eclipse path on the unbound atmosphere for the
+    same reason it fails the transit path, so neither spectrum is quietly produced from
+    an unintended source.
+
+    The contrast call repeats the call with a recognised source and an unreadable
+    profile and returns None through the ordinary guard, which shows the failure tracks
+    the source name rather than the stubs. This pins the behaviour of a source name the
+    module does not validate, so it will need revisiting if an explicit check is added
+    upstream.
+    """
     mod = _import_backend(monkeypatch)
 
     monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: {'p': np.array([1.0e5])})
@@ -623,17 +965,29 @@ def test_eclipse_depth_raises_for_unknown_source_before_parse(monkeypatch, tmp_p
     fake_common.get_eclipse_fpath = lambda *_a, **_k: str(tmp_path / 'unused.csv')
     monkeypatch.setitem(sys.modules, 'proteus.observe.common', fake_common)
     config = _make_config()
+    hf_row = {'Time': 1, 'R_star': 1.0, 'T_star': 1.0, 'separation': 1.0}
+    dirs = {'fwl': str(tmp_path), 'output': str(tmp_path)}
 
     with pytest.raises(UnboundLocalError):
-        mod.eclipse_depth(
-            {'Time': 1, 'R_star': 1.0, 'T_star': 1.0, 'separation': 1.0},
-            config,
-            'unknown_source',
-            {'fwl': str(tmp_path), 'output': str(tmp_path)},
-        )
+        mod.eclipse_depth(hf_row, config, 'unknown_source', dirs)
+
+    monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: None)
+    assert mod.eclipse_depth(hf_row, config, 'profile', dirs) is None
 
 
 def test_transit_depth_prioritizes_broadest_coverage_and_writes_output(monkeypatch, tmp_path):
+    """A complete transit run orders its line species broadest-first, computes one
+    spectrum per gas held back from the opacities, and writes them all to the synthesis
+    file with a column naming the gas that was removed.
+
+    The stand-in radiative transfer returns fixed radii, so what is under test is the
+    orchestration around it rather than the transfer itself. CH4 is deliberately not the
+    first gas in the mix, and its 0.3 to 50 um table is wider than the 0.5 to 5 um H2O
+    one, so it can only reach the front of the line-species list by being promoted. H2 is
+    given no opacity directory at all: it never enters the line species, yet it still
+    earns a removed column, which pins that the removal loop runs over the gases in the
+    mix rather than over the subset that carries opacities.
+    """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2O', 'CH4', 'H2'))
     monkeypatch.setattr(mod, 'prt_rayleigh_species', set())
@@ -718,6 +1072,18 @@ def test_transit_depth_prioritizes_broadest_coverage_and_writes_output(monkeypat
 
 
 def test_eclipse_depth_offchem_uses_latest_sflux_and_writes_output(monkeypatch, tmp_path):
+    """A complete eclipse run driven from the chemistry output divides the planet flux by
+    the most recent stellar spectrum on disk, orders its line species broadest-first, and
+    writes a column per gas held back from the opacities.
+
+    Two stellar spectra are laid down, 1.sflux and 42.sflux, whose fluxes differ by a
+    factor of ten; 42 is the later snapshot and the one the depths must be built from.
+    Both spectra are tabulated only out to 600 nm while the stand-in transfer reports
+    micron-scale wavelengths, so the interpolation runs off the end of the table and
+    holds the last value, which is why the denominator is flat. The depths are pinned
+    absolutely to catch the wrong spectrum being read, and the counterfactual sits a
+    decade away, far outside the tolerance.
+    """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2O', 'CH4', 'H2'))
     monkeypatch.setattr(mod, 'prt_rayleigh_species', set())
@@ -809,6 +1175,16 @@ def test_eclipse_depth_offchem_uses_latest_sflux_and_writes_output(monkeypatch, 
 
     assert result.shape == (2, 2)
     assert FakeRadtrans.init_calls[0]['line_species'][0] == 'CH4'
+
+    # Planet fluxes of 1 and 2 over the 42.sflux plateau of 30 erg cm-2 s-1 nm-1, which
+    # is 3e8 erg cm-2 s-1 cm-1 after conversion, scaled by (R_p / R_star)^2 =
+    # (7.0e8 / 7.0e10)^2 and expressed in ppm.
+    np.testing.assert_allclose(
+        result[:, 1], np.array([3.3333333e-07, 6.6666667e-07]), rtol=1e-6
+    )
+    # Scale guard: 1.sflux would put the depths at 3.3e-6 and 6.7e-6, a decade higher.
+    assert np.all(result[:, 1] < 1.0e-6)
+
     assert Path(tmp_path / 'observe' / 'eclipse_offchem_synthesis.csv').is_file()
     content = (tmp_path / 'observe' / 'eclipse_offchem_synthesis.csv').read_text()
     assert 'CH4_removed/ppm' in content
@@ -823,6 +1199,16 @@ def test_eclipse_depth_offchem_uses_latest_sflux_and_writes_output(monkeypatch, 
 
 
 def test_transit_depth_disables_removed_species_columns(monkeypatch, tmp_path):
+    """Switching the per-gas removal off leaves only the wavelength and the full-mix
+    depth in the written spectrum, so the extra transfer calls are not paid for when
+    their columns were not asked for.
+
+    The setup is the same mix and the same stand-in transfer as the run with removal
+    enabled, differing only in the config flag, so the two-column header here against
+    the five-column header there isolates the flag as the cause. Comparing the headers
+    rather than only the returned array matters because the removal columns exist solely
+    on disk: the return value is two columns wide either way.
+    """
     mod = _import_backend(monkeypatch)
     monkeypatch.setattr(mod, 'prt_gases', ('H2O', 'CH4', 'H2'))
     monkeypatch.setattr(mod, 'prt_rayleigh_species', set())

--- a/tests/observe/test_wrapper_obs.py
+++ b/tests/observe/test_wrapper_obs.py
@@ -271,21 +271,62 @@ def test_calc_synthetic_spectra_single_selected_source(monkeypatch):
 
 
 def test_calc_synthetic_spectra_selected_profile_raises_with_dummy_atmos(monkeypatch):
-    """Explicit profile source should error when no resolved atmosphere exists."""
+    """Asking for the profile source by name while the atmosphere module is the dummy is
+    a configuration mistake and is refused, because a dummy atmosphere writes no profile
+    to synthesise from and silently producing nothing would look like success.
+
+    The second call is the discriminator: the same explicit request against a real
+    atmosphere module is accepted and reaches the backend once, for the profile source.
+    Without it the test would pass just as well for an implementation that refused every
+    explicitly named source, whatever the atmosphere module.
+    """
     _install_fake_petitradtrans(monkeypatch)
     config = _make_config(source='profile', atmos_clim_module='dummy')
 
     with pytest.raises(ValueError, match="observe.source = 'profile'"):
         calc_synthetic_spectra(hf_row={}, config=config, dirs=_make_dirs())
 
+    backend = importlib.import_module('proteus.observe.petitRADTRANS')
+    transit_mock = MagicMock(name='transit_depth')
+    monkeypatch.setattr(backend, 'transit_depth', transit_mock)
+    monkeypatch.setattr(backend, 'eclipse_depth', MagicMock(name='eclipse_depth'))
+
+    calc_synthetic_spectra(
+        hf_row={},
+        config=_make_config(source='profile', atmos_clim_module='janus'),
+        dirs=_make_dirs(),
+    )
+    assert [call.args[2] for call in transit_mock.call_args_list] == ['profile']
+
 
 def test_calc_synthetic_spectra_selected_offchem_raises_without_chem(monkeypatch):
-    """Explicit offchem source should error when atmos_chem is disabled."""
+    """Asking for the offchem source by name while chemistry is switched off is refused,
+    because there is no chemistry output to read and the request cannot be honoured.
+
+    The second call pins the asymmetry that gives the refusal its meaning: the identical
+    unavailable source is quietly skipped when the request was for every source, leaving
+    outgas and profile to run. Asking for everything means whatever is available, while
+    naming a source means that source or an error. A guard that refused in both cases
+    would break ordinary dummy-chemistry runs, and one that skipped in both would let a
+    misconfigured run report success having synthesised nothing.
+    """
     _install_fake_petitradtrans(monkeypatch)
     config = _make_config(source='offchem', atmos_chem_module=None)
 
     with pytest.raises(ValueError, match="observe.source = 'offchem'"):
         calc_synthetic_spectra(hf_row={}, config=config, dirs=_make_dirs())
+
+    backend = importlib.import_module('proteus.observe.petitRADTRANS')
+    transit_mock = MagicMock(name='transit_depth')
+    monkeypatch.setattr(backend, 'transit_depth', transit_mock)
+    monkeypatch.setattr(backend, 'eclipse_depth', MagicMock(name='eclipse_depth'))
+
+    calc_synthetic_spectra(
+        hf_row={},
+        config=_make_config(source='all', atmos_chem_module=None),
+        dirs=_make_dirs(),
+    )
+    assert [call.args[2] for call in transit_mock.call_args_list] == ['outgas', 'profile']
 
 
 def test_calc_synthetic_spectra_transit_only(monkeypatch):


### PR DESCRIPTION
## Description

The observe tests leaned on single-assert functions and undocumented test bodies, so a regression could slip past them. Every test in `tests/observe/test_petitRADTRANS.py` and `tests/observe/test_wrapper_obs.py` now states the contract it checks and why its inputs were chosen, and the tests that rested on one assertion gained a second, independent check rather than a filler line.

The gains are in what the tests can now catch. The zero-total-VMR guard is driven with one empty layer among good ones, which separates a per-layer check from an all-layers one. The stellar spectrum selection is checked against both an unnumbered file and a higher-numbered one, so ranking filenames as text rather than as numbers now fails. The eclipse test named for using the latest spectrum pins the depths it produces, which it never did before; reading the older spectrum lands a decade away. The transit and eclipse guards now assert which reader the source dispatch consulted, so routing outgas through the chemistry output, or offchem through the climate profile, no longer passes unnoticed. The mass-fraction test pins hand-computed values instead of recomputing the implementation, and asserts closure and boundedness on the result.

Two tests carry `physics_invariant`: the mass-fraction conversion, for closure and boundedness of the returned fractions, and the descending-profile reordering, for the clamp holding temperatures inside the range the opacity tables cover. Three tests are renamed to match what they actually check.

Two integration tests are deliberately left as they are. The fixture in `tests/integration/test_integration_observe_wrapper.py` runs the pipeline with the dummy atmosphere module, which writes no profile NetCDF, so every source returns None and no spectrum file is produced: `test_observe_wrapper_run_observe` skips on that and `test_observe_files_persist` runs no assertion at all. Strengthening either would add checks that never execute, so their single-assert findings stay visible until the fixture runs against an atmosphere module that writes a profile (janus or agni), which is a separate decision.

This is the counterpart to #755: together they cover all the files flagged by `tools/check_test_quality.py`, and with both merged the remaining count drops to the two integration tests above.

## Validation of changes

The three touched files report no violations from `tools/check_test_quality.py` apart from the two integration tests documented above. All 66 observe unit tests pass, `ruff check` and `ruff format --check` are clean, and `bash tools/validate_test_structure.sh` passes.

Each strengthened assertion was checked against a deliberately broken copy of the code it covers. Eleven such checks all fail on the broken copy and pass on the real one; the sources were restored and verified clean afterwards. Among them, the per-layer VMR guard, the stellar-spectrum ordering, and the source-dispatch routing checks catch regressions that the previous test bodies passed.

Test configuration: macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
