### PR TITLE
Point testing docs at pages that exist and describe the CI we run

### DIFF
--- a/.github/.claude/rules/proteus-code-review.md
+++ b/.github/.claude/rules/proteus-code-review.md
@@ -94,7 +94,7 @@ attrs validators can silently become dead code if they compare a dataclass insta
 
 ## Test marker discipline
 
-Every test file must begin with a module-level `pytestmark = [pytest.mark.<tier>, pytest.mark.timeout(<budget>)]` (unit/30 s, smoke/60 s, integration/300 s, slow/3600 s). Per-function markers are additive but do not replace the module-level marker; CI runs `pytest -m "unit and not skip"` and any file missing the tier marker ships untested.
+Every test file must begin with a module-level `pytestmark = [pytest.mark.<tier>, pytest.mark.timeout(<budget>)]` (unit/30 s, smoke/60 s, integration/300 s, slow/3600 s). Per-function markers are additive but do not replace the module-level marker; CI runs `pytest -m "unit and not skip and not slow and not integration"` and any file missing the tier marker ships untested.
 
 ## Test quality (cross-reference)
 

--- a/.github/.claude/rules/proteus-tests.md
+++ b/.github/.claude/rules/proteus-tests.md
@@ -235,7 +235,7 @@ with budgets:
 - `integration` -> `timeout(300)`.
 - `slow` -> `timeout(3600)`.
 
-CI runs `pytest -m "unit and not skip"`. Tests without the tier marker are invisible to CI and shipped untested. The lint script blocks any file missing the module-level `pytestmark`.
+CI runs `pytest -m "unit and not skip and not slow and not integration"`. Tests without the tier marker are invisible to CI and shipped untested. The lint script blocks any file missing the module-level `pytestmark`.
 
 ### Per-function markers
 
@@ -353,13 +353,12 @@ The lint script is wired into PR CI (`ci-pr-checks.yml`). The step currently run
 
 ## 15. Coverage strategy (operator's view)
 
-PROTEUS uses two coverage gates with explicit sub-targets. The fast gate is for PR cycle time; the estimated total is the real KPI.
+PROTEUS runs three gates on every pull request. The fast gate is for PR cycle time; the estimated total is the real KPI. The full gate is not a fourth: it is the pyproject value the estimated total is measured against.
 
 | Gate | Tests | Target | When |
 |---|---|---|---|
 | Fast gate (`tool.proteus.coverage_fast`) | unit-only (PR) | fixed **80%** | Every PR (warn-only on drafts) |
-| Estimated total (PR union with nightly artifact) | unit + smoke + integration | **90%** (PROTEUS-ecosystem ceiling) | Every PR (warn-only on drafts) |
-| Full gate (`tool.coverage.report`) | unit + smoke + integration + slow | fixed **90%** | Nightly |
+| Estimated total (PR union with nightly artifact) | unit + smoke + integration + slow | **90%**, the `tool.coverage.report` value | Every PR (warn-only on drafts) |
 | Diff-cover | changed lines (fast + nightly union) | 80% (hard-coded; warn-only on drafts) | Every PR |
 
 Unit tests alone are not expected to reach 90%. Wrapper code that requires real binaries (SOCRATES, AGNI, SPIDER) is covered by smoke / integration / slow tests in nightly; the nightly artifact is downloaded into PR runs and unioned with the PR's own coverage both for the estimated total and for the diff-cover gate. That is why the fast (unit-only) gate is held at a fixed 80% rather than chasing 90%.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,7 +204,7 @@ pytest
 ```bash
 pytest -m unit              # Fast unit tests (<100ms each, mocked physics)
 pytest -m smoke             # Binary validation (1 timestep, low res)
-pytest -m "unit or smoke"   # What PR checks run
+pytest -m "unit and not skip"   # What PR checks run
 pytest -m integration       # Multi-module coupling
 pytest -m "not slow"        # Everything except slow tests
 ```
@@ -261,11 +261,10 @@ pre-commit install -f
 
 **CI runs on PRs** (`.github/workflows/ci-pr-checks.yml`):
 
-1. **Unit tests**: `pytest -m "unit and not skip" --cov=src --cov-fail-under=$FAST_COV_FAIL_UNDER` (CI reads the fast threshold from `pyproject.toml` `[tool.proteus.coverage_fast]`; fixed at 80%, warn-only on draft PRs)
-2. **Smoke tests**: `pytest -m "smoke and not skip"`
-3. **Lint**: `ruff check src/ tests/` and `ruff format --check src/ tests/`
-4. **Diff-cover**: 80% on changed lines, fast-suite coverage unioned with the latest nightly coverage (enforced)
-5. **Test structure**: `bash tools/validate_test_structure.sh`
+1. **Unit tests**: `pytest -m "unit and not skip" --cov=src --cov-fail-under=$FAST_COV_FAIL_UNDER` (CI reads the fast threshold from `pyproject.toml` `[tool.proteus.coverage_fast]`; fixed at 80%, warn-only on draft PRs). The PR cycle runs the unit tier only; smoke, integration, and slow run nightly.
+2. **Lint**: `ruff check src/ tests/` and `ruff format --check src/ tests/`
+3. **Diff-cover**: 80% on changed lines, fast-suite coverage unioned with the latest nightly coverage (enforced)
+4. **Test structure**: `bash tools/validate_test_structure.sh`
 
 **All must pass** before merge. Coverage gates are warn-only on draft PRs and block once the PR is ready for review. Coverage ceilings are fixed (fast 80%, full 90%) and never lowered.
 
@@ -331,7 +330,7 @@ Tier markers, with their CI surface and per-test wall-time budgets:
 | Marker | What it tests | Speed budget | When CI runs it |
 |---|---|---|---|
 | `@pytest.mark.unit` | Python logic, heavy physics mocked | < 100 ms per test | Every PR (`unit and not skip`) |
-| `@pytest.mark.smoke` | Real binaries, 1 timestep, low resolution | < 30 s per test | Every PR (`smoke and not skip`) |
+| `@pytest.mark.smoke` | Real binaries, 1 timestep, low resolution | < 30 s per test | Nightly only (`smoke and not skip`) |
 | `@pytest.mark.integration` | Multi-module coupling | Minutes per test | Nightly only |
 | `@pytest.mark.slow` | Full physics validation | Up to hours per test | Nightly only (targeted file list) |
 | `@pytest.mark.skip` | Placeholder, deliberately disabled | n/a | Never |
@@ -453,8 +452,8 @@ PROTEUS uses two gates with explicit sub-targets:
 | Gate | Tests included | Target | Enforced |
 |---|---|---|---|
 | Fast gate (`tool.proteus.coverage_fast.fail_under`) | unit-only (PR) | Fixed **80%** | Every PR (warn-only on drafts) |
-| Estimated total (PR unit coverage union with latest nightly artifact) | unit + smoke + integration | **90%** (the PROTEUS-ecosystem ceiling) | Every PR (warn-only on drafts) |
-| Full gate (`tool.coverage.report.fail_under`) | unit + smoke + integration + slow | Fixed **90%** | Nightly only |
+| Estimated total (PR unit coverage union with latest nightly artifact) | unit + smoke + integration + slow | **90%** (the PROTEUS-ecosystem ceiling) | Every PR (warn-only on drafts) |
+| Full gate (`tool.coverage.report.fail_under`) | unit + smoke + integration + slow | Fixed **90%** | Read by the PR estimated-total gate; the nightly publishes coverage without failing on it |
 | Diff-cover | changed lines (fast + nightly union) | 80% (hard-coded; warn-only on drafts) | Every PR |
 
 **What this means for contributors**: the coverage ceilings are fixed, not ratcheting: the fast (unit-only) gate is held at **80%** and the full gate at the **90%** PROTEUS-ecosystem target (`tools/update_coverage_threshold.py` enforces `CEILINGS = {'fast': 80.0, 'full': 90.0}` and the PR threshold guard fails if either is edited away from its fixed value). Unit tests alone are not expected to reach 90% because wrapper code that requires real binaries (SOCRATES, AGNI, SPIDER) is exercised only by the nightly tiers; that is why the fast gate sits at 80, not 90. The 90% target is reached via the estimated-total: the PR's unit coverage is unioned with the latest nightly artifact and compared against the full gate, and the diff-cover gate unions the fast and nightly reports the same way. Coverage gates run on draft PRs for visibility but are warn-only there; they block once the PR is marked ready for review.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ Follow the same standards for testing, coverage, code quality, and infrastructur
 >
 > These two files plus this one are the canonical sources of truth for testing rigor and review criteria. Together they enforce PROTEUS's extreme-rigor stance on physics validity, anti-happy-path testing, and validation certification.
 
-1. **Always** read the two rule files above plus the testing standards in this document and `docs/How-to/test_infrastructure.md` before any code change.
+1. **Always** read the two rule files above plus the testing standards in this document and `docs/How-to/testing.md` before any code change.
 2. **Always** inform the user that you are reading in this file by printing a message at the start of your response: "(Read in copilot-instructions.md...)"
 3. When creating a PR, **always** follow the PR template and ensure all sections are filled out with relevant information.
 4. **Claude-specific**: `CLAUDE.md` is a symlink to this file. Session learnings, plans, and memories live in `~/.claude/projects/<repo>/memory/` (per the global voice rule); they do NOT live in this repository.
