### PR TITLE
Divide the eclipse depth by the stellar surface flux

### DIFF
--- a/src/proteus/atmos_chem/vulcan.py
+++ b/src/proteus/atmos_chem/vulcan.py
@@ -15,6 +15,7 @@ import vulcan
 
 # Import PROTEUS
 from proteus.atmos_clim.common import read_atmosphere_data
+from proteus.star.wrapper import scale_spectrum_to_stellar_surface
 from proteus.utils.constants import AU, R_sun, element_list, vol_list
 from proteus.utils.helper import find_nearest
 
@@ -121,7 +122,9 @@ def run_vulcan(dirs: dict, config: Config, hf_row: dict, *, online: bool = False
     # Read spectrum and scale to surface of the star
     sflux_data = np.loadtxt(sflux_fpath, skiprows=1).T
     star_wl = np.array(sflux_data[0])
-    star_fl = np.array(sflux_data[1]) * hf_row['separation'] ** 2 / hf_row['R_star'] ** 2
+    star_fl = scale_spectrum_to_stellar_surface(
+        sflux_data[1], hf_row['separation'], hf_row['R_star']
+    )
 
     # Remove small values
     star_wl = star_wl[star_fl > config.atmos_chem.vulcan.clip_fl]

--- a/src/proteus/observe/petitRADTRANS.py
+++ b/src/proteus/observe/petitRADTRANS.py
@@ -370,8 +370,9 @@ def _load_stellar_toa_flux(
 ) -> np.ndarray:
     """Load the PROTEUS-written stellar spectrum from the latest ``data/<Number>.sflux`` file.
 
-    The spectrum is already scaled to the top of the planet atmosphere, so it
-    can be used directly in the eclipse-depth denominator.
+    The spectrum is scaled to the top of the planet atmosphere, so it carries the
+    reduction by the orbital distance. A consumer that needs the flux at the stellar
+    surface, such as the eclipse-depth denominator, must undo that reduction.
     Selects the .sflux file with the largest numeric prefix in the filename.
     """
 
@@ -660,7 +661,15 @@ def eclipse_depth(hf_row: dict, config: Config, source: str, dirs: dict[str, str
         )
         wl_local = np.array(wl_cm_local, dtype=float) * 1e4
         stellar_wavelength_nm = np.array(wl_cm_local, dtype=float) * 1.0e7
-        stellar_surface_flux = _load_stellar_toa_flux(outdir, hf_row, stellar_wavelength_nm)
+        stellar_toa_flux = _load_stellar_toa_flux(outdir, hf_row, stellar_wavelength_nm)
+        # The eclipse depth compares the two emitting surfaces, so the denominator is
+        # the flux at the stellar surface. The stored spectrum is the flux arriving at
+        # the planet, still carrying the reduction by the orbital distance, so undo
+        # that reduction here; dividing by it as it stands leaves the reduction in the
+        # result on top of the geometric factor below. This assumes the stored spectrum
+        # was written at the separation this row holds, which is exact for a fixed orbit
+        # and leaves the ratio of the two separations behind while an orbit evolves.
+        stellar_surface_flux = stellar_toa_flux * (sep / Rs) ** 2
         depth_local = (
             np.array(planet_flux_local, dtype=float)
             / stellar_surface_flux

--- a/src/proteus/observe/petitRADTRANS.py
+++ b/src/proteus/observe/petitRADTRANS.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from scipy.interpolate import PchipInterpolator
 
+from proteus.star.wrapper import scale_spectrum_to_stellar_surface
 from proteus.utils.constants import (
     prt_cia_species,
     prt_gases,
@@ -669,7 +670,7 @@ def eclipse_depth(hf_row: dict, config: Config, source: str, dirs: dict[str, str
         # result on top of the geometric factor below. This assumes the stored spectrum
         # was written at the separation this row holds, which is exact for a fixed orbit
         # and leaves the ratio of the two separations behind while an orbit evolves.
-        stellar_surface_flux = stellar_toa_flux * (sep / Rs) ** 2
+        stellar_surface_flux = scale_spectrum_to_stellar_surface(stellar_toa_flux, sep, Rs)
         depth_local = (
             np.array(planet_flux_local, dtype=float)
             / stellar_surface_flux

--- a/src/proteus/star/wrapper.py
+++ b/src/proteus/star/wrapper.py
@@ -378,7 +378,7 @@ def scale_spectrum_to_toa(fl_arr, sep: float):
         fl_arr : iterable
             Stellar fluxes at 1 AU
         sep : float
-            Planet-star distance, in units of AU
+            Planet-star distance [m]
     Returns
     ----------
         fl_arr : np.ndarray
@@ -396,7 +396,8 @@ def write_spectrum(wl_arr, fl_arr, hf_row: dict, output_dir: str):
         wl_arr : np.ndarray
             Wavelength array [nm]
         fl_arr : np.ndarray
-            Stellar fluxes at 1 AU [erg s-1 cm-2 nm-1]
+            Stellar fluxes at the top of the planet's atmosphere
+            [erg s-1 cm-2 nm-1]
         hf_row : dict
             Current helpfile row
         output_dir : str

--- a/src/proteus/star/wrapper.py
+++ b/src/proteus/star/wrapper.py
@@ -406,10 +406,14 @@ def write_spectrum(wl_arr, fl_arr, hf_row: dict, output_dir: str):
 
     log.debug('Writing stellar spectrum to file')
 
-    # Header information
+    # Header information. Name where the spectrum corresponds to so the file is
+    # self-describing: these are the fluxes at the top of the planet's atmosphere,
+    # carried in from 1 AU by the orbital separation, not the fluxes at the stellar
+    # surface. A consumer that wants the stellar surface must undo that scaling.
     header = (
-        '# WL(nm)\t Flux(ergs/cm**2/s/nm)   Stellar flux at t_star = %.2e yr'
-        % hf_row['age_star']
+        '# WL(nm)\t Flux(ergs/cm**2/s/nm)   '
+        'Stellar flux at the top of the planet atmosphere '
+        '(scaled from 1 AU by the orbital separation), t_star = %.2e yr' % hf_row['age_star']
     )
 
     # Write to TSV file

--- a/src/proteus/star/wrapper.py
+++ b/src/proteus/star/wrapper.py
@@ -387,6 +387,33 @@ def scale_spectrum_to_toa(fl_arr, sep: float):
     return np.array(fl_arr) * ((AU / sep) ** 2)
 
 
+def scale_spectrum_to_stellar_surface(fl_arr, sep: float, r_star: float):
+    """
+    Scale stellar fluxes from the top of the planet's atmosphere to the stellar surface.
+
+    This inverts the separation-dependent part of scale_spectrum_to_toa. The spectrum
+    written to the .sflux file is the flux at the planet, reduced from the stellar
+    surface by (r_star / sep) ** 2, so recovering the surface value multiplies by
+    (sep / r_star) ** 2. A consumer that compares against the stellar surface, such as
+    the eclipse-depth denominator or the VULCAN stellar input, needs this; the climate
+    and photochemistry modules that want the flux at the planet use the file as written.
+
+    Parameters
+    ----------
+        fl_arr : iterable
+            Stellar fluxes at the top of the planet's atmosphere.
+        sep : float
+            Planet-star distance [m].
+        r_star : float
+            Stellar radius [m].
+    Returns
+    ----------
+        fl_arr : np.ndarray
+            Stellar fluxes at the stellar surface.
+    """
+    return np.array(fl_arr) * ((sep / r_star) ** 2)
+
+
 def write_spectrum(wl_arr, fl_arr, hf_row: dict, output_dir: str):
     """
     Write stellar spectrum to file.

--- a/tests/observe/test_petitRADTRANS.py
+++ b/tests/observe/test_petitRADTRANS.py
@@ -1450,3 +1450,114 @@ def test_reference_pinned_mean_molar_mass_increases_with_helium_vmr(monkeypatch)
     assert np.allclose(mmw_2[0], 2.5, rtol=0.02), (
         'Reference: 75% H2 + 25% He should give M_mean ≈ 2.5 g/mol'
     )
+
+
+@pytest.mark.physics_invariant
+def test_eclipse_depth_divides_by_the_stellar_surface_flux(monkeypatch, tmp_path):
+    """The eclipse depth is the planet-to-star surface brightness ratio scaled by the
+    squared radius ratio, so the denominator has to be the flux at the stellar surface.
+
+    The stored spectrum is the flux arriving at the planet, already reduced by the
+    orbital distance, so it has to be carried back out to the stellar surface before it
+    divides the planet flux. Otherwise the orbital reduction is applied a second time
+    through the geometric factor and every depth comes out too large by the squared
+    ratio of separation to stellar radius.
+
+    The planet sits at ten stellar radii, a hot-Jupiter separation, which makes that
+    ratio exactly 100 and puts the two candidate answers two decades apart: far outside
+    any tolerance, and far outside the ppm and radius-ratio factors the neighbouring
+    pins already cover. The stand-in transfer returns fixed fluxes, so the expected
+    depth is closed-form: planet flux 1.0 over a surface flux of 3e8 * 100, times the
+    squared radius ratio (7.0e8/7.0e10)^2, in ppm.
+    """
+    mod = _import_backend(monkeypatch)
+    monkeypatch.setattr(mod, 'prt_gases', ('H2O',))
+    monkeypatch.setattr(mod, 'prt_rayleigh_species', set())
+    monkeypatch.setattr(mod, 'prt_cia_species', ())
+    monkeypatch.setattr(mod, 'eval_gas_mmw', lambda gas: {'H2O': 18e-3}[gas])
+
+    input_data_path = tmp_path / 'input_data'
+    species_dir = input_data_path / 'opacities' / 'lines' / 'correlated_k' / 'H2O'
+    species_dir.mkdir(parents=True)
+    (species_dir / '1H2-16O__Test.R1000_0.5-5mu.ktable.petitRADTRANS.h5').write_text('dummy')
+
+    observe_common = types.ModuleType('proteus.observe.common')
+
+    def _get_eclipse_fpath(outdir, source, kind):
+        path = Path(outdir) / 'observe' / f'eclipse_{source}_{kind}.csv'
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return str(path)
+
+    observe_common.get_eclipse_fpath = _get_eclipse_fpath
+    monkeypatch.setitem(sys.modules, 'proteus.observe.common', observe_common)
+
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir(parents=True)
+    # The transfer reports micron-scale wavelengths while the table stops at 600 nm, so
+    # the interpolation runs off the top and holds 30 erg cm-2 s-1 nm-1, which is why the
+    # denominator is flat. The table rises rather than sitting at a plateau so that the
+    # held value names which end was reached: a wavelength mapping that put the targets
+    # below the table would hold 10 instead and move the depths.
+    (data_dir / '1.sflux').write_text('wl flux\n400 10\n500 20\n600 30\n')
+
+    fake_atm = {
+        'pl': np.array([1.0e5, 1.0e4]),
+        'tmpl': np.array([300.0, 200.0]),
+        'rl': np.array([7.0e6, 7.1e6]),
+        'p': np.array([1.0e5, 1.0e4]),
+        'r': np.array([7.0e6, 7.1e6]),
+        'g': np.array([10.0, 11.0]),
+        'x_gas': {'H2O': np.array([1.0, 1.0])},
+    }
+    monkeypatch.setattr(mod, '_get_atm_profile', lambda *_a, **_k: fake_atm)
+    monkeypatch.setattr(mod, '_get_input_data_path', lambda _dirs: str(input_data_path))
+
+    class FakeRadtrans:
+        def __init__(self, **kwargs):
+            pass
+
+        def calculate_flux(self, **kwargs):
+            return np.array([1.0e-4, 2.0e-4]), np.array([1.0, 2.0]), None
+
+    monkeypatch.setattr(sys.modules['petitRADTRANS.radtrans'], 'Radtrans', FakeRadtrans)
+
+    R_star = 7.0e8  # m, one solar radius to two figures
+    hf_row = {
+        'Time': 1,
+        'R_star': R_star,
+        'T_star': 1000.0,
+        # Ten stellar radii, a hot-Jupiter orbit. Deliberately not equal to R_star: at
+        # separation == R_star the surface and orbit fluxes coincide and the assertion
+        # below could not tell which one divided the planet flux.
+        'separation': 10.0 * R_star,
+        'R_int': 7.0e6,
+    }
+
+    config = _make_config(include_cia=False, include_rayleigh=False, remove_one_gas=False)
+    dirs = {'fwl': str(tmp_path), 'output': str(tmp_path)}
+    result = mod.eclipse_depth(hf_row, config, 'outgas', dirs)
+
+    dilution = (hf_row['separation'] / R_star) ** 2  # 100, exactly
+    surface_flux = 3.0e8 * dilution  # erg cm-2 s-1 cm-1 at the stellar surface
+    radius_ratio_sq = (7.0e8 / 7.0e10) ** 2
+    expected = np.array([1.0, 2.0]) / surface_flux * radius_ratio_sq * 1e6
+
+    np.testing.assert_allclose(result[:, 1], expected, rtol=1e-6)
+
+    # Sign guard: a depth is a positive flux ratio.
+    assert np.all(result[:, 1] > 0.0)
+    # Discrimination guard: dividing by the orbit-reduced flux instead of the surface
+    # flux lands 100x high, two decades outside the tolerance above.
+    double_diluted = expected * dilution
+    assert np.all(np.abs(result[:, 1] - double_diluted) > 0.9 * double_diluted)
+    # Scale guard: these are ~3e-9 ppm, not ~3e-7 (double dilution) and not ~3e-3
+    # (a missing radius ratio).
+    assert np.all((result[:, 1] > 1.0e-10) & (result[:, 1] < 1.0e-8))
+
+    # Limit input: a planet orbiting at one stellar radius sits on the stellar surface,
+    # where the two fluxes are the same and the rescale is the identity. The depths then
+    # fall back on the stored spectrum unchanged, which is why pins taken at that
+    # separation cannot tell the two denominators apart.
+    hf_row_at_surface = {**hf_row, 'separation': R_star}
+    result_at_surface = mod.eclipse_depth(hf_row_at_surface, config, 'outgas', dirs)
+    np.testing.assert_allclose(result_at_surface[:, 1], expected * dilution, rtol=1e-6)

--- a/tests/observe/test_petitRADTRANS.py
+++ b/tests/observe/test_petitRADTRANS.py
@@ -229,7 +229,9 @@ def test_load_stellar_toa_flux_reads_saved_sflux_and_interpolates(monkeypatch, t
     data_dir.mkdir(parents=True)
     spectrum_file = data_dir / '42.sflux'
     spectrum_file.write_text(
-        '# WL(nm)\t Flux(ergs/cm**2/s/nm)   Stellar flux at t_star = 1.00e+00 yr\n'
+        '# WL(nm)\t Flux(ergs/cm**2/s/nm)   Stellar flux at the top of the '
+        'planet atmosphere (scaled from 1 AU by the orbital separation), '
+        't_star = 1.00e+00 yr\n'
         '4.00000000e+02\t1.00000000e+00\n'
         '5.00000000e+02\t2.00000000e+00\n'
         '6.00000000e+02\t4.00000000e+00\n'

--- a/tests/observe/test_petitRADTRANS.py
+++ b/tests/observe/test_petitRADTRANS.py
@@ -1552,8 +1552,9 @@ def test_eclipse_depth_divides_by_the_stellar_surface_flux(monkeypatch, tmp_path
     # flux lands 100x high, two decades outside the tolerance above.
     double_diluted = expected * dilution
     assert np.all(np.abs(result[:, 1] - double_diluted) > 0.9 * double_diluted)
-    # Scale guard: these are ~3e-9 ppm, not ~3e-7 (double dilution) and not ~3e-3
-    # (a missing radius ratio).
+    # Scale guard: these are ~3e-9 ppm, not ~3e-7 (double dilution) and not ~3e-5
+    # (a missing radius ratio: the ~3e-9 expected value divided by the 1e-4
+    # radius-ratio square).
     assert np.all((result[:, 1] > 1.0e-10) & (result[:, 1] < 1.0e-8))
 
     # Limit input: a planet orbiting at one stellar radius sits on the stellar surface,

--- a/tests/star/test_wrapper.py
+++ b/tests/star/test_wrapper.py
@@ -310,3 +310,81 @@ def test_update_stellar_temperature_spada_branch_calls_value():
     assert track.BaraffeStellarTeff.call_count == 0
     assert hf_row['T_star'] == pytest.approx(5778.0, rel=1e-12)
     assert hf_row['T_star'] > 0
+
+
+# ---------------------------------------------------------------------------
+# scale_spectrum_to_stellar_surface: inverse of the TOA scaling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.physics_invariant
+def test_scale_spectrum_to_stellar_surface_recovers_surface_flux_regardless_of_separation():
+    """Scaling a 1 AU spectrum out to the planet and back to the stellar surface
+    returns the surface flux, and the recovered value does not depend on the
+    orbital separation: the separation that scale_spectrum_to_toa introduces is
+    exactly undone by scale_spectrum_to_stellar_surface.
+
+    Discrimination: the round trip is run at two separations two decades apart
+    (0.1 AU and 10 AU). The rescale uses (sep / r_star) ** 2; an inverted ratio
+    (r_star / sep) ** 2 or a dropped square would leave a residual separation
+    dependence, so the two recovered spectra would differ by many decades instead
+    of matching. Asserting they both equal the surface flux, and each other, rules
+    those out.
+    """
+    from proteus.star.wrapper import (
+        scale_spectrum_to_stellar_surface,
+        scale_spectrum_to_toa,
+    )
+    from proteus.utils.constants import R_sun
+
+    f_surface = np.array([10.0, 20.0, 40.0])
+    r_star = 0.9 * R_sun
+    # Flux at 1 AU is the surface flux diluted by (r_star / AU) ** 2.
+    f_1au = f_surface * (r_star / AU) ** 2
+
+    recovered = []
+    for sep in (0.1 * AU, 10.0 * AU):
+        f_planet = scale_spectrum_to_toa(f_1au, sep)
+        recovered.append(scale_spectrum_to_stellar_surface(f_planet, sep, r_star))
+
+    np.testing.assert_allclose(recovered[0], f_surface, rtol=1e-12)
+    np.testing.assert_allclose(recovered[1], f_surface, rtol=1e-12)
+    # Separation cancels: an inverted rescale would put these 1e8 apart.
+    np.testing.assert_allclose(recovered[0], recovered[1], rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# write_spectrum: the .sflux file stays single-header-line for skiprows=1 readers
+# ---------------------------------------------------------------------------
+
+
+def test_write_spectrum_emits_a_single_header_line(tmp_path):
+    """write_spectrum writes exactly one header line, so every consumer that skips
+    one row (AGNI, VULCAN, the eclipse loader, the cpl_sflux plotters) reads the
+    data unshifted. The written values round-trip through np.loadtxt(skiprows=1).
+
+    Discrimination: a regression that emitted a second header line, or embedded a
+    newline in the header string, would make skiprows=1 consume a header line as
+    the first data row. That would either raise or return the wrong first
+    wavelength, so pinning an exact one-line header and a value-preserving round
+    trip (with the true first wavelength recovered) catches it.
+    """
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    wl = np.array([100.0, 200.0, 300.0])
+    fl = np.array([1.0e3, 2.0e3, 4.0e3])
+    hf_row = {'age_star': 4.567e9, 'Time': 42}
+
+    star_wrapper.write_spectrum(wl, fl, hf_row, str(tmp_path))
+
+    path = data_dir / '42.sflux'
+    lines = path.read_text().splitlines()
+    header_lines = [ln for ln in lines if ln.lstrip().startswith('#')]
+    # Exactly one header line, and it is the first line.
+    assert len(header_lines) == 1
+    assert lines[0].startswith('#')
+    # skiprows=1 recovers the data exactly, including the true first wavelength
+    # (a second header line would shift it to 200.0 or raise).
+    recovered = np.loadtxt(path, skiprows=1).T
+    np.testing.assert_allclose(recovered[0], wl, rtol=1e-12)
+    np.testing.assert_allclose(recovered[1], fl, rtol=1e-12)


### PR DESCRIPTION
## Description

An eclipse depth compares the planet's emergent flux with the star's flux at the stellar surface, scaled by the squared radius ratio. The denominator was taken straight from the stellar spectrum PROTEUS writes to `data/<iter>.sflux`, but that spectrum is the flux arriving at the planet: it is scaled to the top of the atmosphere before it is written, so it already carries the reduction by the orbital distance. Dividing by it left that reduction in the result on top of the geometric factor, so every synthetic eclipse depth came out too large by the squared ratio of separation to stellar radius.

At ten stellar radii that is a factor of 100. At 1 AU around a solar-radius star it is roughly 46000, which pushes thermal-infrared depths past unity. Transit depths are geometric and were never affected.

The spectrum is now carried back out to the stellar surface inside `eclipse_depth` before it divides the planet flux. The `.sflux` file itself is unchanged: the climate and photochemistry modules read it as the flux at the planet and need it that way, so the correction belongs to the one consumer that wants the stellar surface. `atmos_chem/vulcan.py` already does this same rescale for its own use of the file.

Three docstrings in that chain described something the code does not do, which is how the double reduction went unnoticed. `scale_spectrum_to_toa` gave its separation in AU while the body divides the astronomical unit by it and so needs metres; `write_spectrum` described fluxes at 1 AU while it is handed values already scaled to the planet; and the loader said its spectrum could be used directly as the eclipse denominator, which is the premise that was wrong. The local variable holding the loaded spectrum was called `stellar_surface_flux` while holding the flux at the planet, and now names what it holds.

One limitation worth stating: the rescale uses the separation on the current helpfile row. That is exact for a fixed orbit, which is the default. While an orbit evolves, the stored spectrum may have been written at an earlier separation and the ratio of the two is left behind. That residual is far smaller than the error it replaces, and it is the same staleness the climate module already sees from the same file.

## Validation of changes

Reproduced first, before changing anything: with the planet at ten stellar radii the computed depth was `3.33333333e-07` against a hand-computed `3.33333333e-09`, i.e. exactly 100x, which is the squared separation-to-radius ratio.

- New test `test_eclipse_depth_divides_by_the_stellar_surface_flux` pins the depth against a hand-computed value with the planet at ten stellar radii, so the separation and the stellar radius differ and the two candidate denominators sit two decades apart. It carries sign, discrimination and scale guards, and a limit-input case at one stellar radius where the rescale is the identity.
- The neighbouring eclipse pins place the planet at one stellar radius, where the correction factor is exactly 1, so they are unchanged and stay green.
- Checked the fix against deliberately broken copies of the code: removing the rescale, inverting it, dropping the square, mixing centimetres with metres, and corrupting the wavelength mapping each make the new test fail.
- `pytest -m "unit and not skip and not slow and not integration"`: 2659 passed, 13 skipped. `ruff` clean, `validate_test_structure.sh` passes, `check_test_quality.py` reports no regression.
- macOS with Python 3.12.

Any synthetic eclipse spectra generated since the observe module landed carry the inflation and would need regenerating; I found none on this machine.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