@@ -429,7 +429,7 @@ The repo-wide voice rule (zero AI-process disclosure in any public artifact, see
 
 ### Documentation per test
 
-- File-level docstring: name the module under test, list the invariants and contract clauses the file exercises, and link to the three test docs (`test_infrastructure.md`, `test_categorization.md`, `test_building.md`).
+- File-level docstring: name the module under test, list the invariants and contract clauses the file exercises, and link to the test docs (`docs/How-to/testing.md`, `docs/Explanations/test_framework.md`).
 - Function-level docstring: state the physical scenario or contract clause being verified, in plain language. Required (lint-enforced).
 - Inline comments: explain **why** a specific input range was chosen ("T=300 K and T=1500 K so the T**3 vs T**4 difference is resolved well above tolerance").
 
@@ -459,7 +459,7 @@ PROTEUS uses two gates with explicit sub-targets:
 
 **What this means for contributors**: the coverage ceilings are fixed, not ratcheting: the fast (unit-only) gate is held at **80%** and the full gate at the **90%** PROTEUS-ecosystem target (`tools/update_coverage_threshold.py` enforces `CEILINGS = {'fast': 80.0, 'full': 90.0}` and the PR threshold guard fails if either is edited away from its fixed value). Unit tests alone are not expected to reach 90% because wrapper code that requires real binaries (SOCRATES, AGNI, SPIDER) is exercised only by the nightly tiers; that is why the fast gate sits at 80, not 90. The 90% target is reached via the estimated-total: the PR's unit coverage is unioned with the latest nightly artifact and compared against the full gate, and the diff-cover gate unions the fast and nightly reports the same way. Coverage gates run on draft PRs for visibility but are warn-only there; they block once the PR is marked ready for review.
 
-Reports: `pytest --cov=src --cov-report=html` and open `htmlcov/index.html`. Module-level analysis: `bash tools/coverage_analysis.sh`. Diff-cover reasoning is documented in `docs/How-to/test_infrastructure.md`.
+Reports: `pytest --cov=src --cov-report=html` and open `htmlcov/index.html`. Module-level analysis: `bash tools/coverage_analysis.sh`. Diff-cover thresholds are documented in `docs/How-to/testing.md`.
 
 ## Safety & Determinism
 - **Randomness:** Explicitly set seeds (e.g., `np.random.seed(42)`) in tests.
@@ -569,7 +569,7 @@ Under D1A (the chosen design), CALLIOPE / atmodeller chemistry is unchanged. Oxy
 
 ## Documentation References
 
-- **Testing**: `docs/How-to/test_infrastructure.md`, `docs/How-to/test_building.md`, `docs/How-to/test_categorization.md`
+- **Testing**: `docs/How-to/testing.md`, `docs/Explanations/test_framework.md`
 - **Installation**: `docs/How-to/installation.md`, `docs/How-to/local_machine_guide.md`
 - **Usage**: `docs/How-to/usage.md`, `docs/How-to/config.md`
 - **Docs development**: `docs/How-to/documentation.md` (build/serve with `zensical serve`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,9 +204,11 @@ pytest
 ```bash
 pytest -m unit              # Fast unit tests (<100ms each, mocked physics)
 pytest -m smoke             # Binary validation (1 timestep, low res)
-pytest -m "unit and not skip"   # What PR checks run
 pytest -m integration       # Multi-module coupling
 pytest -m "not slow"        # Everything except slow tests
+
+# Exactly what the PR checks run (the extra filters keep slow-marked files out):
+pytest -m "unit and not skip and not slow and not integration" --ignore=tests/examples
 ```
 
 **With coverage**:
@@ -224,7 +226,7 @@ coverage html
 **Coverage thresholds** (in `pyproject.toml`; fixed ceilings, never lowered):
 
 - Fast gate (`[tool.proteus.coverage_fast]`, unit-only on PR, every PR): fixed at **80%**. Unit tests alone cannot exercise wrapper paths that require real binaries, so the fast gate is held at 80 rather than chasing 90. Warn-only on draft PRs; blocking once the PR is ready for review.
-- Full gate (`[tool.coverage.report]`, unit + smoke + integration + slow, nightly): fixed at **90%**.
+- Full gate value (`[tool.coverage.report]`): fixed at **90%**. The nightly does not enforce it; it is the number the PR estimated-total gate is measured against.
 - Estimated total (PR unit coverage union with the latest nightly artifact, every PR): compared against the 90% full gate. This is the 90% KPI; the nightly tier fills the wrapper / binary code paths.
 
 See the `Coverage architecture` block in the Testing Standards section below for the contract.
@@ -261,10 +263,13 @@ pre-commit install -f
 
 **CI runs on PRs** (`.github/workflows/ci-pr-checks.yml`):
 
-1. **Unit tests**: `pytest -m "unit and not skip" --cov=src --cov-fail-under=$FAST_COV_FAIL_UNDER` (CI reads the fast threshold from `pyproject.toml` `[tool.proteus.coverage_fast]`; fixed at 80%, warn-only on draft PRs). The PR cycle runs the unit tier only; smoke, integration, and slow run nightly.
+1. **Unit tests**: `pytest -m "unit and not skip and not slow and not integration" --cov=src --cov-fail-under=$FAST_COV_FAIL_UNDER` (CI reads the fast threshold from `pyproject.toml` `[tool.proteus.coverage_fast]`; fixed at 80%, warn-only on draft PRs). The PR cycle runs the unit tier only; smoke, integration, and slow run nightly.
 2. **Lint**: `ruff check src/ tests/` and `ruff format --check src/ tests/`
 3. **Diff-cover**: 80% on changed lines, fast-suite coverage unioned with the latest nightly coverage (enforced)
-4. **Test structure**: `bash tools/validate_test_structure.sh`
+4. **Estimated-total coverage**: PR unit coverage unioned with the latest nightly, measured against 90%
+5. **Test structure**: `bash tools/validate_test_structure.sh`
+6. **Editable install**: verifies the package installs correctly
+7. **Test quality**: `python tools/check_test_quality.py --check` (reported, does not block)
 
 **All must pass** before merge. Coverage gates are warn-only on draft PRs and block once the PR is ready for review. Coverage ceilings are fixed (fast 80%, full 90%) and never lowered.
 
@@ -296,7 +301,7 @@ pre-commit install -f
 - `pyproject.toml` - Package metadata, pytest config, coverage thresholds, ruff rules
 - `mkdocs.yml` - Documentation configuration (used by Zensical)
 - `.github/workflows/` - CI/CD pipelines
-  - `ci-pr-checks.yml` - Fast PR validation (unit + smoke + lint)
+  - `ci-pr-checks.yml` - Fast PR validation (unit + lint)
   - `code-style.yaml` - Pre-commit hooks
   - `proteus_test_quality_gate.yml` - Reusable test workflow
 
@@ -329,8 +334,8 @@ Tier markers, with their CI surface and per-test wall-time budgets:
 
 | Marker | What it tests | Speed budget | When CI runs it |
 |---|---|---|---|
-| `@pytest.mark.unit` | Python logic, heavy physics mocked | < 100 ms per test | Every PR (`unit and not skip`) |
-| `@pytest.mark.smoke` | Real binaries, 1 timestep, low resolution | < 30 s per test | Nightly only (`smoke and not skip`) |
+| `@pytest.mark.unit` | Python logic, heavy physics mocked | < 100 ms per test | Every PR (`unit and not skip and not slow and not integration`) |
+| `@pytest.mark.smoke` | Real binaries, 1 timestep, low resolution | < 30 s per test | Nightly only (`smoke and not skip and not slow and not integration`) |
 | `@pytest.mark.integration` | Multi-module coupling | Minutes per test | Nightly only |
 | `@pytest.mark.slow` | Full physics validation | Up to hours per test | Nightly only (targeted file list) |
 | `@pytest.mark.skip` | Placeholder, deliberately disabled | n/a | Never |
@@ -341,7 +346,7 @@ Tier markers, with their CI surface and per-test wall-time budgets:
 pytestmark = [pytest.mark.<tier>, pytest.mark.timeout(<budget>)]
 ```
 
-with timeouts: 30 s for unit, 60 s for smoke, 300 s for integration, 3600 s for slow. Per-function markers are additive but do not replace the module-level marker. CI runs `pytest -m "unit and not skip"`; tests without a tier marker are invisible to CI. The `pytest-timeout` ceiling is a defensive net against future regressions that introduce a hang; current budgets are well clear of it.
+with timeouts: 30 s for unit, 60 s for smoke, 300 s for integration, 3600 s for slow. Per-function markers are additive but do not replace the module-level marker. CI runs `pytest -m "unit and not skip and not slow and not integration"`; tests without a tier marker are invisible to CI. The `pytest-timeout` ceiling is a defensive net against future regressions that introduce a hang; current budgets are well clear of it.
 
 ### Physics validity (tiered)
 
@@ -447,13 +452,12 @@ A pull request that adds or substantially modifies > 50 lines of test code acros
 
 ### Coverage architecture
 
-PROTEUS uses two gates with explicit sub-targets:
+PROTEUS runs three gates on every pull request. The full gate is not a fourth: it is the pyproject value the estimated total is measured against.
 
 | Gate | Tests included | Target | Enforced |
 |---|---|---|---|
 | Fast gate (`tool.proteus.coverage_fast.fail_under`) | unit-only (PR) | Fixed **80%** | Every PR (warn-only on drafts) |
-| Estimated total (PR unit coverage union with latest nightly artifact) | unit + smoke + integration + slow | **90%** (the PROTEUS-ecosystem ceiling) | Every PR (warn-only on drafts) |
-| Full gate (`tool.coverage.report.fail_under`) | unit + smoke + integration + slow | Fixed **90%** | Read by the PR estimated-total gate; the nightly publishes coverage without failing on it |
+| Estimated total (PR unit coverage union with latest nightly artifact) | unit + smoke + integration + slow | **90%**, the `tool.coverage.report.fail_under` value | Every PR (warn-only on drafts) |
 | Diff-cover | changed lines (fast + nightly union) | 80% (hard-coded; warn-only on drafts) | Every PR |
 
 **What this means for contributors**: the coverage ceilings are fixed, not ratcheting: the fast (unit-only) gate is held at **80%** and the full gate at the **90%** PROTEUS-ecosystem target (`tools/update_coverage_threshold.py` enforces `CEILINGS = {'fast': 80.0, 'full': 90.0}` and the PR threshold guard fails if either is edited away from its fixed value). Unit tests alone are not expected to reach 90% because wrapper code that requires real binaries (SOCRATES, AGNI, SPIDER) is exercised only by the nightly tiers; that is why the fast gate sits at 80, not 90. The 90% target is reached via the estimated-total: the PR's unit coverage is unioned with the latest nightly artifact and compared against the full gate, and the diff-cover gate unions the fast and nightly reports the same way. Coverage gates run on draft PRs for visibility but are warn-only there; they block once the PR is marked ready for review.

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -24,7 +24,7 @@ Tests are organized into four tiers of increasing scope and cost:
 ```
 Unit (< 100 ms)  →  Smoke (< 30 s)  →  Integration (minutes)  →  Slow (hours)
      ↑                    ↑                     ↑                      ↑
-  Every PR            Every PR              Nightly               Nightly
+  Every PR             Nightly              Nightly               Nightly
 ```
 
 **Unit tests** verify individual Python functions with all external
@@ -147,19 +147,19 @@ Every new test function must include:
 
 ## Coverage architecture
 
-PROTEUS uses two coverage gates:
+PROTEUS uses two coverage gates, both on every pull request:
 
-- **Fast gate** (every PR): unit tests only, fixed at 80%. Unit tests alone
-  are not expected to reach the 90% ecosystem target, because wrapper code
-  that requires real binaries is exercised only by the nightly tiers. That is
-  why the gate sits at 80 rather than chasing 90.
-- **Full gate** (nightly): all tiers combined, fixed at 90%. This is the
-  primary KPI; the fast gate is a lower bound.
+- **Fast gate**: unit tests only, fixed at 80%. Unit tests alone are not
+  expected to reach the 90% ecosystem target, because wrapper code that
+  requires real binaries is exercised only by the nightly tiers. That is why
+  the gate sits at 80 rather than chasing 90.
+- **Estimated total**: the pull request's unit coverage unioned with the
+  latest nightly artifact, fixed at 90%. That union is how the 90% target is
+  reached on a pull request even though smoke, integration, and slow tests do
+  not run there. This is the primary KPI; the fast gate is a lower bound.
 
-The estimated-total mechanism unions PR unit coverage with the latest nightly
-artifact to compare against the full gate on every PR, even though smoke,
-integration, and slow tests do not run on PRs. That union is how the 90%
-target is reached on a PR.
+The nightly runs every tier and publishes the coverage artifact the estimated
+total unions against; it does not itself fail on a coverage percentage.
 
 Both ceilings are fixed rather than ratcheting, and neither may be lowered:
 `tools/update_coverage_threshold.py` holds them and the PR threshold guard

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -149,18 +149,21 @@ Every new test function must include:
 
 PROTEUS uses two coverage gates:
 
-- **Fast gate** (every PR): unit + smoke tests. Ratchets toward 90%
-  but plateaus around 60-75% because wrapper code exercised only by
-  real binaries is excluded.
-- **Full gate** (nightly): all tiers combined. Targets 90%. This is the
+- **Fast gate** (every PR): unit tests only, fixed at 80%. Unit tests alone
+  are not expected to reach the 90% ecosystem target, because wrapper code
+  that requires real binaries is exercised only by the nightly tiers. That is
+  why the gate sits at 80 rather than chasing 90.
+- **Full gate** (nightly): all tiers combined, fixed at 90%. This is the
   primary KPI; the fast gate is a lower bound.
 
-The estimated-total mechanism unions PR unit/smoke coverage with the latest
-nightly artifact to compare against the full gate on every PR, even though
-integration and slow tests do not run on PRs.
+The estimated-total mechanism unions PR unit coverage with the latest nightly
+artifact to compare against the full gate on every PR, even though smoke,
+integration, and slow tests do not run on PRs. That union is how the 90%
+target is reached on a PR.
 
-Coverage thresholds auto-ratchet upward and are capped at 90% (the
-ecosystem ceiling). Neither gate may be manually decreased.
+Both ceilings are fixed rather than ratcheting, and neither may be lowered:
+`tools/update_coverage_threshold.py` holds them and the PR threshold guard
+fails if either is edited away from its value.
 
 ## Float comparison discipline
 

--- a/docs/Explanations/test_framework.md
+++ b/docs/Explanations/test_framework.md
@@ -44,7 +44,7 @@ validate against published benchmarks and cross-implementation checks (e.g.
 SPIDER vs Aragog for the same initial conditions). These are the most
 expensive tests and run only in the nightly CI.
 
-The badge row at the top of this page carries three kinds of badge. The coverage badge reports the line coverage that codecov records for the main branch. The two status badges report the outcome of the latest pull-request checks and the latest nightly run. The three count badges report how many tests the suite collects in each category: the total, the unit tier, and the combined smoke, integration, and slow tiers. The counts come from `pytest --collect-only`, so they track the real suite as it grows.
+The badge row at the top of this page carries three kinds of badge. The coverage badge reports the line coverage that codecov records for the main branch. The two status badges report the outcome of the latest unit-coverage run on the main branch and the latest nightly run. The three count badges report how many tests the suite collects in each category: the total, the unit tier, and the combined smoke, integration, and slow tiers. The counts come from `pytest --collect-only`, so they track the real suite as it grows.
 
 ## Functional tests vs physics tests
 
@@ -147,23 +147,30 @@ Every new test function must include:
 
 ## Coverage architecture
 
-PROTEUS uses two coverage gates, both on every pull request:
+PROTEUS uses three coverage gates, all on every pull request:
 
 - **Fast gate**: unit tests only, fixed at 80%. Unit tests alone are not
   expected to reach the 90% ecosystem target, because wrapper code that
   requires real binaries is exercised only by the nightly tiers. That is why
   the gate sits at 80 rather than chasing 90.
 - **Estimated total**: the pull request's unit coverage unioned with the
-  latest nightly artifact, fixed at 90%. That union is how the 90% target is
-  reached on a pull request even though smoke, integration, and slow tests do
-  not run there. This is the primary KPI; the fast gate is a lower bound.
+  latest nightly artifact, measured against 90%. That union is how the 90%
+  target is reached on a pull request even though smoke, integration, and slow
+  tests do not run there. This is the primary KPI; the fast gate is a lower
+  bound.
+- **Diff-cover**: the lines the pull request changed, held to 80%, again
+  unioning the fast coverage with the latest nightly so that wrapper code the
+  nightly alone exercises is not counted against the change.
 
 The nightly runs every tier and publishes the coverage artifact the estimated
-total unions against; it does not itself fail on a coverage percentage.
+total and diff-cover union against; it does not itself fail on a coverage
+percentage.
 
-Both ceilings are fixed rather than ratcheting, and neither may be lowered:
-`tools/update_coverage_threshold.py` holds them and the PR threshold guard
-fails if either is edited away from its value.
+The fast gate's 80% and the 90% the estimated total is measured against are
+fixed rather than ratcheting, and neither may be lowered:
+`tools/update_coverage_threshold.py` holds both and the pull-request threshold
+guard fails if either is edited away from its value. The diff-cover threshold is
+fixed in the workflow instead.
 
 ## Float comparison discipline
 

--- a/docs/How-to/testing.md
+++ b/docs/How-to/testing.md
@@ -140,11 +140,17 @@ This prevents collection failures on CI runners without the optional package.
 
 | Gate | Tests | Target | Enforced |
 |------|-------|--------|----------|
-| Fast (every PR) | unit + smoke | Ratcheting toward 90% | PR checks |
-| Full (nightly) | unit + smoke + integration + slow | 90% | Nightly CI |
+| Fast (every PR) | unit only | 80% (fixed) | PR checks |
+| Estimated total (every PR) | PR unit coverage unioned with the latest nightly | 90% | PR checks |
+| Full (nightly) | unit + smoke + integration + slow | 90% (fixed) | Nightly CI |
 | Diff-cover (every PR) | Changed lines only | 80% | PR checks |
 
-Thresholds auto-ratchet upward (never decrease) and are capped at 90%.
+The ceilings are fixed rather than ratcheting, and neither may be lowered.
+Unit tests alone are not expected to reach 90%, because wrapper code that
+requires real binaries runs only in the nightly tiers; the 90% target is met
+through the estimated total. Coverage gates run on draft pull requests for
+visibility but only warn there, and block once the pull request is marked
+ready for review.
 
 ### Checking coverage locally
 

--- a/docs/How-to/testing.md
+++ b/docs/How-to/testing.md
@@ -31,7 +31,7 @@ Every test function carries a tier marker that controls when and where it runs:
 | Marker | What it tests | Speed budget | CI surface |
 |--------|---------------|-------------|------------|
 | `@pytest.mark.unit` | Python logic, mocked physics | < 100 ms | Every PR |
-| `@pytest.mark.smoke` | Real binaries, 1 timestep, low res | < 30 s | Every PR |
+| `@pytest.mark.smoke` | Real binaries, 1 timestep, low res | < 30 s | Nightly |
 | `@pytest.mark.integration` | Multi-module coupling | Minutes | Nightly |
 | `@pytest.mark.slow` | Full physics validation | Hours | Nightly |
 | `@pytest.mark.skip` | Deliberately disabled | n/a | Never |
@@ -140,17 +140,24 @@ This prevents collection failures on CI runners without the optional package.
 
 | Gate | Tests | Target | Enforced |
 |------|-------|--------|----------|
-| Fast (every PR) | unit only | 80% (fixed) | PR checks |
-| Estimated total (every PR) | PR unit coverage unioned with the latest nightly | 90% | PR checks |
-| Full (nightly) | unit + smoke + integration + slow | 90% (fixed) | Nightly CI |
-| Diff-cover (every PR) | Changed lines only | 80% | PR checks |
+| Fast | unit only | 80% (fixed) | PR checks |
+| Estimated total | PR unit coverage unioned with the latest nightly | 90% (fixed) | PR checks |
+| Diff-cover | Changed lines, fast coverage unioned with the latest nightly | 80% | PR checks |
 
-The ceilings are fixed rather than ratcheting, and neither may be lowered.
-Unit tests alone are not expected to reach 90%, because wrapper code that
-requires real binaries runs only in the nightly tiers; the 90% target is met
-through the estimated total. Coverage gates run on draft pull requests for
-visibility but only warn there, and block once the pull request is marked
-ready for review.
+All three gates run on pull requests. The nightly runs every tier and
+publishes the coverage artifact the first two union against; it does not
+itself fail on a coverage percentage.
+
+The two ceilings are fixed rather than ratcheting, and neither may be
+lowered: `tools/update_coverage_threshold.py` holds them and a pull-request
+guard fails if either is edited away from its value. Unit tests alone are not
+expected to reach 90%, because wrapper code that requires real binaries runs
+only in the nightly tiers; the 90% target is met through the estimated total.
+
+The gates only warn on draft pull requests and block once the pull request is
+marked ready for review. Two of them also fall back to warning when no nightly
+artifact is available, and the estimated total allows a small grace margin
+below its target before it fails.
 
 ### Checking coverage locally
 
@@ -187,10 +194,12 @@ When you open a PR, CI runs:
 
 1. **Structure validation**: `tests/` mirrors `src/proteus/`
 2. **Unit tests** (Linux + macOS): `pytest -m "unit and not skip"`
-3. **Smoke tests**: `pytest -m "smoke and not skip"`
-4. **Diff-cover**: 80% coverage on changed lines
-5. **Lint**: `ruff check` and `ruff format`
-6. **Editable install**: verifies the package installs correctly
+3. **Diff-cover**: 80% coverage on changed lines
+4. **Lint**: `ruff check` and `ruff format`
+5. **Editable install**: verifies the package installs correctly
+
+The pull-request cycle runs the unit tier only. The smoke, integration, and
+slow tiers run in the nightly workflow.
 
 Runtime: ~5-10 minutes.
 
@@ -202,7 +211,8 @@ The nightly workflow runs all tiers:
 2. **Integration** on Linux and macOS
 3. **Slow** across multiple shards (aragog, zalmoxis-coupled, agni,
    janus-inference, etc.)
-4. **Coverage aggregate**: combines all tiers and checks the 90% gate
+4. **Coverage aggregate**: combines every tier and publishes the coverage
+   artifact that the pull-request gates union against
 
 Runtime: ~2-3 hours.
 

--- a/docs/How-to/testing.md
+++ b/docs/How-to/testing.md
@@ -12,7 +12,7 @@ physics invariants, validation certification), see
 Install with `pip install -e ".[develop]"`, then:
 
 ```bash
-pytest -m "unit and not skip"           # Fast unit tests (~2 min)
+pytest -m "unit and not skip and not slow and not integration"   # Fast unit tests (~2 min)
 pytest -m "smoke and not skip"          # Smoke tests with real binaries
 pytest --cov=src --cov-report=html      # Generate coverage report
 open htmlcov/index.html                 # View coverage in browser
@@ -20,7 +20,7 @@ open htmlcov/index.html                 # View coverage in browser
 
 Before committing:
 
-1. `pytest -m "unit and not skip"` must pass
+1. `pytest -m "unit and not skip and not slow and not integration"` must pass
 2. `ruff check src/ tests/ && ruff format src/ tests/` must pass
 3. `bash tools/validate_test_structure.sh` must pass
 
@@ -145,14 +145,16 @@ This prevents collection failures on CI runners without the optional package.
 | Diff-cover | Changed lines, fast coverage unioned with the latest nightly | 80% | PR checks |
 
 All three gates run on pull requests. The nightly runs every tier and
-publishes the coverage artifact the first two union against; it does not
-itself fail on a coverage percentage.
+publishes the coverage artifact that the estimated total and diff-cover union
+against; it does not itself fail on a coverage percentage.
 
-The two ceilings are fixed rather than ratcheting, and neither may be
-lowered: `tools/update_coverage_threshold.py` holds them and a pull-request
-guard fails if either is edited away from its value. Unit tests alone are not
-expected to reach 90%, because wrapper code that requires real binaries runs
-only in the nightly tiers; the 90% target is met through the estimated total.
+The fast gate's 80% and the 90% the estimated total is measured against are
+fixed rather than ratcheting, and neither may be lowered:
+`tools/update_coverage_threshold.py` holds both and a pull-request guard fails
+if either is edited away from its value. The diff-cover threshold is fixed in
+the workflow instead. Unit tests alone are not expected to reach 90%, because
+wrapper code that requires real binaries runs only in the nightly tiers; the
+90% target is met through the estimated total.
 
 The gates only warn on draft pull requests and block once the pull request is
 marked ready for review. Two of them also fall back to warning when no nightly
@@ -193,10 +195,14 @@ This AST-based linter flags:
 When you open a PR, CI runs:
 
 1. **Structure validation**: `tests/` mirrors `src/proteus/`
-2. **Unit tests** (Linux + macOS): `pytest -m "unit and not skip"`
-3. **Diff-cover**: 80% coverage on changed lines
-4. **Lint**: `ruff check` and `ruff format`
-5. **Editable install**: verifies the package installs correctly
+2. **Unit tests** (Linux + macOS): `pytest -m "unit and not skip and not slow and not integration"`
+3. **Estimated-total coverage**: PR unit coverage unioned with the latest
+   nightly, measured against 90%
+4. **Diff-cover**: 80% coverage on changed lines
+5. **Lint**: `ruff check` and `ruff format`
+6. **Editable install**: verifies the package installs correctly
+7. **Test quality**: `python tools/check_test_quality.py --check` (reported,
+   does not block)
 
 The pull-request cycle runs the unit tier only. The smoke, integration, and
 slow tiers run in the nightly workflow.
@@ -221,7 +227,7 @@ Runtime: ~2-3 hours.
 Before every commit:
 
 ```bash
-pytest -m "unit and not skip"           # Tests pass
+pytest -m "unit and not skip and not slow and not integration"   # Tests pass
 ruff check --fix src/ tests/            # Lint
 ruff format src/ tests/                 # Format
 bash tools/validate_test_structure.sh   # Structure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,8 +213,9 @@ markers = [
 ]
 
 [tool.coverage.report]
-# Full coverage gate: unit + smoke + integration + slow tests, enforced by the
-# nightly workflow. Fixed ceiling at 90% (the PROTEUS-ecosystem target). The
+# Full coverage gate value: unit + smoke + integration + slow tests. The nightly
+# does not enforce it; it is the number the PR estimated-total gate is measured
+# against. Fixed ceiling at 90% (the PROTEUS-ecosystem target). The
 # estimated-total coverage on PRs (union of PR unit coverage with the latest
 # nightly artifact) is also compared against this gate; that is the 90% KPI
 # operators read. The fixed value is enforced by

--- a/tests/atmos_chem/test_atmos_chem.py
+++ b/tests/atmos_chem/test_atmos_chem.py
@@ -12,9 +12,8 @@ Physics tested:
 - Integration with offline chemistry calculations
 
 Related documentation:
-- docs/test_infrastructure.md: Testing standards and structure
-- docs/test_categorization.md: Test classification criteria
-- docs/test_building.md: Best practices for test implementation
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Mocking strategy:
 - Mock VULCAN offline runs to avoid heavy computation

--- a/tests/atmos_chem/test_common.py
+++ b/tests/atmos_chem/test_common.py
@@ -10,9 +10,8 @@ Invariants tested:
   - Successful read of well-formed whitespace-delimited CSV
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/atmos_chem/test_vulcan.py
+++ b/tests/atmos_chem/test_vulcan.py
@@ -14,9 +14,8 @@ Physics tested:
 - Directory handling differences between offline (wipe) and online (exist_ok)
 
 Related documentation:
-- docs/test_infrastructure.md: Testing standards and structure
-- docs/test_categorization.md: Test classification criteria
-- docs/test_building.md: Best practices for test implementation
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Mocking strategy:
 - Mock the entire `vulcan` package (not available in CI)

--- a/tests/atmos_chem/test_wrapper_chem.py
+++ b/tests/atmos_chem/test_wrapper_chem.py
@@ -12,9 +12,8 @@ Invariants tested:
   - Dispatch: correct backend is called for vulcan/dummy in offline/online mode
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/atmos_clim/test_agni.py
+++ b/tests/atmos_clim/test_agni.py
@@ -7,9 +7,8 @@ This module tests the AGNI atmosphere interface including:
 - AGNI atmosphere initialization (init_agni_atmos)
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/atmos_clim/test_atmos_clim.py
+++ b/tests/atmos_clim/test_atmos_clim.py
@@ -17,12 +17,10 @@ Physics tested:
 - Net flux constraint (prevent warming: F_atm >= 0)
 
 All tests use mocked config objects to isolate physics calculations (<100ms runtime).
-See docs/test_infrastructure.md, docs/test_building.md for testing standards.
 
 Related documentation:
-- docs/test_infrastructure.md: Test framework and CI integration
-- docs/test_categorization.md: Test markers and categories
-- docs/test_building.md: Best practices for writing robust tests
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 """
 
 from __future__ import annotations

--- a/tests/atmos_clim/test_common.py
+++ b/tests/atmos_clim/test_common.py
@@ -9,7 +9,8 @@ This module tests the shared utility functions used by all atmosphere-climate mo
 - Interpolation of lookup tables (Albedo)
 
 See also:
-- docs/test_infrastructure.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/atmos_clim/test_janus.py
+++ b/tests/atmos_clim/test_janus.py
@@ -33,9 +33,8 @@ Invariants asserted:
   species sits above the ``1e-5`` mixing-ratio threshold.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -7,9 +7,8 @@ scipy.solve_ivp). The heavy ``run_atmosphere`` dispatch is exercised
 by integration tests in nightly tier.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -2,8 +2,8 @@
 
 This file targets config parsing helpers plus validator guardrails across
 _config.py, _interior.py, and _params.py. See testing standards in
-docs/test_infrastructure.md, docs/test_categorization.md, and
-docs/test_building.md for required structure, speed, and physics validity.
+docs/How-to/testing.md and docs/Explanations/test_framework.md for required
+structure, speed, and physics validity.
 """
 
 from __future__ import annotations

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -7,9 +7,8 @@ This ensures that the simulation defaults to a known state (usually Earth-like o
 without preventing manual configuration.
 
 See also:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
-- docs/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/config/test_observe_validators.py
+++ b/tests/config/test_observe_validators.py
@@ -1,8 +1,8 @@
 """Tests for observe config validators.
 
 This file targets _observe.py validators. See testing standards in
-docs/test_infrastructure.md, docs/test_categorization.md, and
-docs/test_building.md for required structure, speed, and physics validity.
+docs/How-to/testing.md and docs/Explanations/test_framework.md for required
+structure, speed, and physics validity.
 """
 
 from __future__ import annotations

--- a/tests/config/test_outgas_validators.py
+++ b/tests/config/test_outgas_validators.py
@@ -1,8 +1,9 @@
 """Tests for outgas config validators.
 
 This file targets _outgas.py (Outgas, Calliope, Atmodeller parameters).
-See testing standards in docs/test_infrastructure.md, docs/test_categorization.md,
-and docs/test_building.md for required structure, speed, and physics validity.
+See testing standards in docs/How-to/testing.md and
+docs/Explanations/test_framework.md for required structure, speed, and
+physics validity.
 """
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ for consistency across the PROTEUS ecosystem.
       assert earth_params.planet_mass == earth_params.planet_mass
       assert earth_params.equilibrium_temperature > 273  # Above freezing
 
-See test_infrastructure.md for full documentation of conftest.py role in the
-testing framework.
+See docs/How-to/testing.md for full documentation of the conftest.py role in
+the testing framework.
 """
 
 from __future__ import annotations

--- a/tests/escape/test_common.py
+++ b/tests/escape/test_common.py
@@ -11,9 +11,8 @@ Invariants tested:
   - Error contract: invalid reservoir string raises ValueError
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/escape/test_wrapper.py
+++ b/tests/escape/test_wrapper.py
@@ -15,12 +15,10 @@ Physics tested:
 - XUV-driven hydrodynamic escape (ZEPHYRUS)
 
 All tests use mocked ZEPHYRUS calls to avoid heavy physics computation (<100ms runtime).
-See docs/test_infrastructure.md, docs/test_building.md for testing standards.
 
 Related documentation:
-- docs/test_infrastructure.md: Test framework and CI integration
-- docs/test_categorization.md: Test markers and categories
-- docs/test_building.md: Best practices for writing robust tests
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 """
 
 from __future__ import annotations

--- a/tests/grid/test_manage.py
+++ b/tests/grid/test_manage.py
@@ -8,9 +8,8 @@ least two discriminating post-state facts so that a regression which
 silently no-ops one branch cannot pass.
 
 Links:
-- ``docs/How-to/test_infrastructure.md``
-- ``docs/How-to/test_categorization.md``
-- ``docs/How-to/test_building.md``
+- ``docs/How-to/testing.md``
+- ``docs/Explanations/test_framework.md``
 """
 
 from __future__ import annotations

--- a/tests/grid/test_pack.py
+++ b/tests/grid/test_pack.py
@@ -6,9 +6,8 @@ filesystem operations because pack is a thin wrapper around shutil +
 zipfile primitives that would amount to mocking the function under test.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/grid/test_summarise.py
+++ b/tests/grid/test_summarise.py
@@ -5,9 +5,8 @@ aggregation, general-category dispatch (Running / Completed / Error /
 All / named statuses), code-status dispatch, and unmatched input.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_async_bo.py
+++ b/tests/inference/test_async_bo.py
@@ -2,9 +2,8 @@
 Unit tests for asynchronous Bayesian optimization orchestration helpers.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_bo.py
+++ b/tests/inference/test_bo.py
@@ -14,9 +14,8 @@ Physics invariants exercised:
     busy points for the diversity-aware scheduler.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_gen_D_init.py
+++ b/tests/inference/test_gen_D_init.py
@@ -2,9 +2,8 @@
 Unit tests for inference initial-dataset generation utilities.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -2,9 +2,8 @@
 Tests for the inference pipeline entrypoints.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 # ruff: noqa: E402, I001

--- a/tests/inference/test_objective.py
+++ b/tests/inference/test_objective.py
@@ -2,9 +2,8 @@
 Unit tests for inference objective helpers and simulator wrapping.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_plot.py
+++ b/tests/inference/test_plot.py
@@ -18,9 +18,8 @@ Matplotlib is mocked at the module-attribute level (``plot_mod.plt``) so no
 figure is rendered and ``savefig`` is captured as a call assertion.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_transforms.py
+++ b/tests/inference/test_transforms.py
@@ -14,9 +14,8 @@ Invariants exercised:
   botorch's plain normalize/unnormalize.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_utils.py
+++ b/tests/inference/test_utils.py
@@ -2,9 +2,8 @@
 Unit tests for inference utility helpers.
 
 References:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/inference/test_utils_branches.py
+++ b/tests/inference/test_utils_branches.py
@@ -7,9 +7,8 @@ reads and is exercised here against a small synthetic workspace
 written to ``tmp_path``.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,8 +24,8 @@ integration tests.
         validate_mass_conservation(runner.hf_all)
 
 Documentation:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_agni_aragog.py
+++ b/tests/integration/test_integration_agni_aragog.py
@@ -28,9 +28,8 @@ AGNI-specific real-binary coupling is exercised by the existing
 ``test_smoke_modules.py`` chain.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_agni_atmodeller.py
+++ b/tests/integration/test_integration_agni_atmodeller.py
@@ -33,9 +33,8 @@ with a real interior solver; the AGNI leg is exercised by the
 existing ``test_smoke_modules.py`` chain.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_agni_calliope.py
+++ b/tests/integration/test_integration_agni_calliope.py
@@ -28,9 +28,8 @@ a real interior solver; the AGNI leg is exercised by the existing
 ``test_smoke_modules.py`` chain.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_agni_mors.py
+++ b/tests/integration/test_integration_agni_mors.py
@@ -33,9 +33,8 @@ ZEPHYRUS escape; the AGNI leg is exercised by the existing
 ``test_smoke_modules.py`` chain.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_agni_zephyrus.py
+++ b/tests/integration/test_integration_agni_zephyrus.py
@@ -38,9 +38,8 @@ with a dummy atmosphere; the AGNI leg is exercised by the
 existing ``test_smoke_modules.py`` chain.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_aragog_atmodeller.py
+++ b/tests/integration/test_integration_aragog_atmodeller.py
@@ -10,9 +10,8 @@ integration tier so it runs on every nightly without burning the
 integration step budget.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_aragog_calliope.py
+++ b/tests/integration/test_integration_aragog_calliope.py
@@ -10,9 +10,8 @@ so it runs on every nightly without burning the integration step
 budget.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_aragog_mors.py
+++ b/tests/integration/test_integration_aragog_mors.py
@@ -33,9 +33,8 @@ the slow-tier ``test_slow_aragog_calliope.py`` (with calliope
 outgas) at the production aragog backend.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_aragog_zephyrus.py
+++ b/tests/integration/test_integration_aragog_zephyrus.py
@@ -35,9 +35,8 @@ dummy interior) and the slow-tier aragog tests for the interior
 leg.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_atmodeller_dummy.py
+++ b/tests/integration/test_integration_atmodeller_dummy.py
@@ -32,9 +32,8 @@ Invariants asserted per scenario:
 - Cross-step continuity on P_surf and T_surf.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_atmodeller_mors.py
+++ b/tests/integration/test_integration_atmodeller_mors.py
@@ -50,9 +50,8 @@ interior) for the atmodeller leg; the MORS leg is exercised by
 ``test_smoke_modules.py``.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_atmodeller_zephyrus.py
+++ b/tests/integration/test_integration_atmodeller_zephyrus.py
@@ -57,9 +57,8 @@ interior) and ``test_integration_mors_zephyrus.py`` (zephyrus
 leg with dummy interior).
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_calliope_mors.py
+++ b/tests/integration/test_integration_calliope_mors.py
@@ -43,9 +43,8 @@ real atmosphere is exercised by the slow-tier
 MORS leg is exercised by ``test_smoke_modules.py``.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_calliope_multi_timestep.py
+++ b/tests/integration/test_integration_calliope_multi_timestep.py
@@ -13,8 +13,8 @@ a real physics module while maintaining reasonable runtime.
 **Runtime**: ~60-120s (5-10 timesteps, CALLIOPE + dummy modules)
 
 **Documentation**:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_calliope_variants.py
+++ b/tests/integration/test_integration_calliope_variants.py
@@ -9,9 +9,8 @@ an H2-dominated regime. Each runs the all-dummy backend with CALLIOPE
 swapped in for outgassing.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_calliope_zephyrus.py
+++ b/tests/integration/test_integration_calliope_zephyrus.py
@@ -46,9 +46,8 @@ zephyrus) and the AGNI x CALLIOPE leg covers the calliope
 atmosphere boundary.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_dummy_variants.py
+++ b/tests/integration/test_integration_dummy_variants.py
@@ -16,9 +16,8 @@ several dummy timesteps end-to-end (~30-60 s), and these tests are intended
 to be exercised by nightly CI alongside the existing slow integration suite.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_mors_zephyrus.py
+++ b/tests/integration/test_integration_mors_zephyrus.py
@@ -33,9 +33,8 @@ Invariants asserted per scenario:
   the final row (conservation invariant carve-out, §2).
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_multi_timestep.py
+++ b/tests/integration/test_integration_multi_timestep.py
@@ -15,8 +15,8 @@ for multiple timesteps with dummy modules and checking:
 **Runtime**: ~30-60s (5-10 timesteps, dummy modules)
 
 **Documentation**:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_outgas_xcheck.py
+++ b/tests/integration/test_integration_outgas_xcheck.py
@@ -33,8 +33,8 @@ Per ``proteus-tests.md`` §1 the file also includes an error-contract test
 exercising the outgas module schema validator.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 - CALLIOPE docs/Explanations/cross_backend_comparison.md
 """
 

--- a/tests/integration/test_integration_std_config.py
+++ b/tests/integration/test_integration_std_config.py
@@ -24,8 +24,8 @@ This test validates the full PROTEUS "standard candle" configuration using
 - Sufficient memory for AGNI/ARAGOG calculations
 
 **Documentation**:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_zalmoxis_aragog.py
+++ b/tests/integration/test_integration_zalmoxis_aragog.py
@@ -84,9 +84,8 @@ energetics) and ``test_slow_aragog_calliope.py`` /
 structure).
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_zalmoxis_atmodeller.py
+++ b/tests/integration/test_integration_zalmoxis_atmodeller.py
@@ -52,9 +52,8 @@ atmodeller + dummy Zalmoxis lives at the slow tier in
 ``test_slow_aragog_atmodeller.py``.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_zalmoxis_calliope.py
+++ b/tests/integration/test_integration_zalmoxis_calliope.py
@@ -55,9 +55,8 @@ The full two-timestep coupled run with real Aragog + real CALLIOPE
 ``test_slow_aragog_calliope.py``.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_integration_zalmoxis_spider.py
+++ b/tests/integration/test_integration_zalmoxis_spider.py
@@ -58,9 +58,8 @@ Integration-tier scope:
   ``core_density``, ``core_heatcap``, ``T_cmb_initial``, ``F_cmb``).
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_slow_agni_aragog.py
+++ b/tests/integration/test_slow_agni_aragog.py
@@ -37,9 +37,8 @@ plus AGNI's per-step Newton solve at the grey-gas level. The 3600 s
 timeout sits inside the slow-tier 200 min step cap.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_slow_aragog_atmodeller.py
+++ b/tests/integration/test_slow_aragog_atmodeller.py
@@ -32,9 +32,8 @@ validator) lives in ``test_integration_aragog_atmodeller.py`` at the
 integration tier since it is a sub-second config-only check.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_slow_aragog_calliope.py
+++ b/tests/integration/test_slow_aragog_calliope.py
@@ -27,9 +27,8 @@ validator) lives in ``test_integration_aragog_calliope.py`` at the
 integration tier since it is a sub-second config-only check.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_slow_janus_aragog.py
+++ b/tests/integration/test_slow_janus_aragog.py
@@ -41,9 +41,8 @@ on the Aragog interior. The 9000 s per-test timeout sits inside
 the slow-tier job cap with headroom for runner variance.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_slow_zalmoxis_aragog_calliope.py
+++ b/tests/integration/test_slow_zalmoxis_aragog_calliope.py
@@ -75,9 +75,8 @@ keeps the coupled cost bounded; the per-row dynamic refresh path is
 exercised separately by the structure-update unit tests.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_slow_zalmoxis_dummy.py
+++ b/tests/integration/test_slow_zalmoxis_dummy.py
@@ -47,9 +47,8 @@ markedly longer there and exhausts the 3600 s pytest-timeout; if
 the macOS path is re-enabled later, budget at least 3600 s.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_smoke_atmos_interior.py
+++ b/tests/integration/test_smoke_atmos_interior.py
@@ -12,8 +12,8 @@
 # Runtime: Each test <30s (target for fast PR CI)
 #
 # Documentation: For testing standards, see:
-# - docs/test_infrastructure.md
-# - docs/test_categorization.md
+# - docs/How-to/testing.md
+# - docs/Explanations/test_framework.md
 #
 from __future__ import annotations
 

--- a/tests/integration/test_smoke_janus.py
+++ b/tests/integration/test_smoke_janus.py
@@ -14,9 +14,8 @@ Invariants tested:
   - Time advances beyond initial value
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/integration/test_smoke_multi_timestep.py
+++ b/tests/integration/test_smoke_multi_timestep.py
@@ -11,9 +11,8 @@ Invariants tested:
   - No NaN in critical columns
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/interior_energetics/test_aragog.py
+++ b/tests/interior_energetics/test_aragog.py
@@ -6,9 +6,8 @@ inner_radius from zalmoxis_solver and configure temperature-dependent initial
 conditions.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - AragogRunner.setup_solver(): Zalmoxis branches for inner_radius, EOS fallback

--- a/tests/interior_energetics/test_aragog_jax.py
+++ b/tests/interior_energetics/test_aragog_jax.py
@@ -22,9 +22,8 @@ the dispatch code is exercised without paying the diffrax compile or
 running into the v1-v5 failure modes.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/interior_energetics/test_common.py
+++ b/tests/interior_energetics/test_common.py
@@ -6,9 +6,8 @@ Tests the _load_ps_table() method which loads SPIDER's P-S lookup tables
 fallback logic, and verifies the loaders are wired by ``Interior_t.__init__``.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - Interior_t._load_ps_table(): Load arbitrary P-S table with path fallback

--- a/tests/interior_energetics/test_entropy_ic_verify.py
+++ b/tests/interior_energetics/test_entropy_ic_verify.py
@@ -29,9 +29,8 @@ ordering bugs surface), S values designed so the 1 %, 5 % and 8 % cases are
 clearly in the right bucket.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
-- docs/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/interior_energetics/test_interior.py
+++ b/tests/interior_energetics/test_interior.py
@@ -5,9 +5,8 @@ This test file validates the dummy interior evolution model used for simple
 thermal evolution calculations without full mantle convection physics.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - calculate_simple_mantle_mass(): Mantle mass from radius/core fraction

--- a/tests/interior_energetics/test_spider.py
+++ b/tests/interior_energetics/test_spider.py
@@ -6,9 +6,8 @@ extraction, EOS range checking, JSON solution rewriting, and the
 _try_spider() call-sequence builder (EOS path resolution, mesh handling).
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - _coresize_from_mesh(): Extract R_cmb/R_surf ratio from mesh file

--- a/tests/interior_energetics/test_timestep_branches.py
+++ b/tests/interior_energetics/test_timestep_branches.py
@@ -7,9 +7,8 @@ invalid-method error path, and the three "time until X" estimators
 including their "already there" short-circuits.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/interior_energetics/test_wrapper.py
+++ b/tests/interior_energetics/test_wrapper.py
@@ -7,9 +7,8 @@ Also tests solve_structure() dispatch, phi_crit warning, full update path
 with mesh blending, convergence tracking, and entropy remap.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - update_structure_from_interior(): Trigger logic, T(r) profile building,

--- a/tests/interior_energetics/test_wrapper_adiabat_ic.py
+++ b/tests/interior_energetics/test_wrapper_adiabat_ic.py
@@ -50,9 +50,8 @@ Invariants exercised:
   violation.
 
 Testing standards and documentation:
-- docs/How-to/test_infrastructure.md: Test infrastructure overview
-- docs/How-to/test_categorization.md: Test marker definitions
-- docs/How-to/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 """
 
 from __future__ import annotations

--- a/tests/interior_struct/test_dummy_struct_branches.py
+++ b/tests/interior_struct/test_dummy_struct_branches.py
@@ -6,9 +6,8 @@ the R_c > R_p clamp inside ``solve_dummy_structure``. These complement
 the existing scaling-law tests in ``test_dummy_struct.py``.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/interior_struct/test_superliquidus_adiabat.py
+++ b/tests/interior_struct/test_superliquidus_adiabat.py
@@ -8,8 +8,8 @@ path. Each solve runs a surface-temperature scan plus bisection over the PALEOS
 adiabat, so they live in the slow nightly tier; the unit suite exercises the
 solver control flow against a synthetic adiabat in ``test_liquidus_super_ic``.
 
-See also: ``docs/How-to/test_infrastructure.md``,
-``docs/How-to/test_categorization.md``, ``docs/How-to/test_building.md``.
+See also: ``docs/How-to/testing.md``,
+``docs/Explanations/test_framework.md``.
 """
 
 from __future__ import annotations

--- a/tests/interior_struct/test_zalmoxis.py
+++ b/tests/interior_struct/test_zalmoxis.py
@@ -5,9 +5,8 @@ Validates SPIDER mesh file generation from Zalmoxis mantle profiles,
 Zalmoxis configuration building, and solidus/liquidus loading.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - write_spider_mesh_file(): Interpolate Zalmoxis profiles onto SPIDER mesh

--- a/tests/observe/test_observe.py
+++ b/tests/observe/test_observe.py
@@ -14,9 +14,8 @@ Physics tested:
 - Data structure validation (column presence, data types)
 
 Related documentation:
-- docs/test_infrastructure.md: Testing standards and structure
-- docs/test_categorization.md: Test classification criteria
-- docs/test_building.md: Best practices for test implementation
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Mocking strategy:
 - Use tmp_path fixture for temporary file creation

--- a/tests/orbit/test_lovepy_mocked.py
+++ b/tests/orbit/test_lovepy_mocked.py
@@ -33,8 +33,8 @@ Module scope:
   - ``juliacall.JuliaError`` is wrapped into ``RuntimeError``.
 
 See also:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/outgas/test_atmodeller.py
+++ b/tests/outgas/test_atmodeller.py
@@ -26,8 +26,8 @@ Invariants exercised:
   outgas-reservoir escape debit, whereas the zeroed-reservoir bug state
   collapses it.
 
-See ``docs/How-to/test_infrastructure.md``, ``docs/How-to/test_building.md``,
-``docs/How-to/test_categorization.md``.
+See ``docs/How-to/testing.md``,
+``docs/Explanations/test_framework.md``.
 """
 
 from __future__ import annotations

--- a/tests/outgas/test_calliope.py
+++ b/tests/outgas/test_calliope.py
@@ -13,9 +13,8 @@ Invariants tested:
   - flag_included_volatiles: O2 is always included
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/outgas/test_common.py
+++ b/tests/outgas/test_common.py
@@ -11,9 +11,8 @@ Invariants tested:
   - Structural: element mass-ratio keys are symmetric-pair unique
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/outgas/test_noble_gas_atmodeller_smoke.py
+++ b/tests/outgas/test_noble_gas_atmodeller_smoke.py
@@ -8,9 +8,8 @@ solubility laws since before this branch, so this test runs on the released
 atmodeller rather than being gated on a new capability.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/outgas/test_noble_gas_smoke.py
+++ b/tests/outgas/test_noble_gas_smoke.py
@@ -11,9 +11,8 @@ that predates that support it skips, so the fast PR gate stays green; it
 activates automatically once the CALLIOPE version pin is bumped.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/outgas/test_wrapper.py
+++ b/tests/outgas/test_wrapper.py
@@ -15,9 +15,8 @@ Physics tested:
 - Mean molecular weight calculation (atm_kg_per_mol)
 
 Related documentation:
-- docs/test_infrastructure.md: Testing standards and structure
-- docs/test_categorization.md: Test classification criteria
-- docs/test_building.md: Best practices for test implementation
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Mocking strategy:
 - Mock all CALLIOPE functions (calc_surface_pressures, calc_target_masses) to isolate wrapper logic

--- a/tests/plot/test_cpl_atmosphere.py
+++ b/tests/plot/test_cpl_atmosphere.py
@@ -6,9 +6,8 @@ transparent / opaque profile styling) and the
 source-binding attributes so tests run in milliseconds.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_atmosphere_cbar.py
+++ b/tests/plot/test_cpl_atmosphere_cbar.py
@@ -5,9 +5,8 @@ with colour bar) and the ``plot_atmosphere_cbar_entry`` wrapper.
 Matplotlib + axes_grid1 are mocked at the source-binding attributes.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_bolometry.py
+++ b/tests/plot/test_cpl_bolometry.py
@@ -5,9 +5,8 @@ the ``plot_bolometry_entry`` wrapper. Matplotlib is mocked at the
 source-binding attribute.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_chem_atmosphere.py
+++ b/tests/plot/test_cpl_chem_atmosphere.py
@@ -5,9 +5,8 @@ profiles. All matplotlib rendering, file I/O, NetCDF reads, and filesystem
 operations are mocked for fast unit testing (<100 ms).
 
 Testing standards:
-  - docs/test_infrastructure.md
-  - docs/test_categorization.md
-  - docs/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_escape.py
+++ b/tests/plot/test_cpl_escape.py
@@ -5,9 +5,8 @@ plot path through 3 panels) and the ``plot_escape_entry`` wrapper.
 Matplotlib is mocked at the source-binding attribute.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_fluxes_atmosphere.py
+++ b/tests/plot/test_cpl_fluxes_atmosphere.py
@@ -6,9 +6,8 @@ optional and required NetCDF variables) and the
 mocked at the source-binding attributes so tests run in milliseconds.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_fluxes_global.py
+++ b/tests/plot/test_cpl_fluxes_global.py
@@ -5,9 +5,8 @@ full plot path) and the ``plot_fluxes_global_entry`` wrapper.
 Matplotlib is mocked at the source-binding attribute.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_global.py
+++ b/tests/plot/test_cpl_global.py
@@ -6,9 +6,8 @@ fluxes + temperatures + radii) and is exercised by integration tests
 in nightly tier; this unit test scope is the lightweight branches.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_interior.py
+++ b/tests/plot/test_cpl_interior.py
@@ -6,9 +6,8 @@ spider branches, plus early-return guards) and the
 source-binding attribute.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_interior_cmesh.py
+++ b/tests/plot/test_cpl_interior_cmesh.py
@@ -7,9 +7,8 @@ source-binding attribute; numerical data structures are small synthetic
 arrays.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_orbit.py
+++ b/tests/plot/test_cpl_orbit.py
@@ -5,9 +5,8 @@ wrapper. Heavy matplotlib operations are mocked at the source-binding
 attribute (``cpl_orbit.plt``) so tests run in milliseconds.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_population_full.py
+++ b/tests/plot/test_cpl_population_full.py
@@ -6,9 +6,8 @@ Zeng-2019 mass-radius curves. Complements the existing missing-data
 guards in ``test_cpl_population.py``.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_sflux.py
+++ b/tests/plot/test_cpl_sflux.py
@@ -6,9 +6,8 @@ multi-time and single-time branches plus modern-spectrum overlay) and
 source-binding attributes.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_sflux_cross.py
+++ b/tests/plot/test_cpl_sflux_cross.py
@@ -6,9 +6,8 @@ modern-spectrum overlay) and the ``plot_sflux_cross_entry`` wrapper.
 Matplotlib is mocked at the source-binding attribute.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_spectra.py
+++ b/tests/plot/test_cpl_spectra.py
@@ -5,9 +5,8 @@ fallback, full-path two-panel plot) and ``plot_spectra_entry``.
 Matplotlib + the read_transit / read_eclipse helpers are mocked.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_structure.py
+++ b/tests/plot/test_cpl_structure.py
@@ -7,9 +7,8 @@ mocked at the source-binding attributes (``cpl_structure.plt`` and
 ``cpl_structure.mpl``) so tests run in milliseconds.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/plot/test_cpl_visual.py
+++ b/tests/plot/test_cpl_visual.py
@@ -6,9 +6,8 @@ These plots depend on how the planet RT is calculated, and how the atmosphere st
 is represented in the NetCDF files.
 
 Testing standards:
-  - docs/test_infrastructure.md
-  - docs/test_categorization.md
-  - docs/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/star/test_phoenix.py
+++ b/tests/star/test_phoenix.py
@@ -10,9 +10,8 @@ so the discrimination guard tests pin closed-form log g values rather
 than physical invariants.
 
 See also:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/star/test_star.py
+++ b/tests/star/test_star.py
@@ -2,7 +2,7 @@
 
 Exercises stellar radius calculation (empirical scaling laws and direct config),
 blackbody spectrum generation, bolometric luminosity, and planetary instellation.
-Follows PROTEUS testing standards (see docs/test_infrastructure.md).
+Follows PROTEUS testing standards (see docs/How-to/testing.md).
 """
 
 from __future__ import annotations

--- a/tests/star/test_wrapper.py
+++ b/tests/star/test_wrapper.py
@@ -5,9 +5,8 @@ helper. Heavier dispatch functions that drive MORS / Spada tracks are
 covered by integration tests in nightly tier.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -5,9 +5,8 @@ Tests the resume code path in Proteus.start() that restores the Zalmoxis
 mesh file path when resuming a SPIDER interior simulation.
 
 Testing standards and documentation:
-- docs/test_infrastructure.md: Test infrastructure overview
-- docs/test_categorization.md: Test marker definitions
-- docs/test_building.md: Best practices for test construction
+- docs/How-to/testing.md: Running, writing, and marking tests; coverage and CI
+- docs/Explanations/test_framework.md: Test tiers, physics invariants, and quality rules
 
 Functions tested:
 - Proteus.start(): Resume path restoring spider_mesh and spider_mesh_prev

--- a/tests/test_readme_badges.py
+++ b/tests/test_readme_badges.py
@@ -8,8 +8,8 @@ without a third-party request. The two surfaces use different image sources by
 design but must link to the same destinations; these tests pin both the README
 source contract and that the two surfaces stay in sync on what they point to.
 
-Testing standards: docs/test_infrastructure.md, docs/test_categorization.md,
-docs/test_building.md
+Testing standards: docs/How-to/testing.md,
+docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/tools/test_cache_badges.py
+++ b/tests/tools/test_cache_badges.py
@@ -6,8 +6,8 @@ fallback, the run-conclusion to badge-style mapping, the fetch/last-good/
 placeholder branch in cache_badge, the main-branch run query in
 _latest_conclusion, and the workflow-to-badge mapping that reports main.
 
-Testing standards: docs/How-to/test_infrastructure.md, test_categorization.md,
-test_building.md
+Testing standards: docs/How-to/testing.md,
+docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/tools/test_chili_generate.py
+++ b/tests/tools/test_chili_generate.py
@@ -11,9 +11,8 @@ cases (tools/chili_generate.py). These tests pin that contract:
   regeneration, so a tutorial retune without regeneration fails CI.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -32,9 +32,8 @@ no network access and no real builds; the configuration tests read the
 checked-in files directly.
 
 See also:
-- docs/test_infrastructure.md
-- docs/test_categorization.md
-- docs/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/tools/test_solidus_func.py
+++ b/tests/tools/test_solidus_func.py
@@ -10,9 +10,8 @@ Covers:
 5. Edge cases and error handling
 
 References:
-- docs/How-to/test_infrastructure.md
-- docs/How-to/test_categorization.md
-- docs/How-to/test_building.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/tools/test_update_coverage_threshold.py
+++ b/tests/tools/test_update_coverage_threshold.py
@@ -9,8 +9,8 @@ fixed per-gate ceilings (fast 80%, full 90%). These tests exercise:
 * the no-op-at-ceiling short circuit,
 * the validation/error contract (missing coverage file, unknown target).
 
-See ``docs/How-to/test_infrastructure.md``, ``docs/How-to/test_building.md``,
-and ``docs/How-to/test_categorization.md`` for the test framework.
+See ``docs/How-to/testing.md`` and
+``docs/Explanations/test_framework.md`` for the test framework.
 """
 
 from __future__ import annotations

--- a/tests/utils/test_archive.py
+++ b/tests/utils/test_archive.py
@@ -7,9 +7,8 @@ os.* primitives; mocking those would amount to mocking the function
 under test.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -14,9 +14,8 @@ Invariants tested:
     expected species
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -8,7 +8,8 @@ external physics data (spectral files, lookup tables). It covers:
 - Configuration mapping for remote resources.
 
 See also:
-- docs/test_infrastructure.md
+- docs/How-to/testing.md
+- docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/utils/test_helper_branches.py
+++ b/tests/utils/test_helper_branches.py
@@ -7,9 +7,8 @@ input and a molecular formula, and the full ``CommentFromStatus``
 table including the unhandled-status fallback.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/utils/test_phys.py
+++ b/tests/utils/test_phys.py
@@ -6,9 +6,8 @@ Wien displacement relations, and exercises the overflow-fallback path
 at extreme short wavelengths.
 
 Testing standards:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tests/utils/test_terminate.py
+++ b/tests/utils/test_terminate.py
@@ -2,7 +2,7 @@
 
 Exercises convergence/termination criteria for solidification, energy balance,
 volatile escape, disintegration, time/iteration limits, and keepalive guard.
-Follows PROTEUS testing standards (see docs/test_infrastructure.md).
+Follows PROTEUS testing standards (see docs/How-to/testing.md).
 """
 
 from __future__ import annotations

--- a/tests/utils/test_visual.py
+++ b/tests/utils/test_visual.py
@@ -8,9 +8,8 @@ Utility module: physics-invariant marker not required; anti-happy-path
 rules still apply (edge case + limit-input + non-trivial assertion).
 
 See also:
-  - docs/How-to/test_infrastructure.md
-  - docs/How-to/test_categorization.md
-  - docs/How-to/test_building.md
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
 """
 
 from __future__ import annotations

--- a/tools/get_petsc.sh
+++ b/tools/get_petsc.sh
@@ -71,7 +71,7 @@ on_error() {
             echo "   - Check petsc/configure.log for details"
             echo "   - On macOS: ensure Xcode CLI tools are installed (xcode-select --install)"
             echo "   - Verify MPI is installed (mpicc --version)"
-            echo "   - See PROTEUS docs/troubleshooting.md for platform-specific fixes"
+            echo "   - See PROTEUS docs/How-to/troubleshooting.md for platform-specific fixes"
             ;;
         *"Build"*)
             echo "   - Check petsc/make.log for compiler errors"
@@ -82,10 +82,10 @@ on_error() {
             echo "   - PETSc built but tests failed"
             echo "   - Check petsc/make.log for details"
             echo "   - On macOS: check /etc/hosts for localhost entry"
-            echo "     (see docs/troubleshooting.md: PETSc tests error)"
+            echo "     (see docs/How-to/troubleshooting.md: PETSc tests error)"
             ;;
         *)
-            echo "   - See docs/troubleshooting.md for platform-specific advice"
+            echo "   - See docs/How-to/troubleshooting.md for platform-specific advice"
             ;;
     esac
     echo "========================================"

--- a/tools/get_spider.sh
+++ b/tools/get_spider.sh
@@ -70,7 +70,7 @@ on_error() {
             echo "   - Verify mpicc is working: mpicc --version"
             echo "   - Verify PETSc is intact: ls \$PETSC_DIR/\$PETSC_ARCH/lib/libpetsc.*"
             echo "   - On macOS: ensure SDKROOT is set (xcrun --show-sdk-path)"
-            echo "   - See PROTEUS docs/troubleshooting.md for platform-specific fixes"
+            echo "   - See PROTEUS docs/How-to/troubleshooting.md for platform-specific fixes"
             ;;
         *"Verif"*)
             echo "   - The build completed without make errors but no binary was produced"
@@ -78,7 +78,7 @@ on_error() {
             echo "   - Try rebuilding with verbose output: cd $workpath && make V=1"
             ;;
         *)
-            echo "   - See docs/troubleshooting.md for platform-specific advice"
+            echo "   - See docs/How-to/troubleshooting.md for platform-specific advice"
             ;;
     esac
     echo ""


### PR DESCRIPTION
## Description
The testing documentation pointed readers at pages that do not exist, and then described a CI pipeline we do not run. This fixes both.

Nearly every file under `tests/` carried a "See also" block naming `docs/test_infrastructure.md`, `docs/test_categorization.md`, and `docs/test_building.md`, or the `docs/How-to/` spelling of the same three. None of those six pages is in the repo, so every pointer led nowhere. The material lives on two pages now: `docs/How-to/testing.md` (running, writing, and marking tests; coverage and CI) and `docs/Explanations/test_framework.md` (tier hierarchy, physics invariants, quality rules). Each reference now names whichever page carries what it was pointing at, so three pointers usually collapse to two. The PETSc and SPIDER install scripts had the same class of dead pointer: on failure they told the user to read `docs/troubleshooting.md`, which is really `docs/How-to/troubleshooting.md`.

Repointing meant reading the two surviving pages closely, and they turned out to describe gates CI does not run:

- Both said the fast pull-request gate measures unit + smoke coverage, ratcheting toward 90% and plateauing at 60-75%. It reads unit-only coverage against a fixed 80%.
- Both said the smoke tier runs on every pull request. `ci-pr-checks.yml` has no smoke job; its own summary says the PR cycle runs the unit tier only.
- The nightly was credited with enforcing the 90% gate. Every coverage command there passes `--cov-fail-under=0` and nothing runs `coverage report`; the 90 is read by the pull-request estimated-total gate instead.
- The three surfaces disagreed on how many gates exist (two, three, and four). There are three, all on pull requests: fast (80%, unit-only), estimated total (90%, unioned with the latest nightly), and diff-cover (80%, also unioned).
- Both lists of "what a PR runs" quoted the unit selector as `pytest -m "unit and not skip"`, which collects five slow-marked tests CI excludes, and both omitted the estimated-total gate. The test-quality step was listed as required when its step sets `continue-on-error`.

`.github/copilot-instructions.md` and the two rule files under `.github/.claude/` carried the same claims and are corrected with them; the rule file states a contract to stay in sync with the project instructions, so it moves too. One `pyproject.toml` comment repeated the nightly-enforcement claim and is fixed.

Five test files keep their stale pointers for now because they have edits in flight on other branches and I did not want to hand anyone a conflict: `tests/config/test_struct.py`, `tests/interior_energetics/test_boundary.py`, `tests/observe/test_wrapper_obs.py`, `tests/test_installer.py`, and `tests/utils/test_coupler.py`. They can follow once those land.

No code or CI behaviour changes: this is documentation, two `echo` strings, and one config comment.

## Validation of changes
macOS, Python 3.12.

- Every claim in the rewritten prose was checked against its authority rather than against another doc: `ci-pr-checks.yml` and `ci-nightly.yml` for what runs where, `coverage-baseline.yml` for what the status badge reports, `pyproject.toml` and `tools/update_coverage_threshold.py` for the numbers.
- `pytest -m "unit and not skip and not slow and not integration"`: 2657 passed, 13 skipped. The docstring edits change no collection.
- `ruff check` and `ruff format --check` clean on all touched files; `bash tools/validate_test_structure.sh` passes; `bash -n` passes on both install scripts.
- Verified no dead pointer survives outside the five deferred files, and that every pointer the diff introduces resolves to a file that exists.
- Spot-checked the mechanical rewrite by hand across each distinct block shape: plain bullets, annotated bullets, RST double-backticks, comment headers, and prose sentences.
- `.github/copilot-instructions.md` is 636 lines, under its 750-line limit, and the `CLAUDE.md` symlink is intact.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
