### PR TITLE
Make petitRADTRANS an opt-in extra and fetch its opacity tables directly

### DIFF
--- a/.github/data-manifest.yaml
+++ b/.github/data-manifest.yaml
@@ -38,6 +38,14 @@ datasets:
   mors_evolution_tracks:
     family: Spada
 
+  # petitRADTRANS opacity tables (~5.6 GB), fetched only for configs that select the
+  # optional observe module. These come from the library the petitRADTRANS team
+  # publishes, which stays the source of truth; PROTEUS names which file it wants per
+  # species in proteus.utils.prt_data and caches the result here. Bump the version to
+  # re-cut the cache after any of those names change.
+  prt_opacities:
+    version: 2026-07-17
+
   # DACE / Zeng-2019 reference catalogs for the cpl_population plots.
   exoplanet_archive:
     version: 2026-05

--- a/docs/How-to/optionalmodules_installation.md
+++ b/docs/How-to/optionalmodules_installation.md
@@ -43,17 +43,103 @@ written in Julia.
 bash tools/get_lovepy.sh
 ```
 
-## Synthetic observations (PetitRADTRANS)
+## Synthetic observations (petitRADTRANS)
 
-[PetitRADTRANS](https://petitradtrans.readthedocs.io/en/latest/) generates
-synthetic transmission and secondary eclipse spectra.
+[petitRADTRANS](https://petitradtrans.readthedocs.io/en/latest/) generates
+synthetic transmission and secondary eclipse spectra. It is selected with
+`observe.module = "petitRADTRANS"`.
+
+Installing it takes three steps.
+
+**1. Install the package.** It builds Fortran, C and C++ extensions from
+source, so the host needs `gfortran` and a C/C++ toolchain before you start.
+
+```console
+pip install -e ".[observe]"
+```
+
+**2. Fetch the opacity tables.** About 5.6 GB, so allow time and disk. They
+land in `$FWL_DATA/prt/input_data` and are fetched once; a run interrupted
+part-way picks up where it stopped.
+
+```console
+python -c "from proteus.utils.prt_data import download_prt_opacities; download_prt_opacities()"
+```
+
+**3. Write the configuration.** This tells petitRADTRANS where the tables are
+and which file to use for each species. Step 2 does it for you; run this if
+you move `FWL_DATA` or want to rewrite the file.
 
 ```console
 bash tools/get_prt.sh
 ```
 
-!!! note
-    PetitRADTRANS downloads around 2 GB of opacity data on first use.
+### Citing the opacity data
+
+The tables are line lists produced by other groups and processed into
+correlated-k form by the petitRADTRANS team. If you publish spectra, cite the
+line list for each species you used, alongside petitRADTRANS itself
+([Mollière et al. 2019](https://doi.org/10.1051/0004-6361/201935470)).
+
+| Species | Source | Reference |
+|---|---|---|
+| H<sub>2</sub>O, CO | HITEMP | [Rothman et al. 2010](https://doi.org/10.1016/j.jqsrt.2010.05.001) |
+| CH<sub>4</sub> | HITEMP | [Hargreaves et al. 2020](https://doi.org/10.3847/1538-4365/ab7a1a) |
+| H<sub>2</sub>, O<sub>3</sub> | HITRAN | [Rothman et al. 2013](https://doi.org/10.1016/j.jqsrt.2013.07.002) |
+| O<sub>2</sub> | HITRAN | [Gordon et al. 2022](https://doi.org/10.1016/j.jqsrt.2021.107949) |
+| C<sub>2</sub>H<sub>2</sub> | ExoMol aCeTY | [Chubb et al. 2020](https://doi.org/10.1093/mnras/staa229) |
+| C<sub>2</sub>H<sub>4</sub> | ExoMol MaYTY | [Mant et al. 2018](https://doi.org/10.1093/mnras/sty1239) |
+| H<sub>2</sub>S | ExoMol AYT2 | [Azzam et al. 2016](https://doi.org/10.1093/mnras/stw1133) |
+| HCN | ExoMol Harris | [Barber et al. 2013](https://doi.org/10.1093/mnras/stt2011) |
+| NH<sub>3</sub> | ExoMol CoYuTe | [Coles et al. 2019](https://doi.org/10.1093/mnras/stz2778) |
+| SO<sub>2</sub> | ExoMol ExoAmes | [Underwood et al. 2016](https://doi.org/10.1093/mnras/stw849) |
+| SH | ExoMol GYT | [Yurchenko et al. 2018](https://doi.org/10.1093/mnras/sty939) |
+| SiO | ExoMol SiOUVenIR | [Yurchenko et al. 2021](https://doi.org/10.1093/mnras/stab3267) |
+| OH | MoLLIST | [Yousefi et al. 2018](https://doi.org/10.1016/j.jqsrt.2018.06.016) |
+
+Each reference above is the one recorded inside the table itself.
+
+Three groups of tables need care, because what they record is not enough to
+cite from.
+
+**Tables giving a source but no formal citation.** SiO<sub>2</sub> records the
+ExoMol OYT3 line list, and O, Si and Si<sup>+</sup> record the
+[Kurucz atomic line lists](http://kurucz.harvard.edu/), each as a bare URL.
+Cite those sources directly.
+
+**Tables recording nothing usable.** CO<sub>2</sub> carries a placeholder where
+its reference should be, and the collision-induced absorption tables for
+CO<sub>2</sub>--CO<sub>2</sub>, H<sub>2</sub>O--H<sub>2</sub>O,
+H<sub>2</sub>O--N<sub>2</sub>, N<sub>2</sub>--H<sub>2</sub>,
+N<sub>2</sub>--He, N<sub>2</sub>--N<sub>2</sub>, N<sub>2</sub>--O<sub>2</sub>
+and O<sub>2</sub>--O<sub>2</sub> record no source at all. The CO<sub>2</sub>
+filename points to the ExoMol UCL-4000 line list, but that is read off the name
+rather than confirmed by the table, so check it against petitRADTRANS' own
+[opacity documentation](https://petitradtrans.readthedocs.io/en/latest/) before
+citing it.
+
+**Tables recording petitRADTRANS in place of the data's own source.** The
+H<sub>2</sub>--H<sub>2</sub> and H<sub>2</sub>--He collision-induced absorption
+tables record the petitRADTRANS release paper as their reference. That is the
+code, not the origin of the cross-sections, which come from a third-party
+compilation. Cite the primary source from petitRADTRANS' opacity documentation
+rather than the reference the file carries.
+
+ExoMol data are released under
+[CC BY-SA 4.0](https://exomol.com/data/licence/). HITRAN asks that you cite the
+database edition you used; see its
+[citation policy](https://hitran.org/citepolicy/).
+
+### Which species are covered
+
+`proteus.utils.prt_data.PRT_DEFAULT_FILES` names the file used for each
+species. Several species publish more than one line list, and they do not give
+the same spectrum, so the choice is written out rather than left to a rule.
+Changing an entry changes your spectra.
+
+A gas with no table is dropped from the radiative transfer and its opacity is
+absent from the result. `proteus.utils.prt_data.uncovered_species()` reports
+any such gas.
 
 ## Alternative outgassing (atmodeller)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,14 @@ atmodeller = ["atmodeller>=1.0.2"]
 # atmos_chem.module = "vulcan". Also installable editable via
 # tools/get_vulcan.sh.
 vulcan = ["fwl-vulcan>=26.04.22"]
+# observe: synthetic transit and eclipse spectra, selected via
+# observe.module = "petitRADTRANS". Pinned to a commit because the fork
+# publishes no versioned releases, so an unpinned dependency would track
+# its default branch. The opacity tables are a separate ~2.4 GB download
+# handled by proteus.utils.prt_data, not by pip.
+observe = [
+    "petitRADTRANS @ git+https://github.com/FormingWorlds/petitRADTRANS.git@0d9303cd981766496f4ec3045a230abc01d6269a",
+]
 
 develop = [
     # coverage[toml] enables standalone coverage tool with TOML config support (used by ratcheting script)

--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -1598,6 +1598,19 @@ def _get_sufficient(config: Config, clean: bool = False):
             group, bands = get_spfile_name_and_bands(config)
             download_spectral_file(group, bands)
 
+    # Opacity tables for synthetic observations. petitRADTRANS is optional, so these are
+    # fetched only when a config asks for it. A config that asks for it cannot proceed
+    # without them, so a failure here stops the run rather than surfacing later inside
+    # petitRADTRANS.
+    if config.observe.module == 'petitRADTRANS':
+        from proteus.utils.prt_data import download_prt_opacities
+
+        if not download_prt_opacities():
+            raise RuntimeError(
+                'Could not obtain the petitRADTRANS opacity tables required by '
+                'observe.module = "petitRADTRANS"'
+            )
+
     # Surface single-scattering data
     if config.atmos_clim.module == 'agni':
         download_surface_albedos()

--- a/src/proteus/utils/prt_data.py
+++ b/src/proteus/utils/prt_data.py
@@ -1,0 +1,326 @@
+"""Reference data and configuration for the petitRADTRANS observation module.
+
+petitRADTRANS is an optional component. Nothing here is imported unless a config selects
+``observe.module = "petitRADTRANS"``, and a machine without the package or its opacity
+tables is a supported configuration.
+
+Two jobs live here:
+
+- fetching the opacity tables into ``$FWL_DATA/prt/input_data`` from the upstream library
+  the petitRADTRANS team publishes;
+- writing the petitRADTRANS configuration file, which names one opacity file per species
+  so the library never stops to ask which file to use.
+
+The library serves files over plain HTTP, so neither job needs a browser.
+"""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from proteus.utils.constants import prt_gases
+from proteus.utils.data import GetFWLData
+
+log = logging.getLogger('fwl.' + __name__)
+
+# The upstream petitRADTRANS input-data library, a Keeper (Seafile) share.
+PRT_LIBRARY_TOKEN = 'ccf25082fda448c8a0d0'
+PRT_LIBRARY_HOST = 'https://keeper.mpdl.mpg.de'
+PRT_LIBRARY_FILE_URL = f'{PRT_LIBRARY_HOST}/d/{PRT_LIBRARY_TOKEN}/files/?p='
+
+# Opening bytes of an HDF5 file. The library answers a request for a path it does not hold
+# with a web page and a success status rather than an error, so what came back has to be
+# looked at: without this, a table renamed upstream would be saved as an opacity file and
+# counted as installed, and petitRADTRANS would fail reading it far from the cause.
+HDF5_MAGIC = b'\x89HDF\r\n\x1a\n'
+
+# Line species PROTEUS models. Derived from the gas list the observe module iterates over,
+# so a gas added to prt_gases is covered here without a second edit.
+PRT_LINE_SPECIES: tuple[str, ...] = tuple(prt_gases)
+
+# The opacity file used for each species, keyed by its path within the library.
+#
+# These are choices, not defaults. Several species publish more than one table: water
+# alone offers a HITEMP and a POKAZATEL line list over different wavelength ranges, and
+# they do not produce the same spectrum. The entries below reproduce the set PROTEUS has
+# been running with, made explicit here rather than left implicit in an install script.
+#
+# Naming a file per species is also what keeps petitRADTRANS from asking. Faced with
+# several candidates and no instruction, it prompts for a choice, which on an unattended
+# machine waits rather than fails.
+#
+# Swapping any entry changes the spectra PROTEUS produces and is a spectroscopic decision
+# to take deliberately. Do not replace this table with a rule such as largest-file or
+# newest-wins: those would drift the science quietly, which is the failure this constant
+# exists to prevent.
+PRT_DEFAULT_FILES: dict[str, str] = {
+    # Line opacities
+    'opacities/lines/correlated_k/C2H2/12C2-1H2': (
+        '12C2-1H2__aCeTY.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/C2H4/12C2-1H4': (
+        '12C2-1H4__MaYTY.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/CH4/12C-1H4': (
+        '12C-1H4__HITEMP.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/CO/12C-16O': (
+        '12C-16O__HITEMP.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/CO2/12C-16O2': (
+        '12C-16O2__UCL-4000.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/H2/1H2': (
+        '1H2__HITRAN.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/H2O/1H2-16O': (
+        '1H2-16O__HITEMP.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/H2S/1H2-32S': (
+        '1H2-32S__AYT2.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/HCN/1H-12C-14N': (
+        '1H-12C-14N__Harris.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/NH3/14N-1H3': (
+        '14N-1H3__CoYuTe.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/O/16O': (
+        '16O__Kurucz.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/O2/16O2': (
+        '16O2__HITRAN.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/O3/16O3': (
+        '16O3__HITRAN.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/OH/16O-1H': (
+        '16O-1H__MoLLIST.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/SH/32S-1H': (
+        '32S-1H__GYT.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/SO2/32S-16O2': (
+        '32S-16O2__ExoAmes.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/Si/28Si': (
+        '28Si__Kurucz.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/SiO/28Si-16O': (
+        '28Si-16O__SiOUVenIR.R1000_0.1-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/SiO2/28Si-16O2': (
+        '28Si-16O2__OYT3.R1000_0.3-50mu.ktable.petitRADTRANS.h5'
+    ),
+    'opacities/lines/correlated_k/Si_+/28Si_+': (
+        '28Si_p__Kurucz.R1000_0.1-250mu.ktable.petitRADTRANS.h5'
+    ),
+    # Collision-induced absorption
+    'opacities/continuum/collision_induced_absorptions/CO2--CO2/C-O2--C-O2-NatAbund': (
+        'C-O2--C-O2-NatAbund.DeltaWavelength1e-6_3-100mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/H2--H2/H2--H2-NatAbund': (
+        'H2--H2-NatAbund__BoRi.R831_0.6-250mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/H2--He/H2--He-NatAbund': (
+        'H2--He-NatAbund__BoRi.DeltaWavenumber2_0.5-500mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/H2O--H2O/H2-O--H2-O-NatAbund': (
+        'H2-O--H2-O-NatAbund.DeltaWavenumber10_0.5-77mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/H2O--N2/H2-O--N2-NatAbund': (
+        'H2-O--N2-NatAbund.DeltaWavenumber10_0.5-77mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/N2--H2/N2--H2-NatAbund': (
+        'N2--H2-NatAbund.DeltaWavenumber1_5.3-909mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/N2--He/N2--He-NatAbund': (
+        'N2--He-NatAbund.DeltaWavenumber1_10-909mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/N2--N2/N2--N2-NatAbund': (
+        'N2--N2-NatAbund.DeltaWavelength1e-6_2-100mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/N2--O2/N2--O2-NatAbund': (
+        'N2--O2-NatAbund.DeltaWavelength1e-6_0.72-5.4mu.ciatable.petitRADTRANS.h5'
+    ),
+    'opacities/continuum/collision_induced_absorptions/O2--O2/O2--O2-NatAbund': (
+        'O2--O2-NatAbund.DeltaWavelength1e-6_0.34-8.7mu.ciatable.petitRADTRANS.h5'
+    ),
+}
+
+# Bytes per read while streaming a table to disk.
+_CHUNK = 1 << 20
+
+
+def _config_path() -> Path:
+    """Return the path petitRADTRANS reads its configuration from."""
+    return Path.home() / '.petitradtrans' / 'petitradtrans_config_file.ini'
+
+
+def prt_input_data_dir() -> Path:
+    """Return the directory holding the petitRADTRANS opacity tables."""
+    return GetFWLData() / 'prt' / 'input_data'
+
+
+def _expected_files() -> dict[Path, str]:
+    """Map each table's destination on disk to its path within the library."""
+    root = prt_input_data_dir()
+    return {root / sub / name: f'/{sub}/{name}' for sub, name in PRT_DEFAULT_FILES.items()}
+
+
+def missing_tables() -> list[Path]:
+    """Return the opacity tables named in PRT_DEFAULT_FILES that are not on disk."""
+    return [dest for dest in _expected_files() if not dest.is_file()]
+
+
+def opacities_present() -> bool:
+    """True when every table PROTEUS asks for is on disk.
+
+    Completeness is judged against the named set rather than against whatever happens to
+    be in the directory. A run interrupted part-way leaves some tables behind, and calling
+    that present would strand the tree: nothing would fetch the rest, and petitRADTRANS
+    would go looking for them over the network mid-run.
+    """
+    return not missing_tables()
+
+
+def uncovered_species() -> list[str]:
+    """Return the gases PROTEUS may model that no opacity table is named for.
+
+    These are not an error. The observe module drops a gas with no table from the
+    radiative transfer and carries on, so the spectrum is computed without those
+    opacities rather than failing. The list is reported so the omission is visible.
+    """
+    named = {
+        sub.split('/')[3] for sub in PRT_DEFAULT_FILES if sub.startswith('opacities/lines/')
+    }
+    return [species for species in PRT_LINE_SPECIES if species not in named]
+
+
+def _download(library_path: str, destination: Path) -> None:
+    """Stream one table out of the library, leaving nothing behind unless it is a table.
+
+    The file lands under a temporary name and is moved into place only once it has
+    arrived in full and been recognised as HDF5, so neither a truncated transfer nor a
+    web page returned in place of a table can leave something behind that later looks
+    installed.
+
+    Raises
+    ------
+    OSError
+        If the transfer fails, or if what came back is not an opacity table.
+    """
+    url = PRT_LIBRARY_FILE_URL + urllib.parse.quote(library_path, safe='') + '&dl=1'
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_suffix(destination.suffix + '.part')
+
+    try:
+        with urllib.request.urlopen(url, timeout=120) as response:
+            content_type = response.headers.get('Content-Type', '')
+            if 'html' in content_type.lower():
+                raise OSError(
+                    f'The library answered with a web page rather than a table for '
+                    f'{library_path}. The file is most likely no longer at that path.'
+                )
+            with open(partial, 'wb') as handle:
+                while chunk := response.read(_CHUNK):
+                    handle.write(chunk)
+
+        with open(partial, 'rb') as handle:
+            if handle.read(len(HDF5_MAGIC)) != HDF5_MAGIC:
+                raise OSError(f'What arrived for {library_path} is not an HDF5 table.')
+
+        partial.rename(destination)
+    finally:
+        partial.unlink(missing_ok=True)
+
+
+def download_prt_opacities(clean: bool = False) -> bool:
+    """Fetch the petitRADTRANS opacity tables PROTEUS needs.
+
+    Only the tables named in PRT_DEFAULT_FILES are fetched, and only those not already on
+    disk, so an interrupted run resumes where it stopped rather than starting over. The
+    configuration is written afterwards, because tables petitRADTRANS cannot locate are of
+    no use.
+
+    Parameters
+    ----------
+    clean : bool
+        Fetch every table again, even those already present.
+
+    Returns
+    -------
+    bool
+        True when every table is in place afterwards.
+    """
+    expected = _expected_files()
+    wanted = list(expected) if clean else missing_tables()
+
+    if not wanted:
+        log.debug('petitRADTRANS opacity tables already present')
+        write_prt_config()
+        return True
+
+    log.info('Downloading %d petitRADTRANS opacity tables (several GB)', len(wanted))
+
+    for dest in wanted:
+        library_path = expected[dest]
+        log.debug('Fetching %s', library_path)
+        try:
+            _download(library_path, dest)
+        except Exception as exc:
+            log.warning('Failed to fetch %s: %s', library_path, exc)
+            return False
+
+    absent = missing_tables()
+    if absent:
+        log.warning('petitRADTRANS opacity tables still missing: %s', [p.name for p in absent])
+        return False
+
+    write_prt_config()
+    return True
+
+
+def write_prt_config() -> Path:
+    """Write the petitRADTRANS configuration file and return its path.
+
+    Records where the tables live and names the file to use for each species.
+
+    Raises
+    ------
+    FileNotFoundError
+        If any table PROTEUS asks for is absent, since a configuration naming files that
+        are not there would send petitRADTRANS to fetch them mid-run.
+    """
+    root = prt_input_data_dir()
+    absent = missing_tables()
+    if absent:
+        raise FileNotFoundError(
+            f'{len(absent)} petitRADTRANS opacity tables are missing under {root}, '
+            f'starting with {absent[0].name}. Fetch them with '
+            'proteus.utils.prt_data.download_prt_opacities() first.'
+        )
+
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = ['[Default files]', '']
+    lines += [f'{sub} = {name}' for sub, name in sorted(PRT_DEFAULT_FILES.items())]
+    lines += [
+        '',
+        '[Paths]',
+        f'prt_input_data_path = {root}',
+        '',
+        '[URLs]',
+        f'prt_input_data_url = {PRT_LIBRARY_FILE_URL}',
+        '',
+    ]
+    path.write_text('\n'.join(lines), encoding='utf-8')
+
+    log.debug(
+        'Wrote petitRADTRANS config to %s with %d named files', path, len(PRT_DEFAULT_FILES)
+    )
+    return path

--- a/tests/integration/test_integration_observe_wrapper.py
+++ b/tests/integration/test_integration_observe_wrapper.py
@@ -34,20 +34,41 @@ import numpy as np
 import pytest
 from helpers import PROTEUS_ROOT
 
-from proteus import Proteus
-from proteus.observe.common import (
+# petitRADTRANS is an optional component and a machine without it is supported, so the
+# absence of the package skips this file with a reason that names it. Anything else that
+# goes wrong here is a failure: the point of these tests is to exercise the real
+# synthesis, and a run that quietly declines to do so would report success having checked
+# nothing.
+pytest.importorskip('petitRADTRANS', reason='petitRADTRANS not installed (observe extra)')
+
+from proteus import Proteus  # noqa: E402
+from proteus.observe.common import (  # noqa: E402
     OBS_SOURCES,
     get_eclipse_fpath,
     get_transit_fpath,
     read_eclipse,
     read_transit,
 )
-from proteus.observe.wrapper import calc_synthetic_spectra, run_observe
+from proteus.observe.wrapper import calc_synthetic_spectra, run_observe  # noqa: E402
+from proteus.utils.prt_data import opacities_present  # noqa: E402
 
 if TYPE_CHECKING:
     pass
 
 pytestmark = [pytest.mark.integration, pytest.mark.timeout(300)]
+
+
+def _require_checked(count: int, what: str) -> None:
+    """Skip when a test found nothing to check, rather than let it report success.
+
+    The tests below walk the observation sources and check whatever spectra the run
+    produced. An atmosphere module that writes no profile leaves every source with
+    nothing, so the loop bodies never execute and the test would end green having
+    verified nothing at all. Saying so as a skip keeps the difference between "checked
+    and correct" and "had nothing to check" visible in the run report.
+    """
+    if count == 0:
+        pytest.skip(f'No {what} was produced; the run wrote no atmosphere profile')
 
 
 @pytest.fixture(scope='module')
@@ -59,12 +80,20 @@ def dummy_run_with_observe():
     module enabled to generate transit/eclipse spectra. The output can be
     used for all observation-related tests in this module.
 
+    The opacity tables are the one other thing that may legitimately be absent, and their
+    absence skips. A failure of the run itself is raised, not skipped: these tests exist
+    to exercise the real synthesis, so a fixture that swallowed the failure would leave
+    every test in the file passing while checking nothing.
+
     Yields:
         tuple: (runner: Proteus, output_dir: str, hf_row: dict)
             - runner: The PROTEUS runner object
             - output_dir: Path to the output directory
             - hf_row: The last row from the helpfile (used for spectrum calculation)
     """
+    if not opacities_present():
+        pytest.skip('petitRADTRANS opacity tables not installed; see proteus.utils.prt_data')
+
     unique_id = str(uuid.uuid4())[:8]
     with tempfile.TemporaryDirectory() as tmpdir:
         # Load configuration with observe module enabled
@@ -94,19 +123,17 @@ def dummy_run_with_observe():
         runner.config.params.out.write_mod = 0
         runner.config.params.out.archive_mod = 'none'
 
-        try:
-            # Run simulation to generate atmosphere output
-            runner.start(resume=False, offline=True)
+        # Run simulation to generate atmosphere output. A failure here is a failure of
+        # the thing under test and is left to propagate.
+        runner.start(resume=False, offline=True)
 
-            # Get the last helpfile row for spectrum calculations
-            if runner.hf_all is None or len(runner.hf_all) == 0:
-                pytest.skip('Helpfile is empty')
+        assert runner.hf_all is not None and len(runner.hf_all) > 0, (
+            'PROTEUS produced no helpfile rows, so there is no state to synthesise from'
+        )
 
-            hf_row = runner.hf_all.iloc[-1].to_dict()
+        hf_row = runner.hf_all.iloc[-1].to_dict()
 
-            yield runner, output_dir, hf_row
-        except Exception as e:
-            pytest.skip(f'Failed to run PROTEUS with observe module: {e}')
+        yield runner, output_dir, hf_row
 
 
 @pytest.mark.integration
@@ -132,6 +159,7 @@ def test_observe_wrapper_calc_synthetic_spectra(dummy_run_with_observe):
     assert observe_dir.exists(), f'Observe directory not created: {observe_dir}'
 
     # Check that transit/eclipse files exist for at least one source
+    checked = 0
     for source in OBS_SOURCES:
         # Skip profile source if using dummy atmosphere module
         if source == 'profile' and config.atmos_clim.module == 'dummy':
@@ -145,6 +173,7 @@ def test_observe_wrapper_calc_synthetic_spectra(dummy_run_with_observe):
 
         # At least one should exist
         if transit_file.exists() or eclipse_file.exists():
+            checked += 1
             # Validate transit spectrum if it exists
             if transit_file.exists():
                 transit_data = read_transit(output_dir, source, 'synthesis')
@@ -186,6 +215,8 @@ def test_observe_wrapper_calc_synthetic_spectra(dummy_run_with_observe):
                     f'Non-finite wavelengths in eclipse: {source}'
                 )
                 assert np.all(np.isfinite(depths)), f'Non-finite depths in eclipse: {source}'
+
+    _require_checked(checked, 'spectrum')
 
 
 @pytest.mark.integration
@@ -233,6 +264,7 @@ def test_transit_depth_spectrum_format(dummy_run_with_observe):
     # Calculate spectra
     from proteus.observe.petitRADTRANS import transit_depth
 
+    checked = 0
     for source in OBS_SOURCES:
         # Skip unsupported sources
         if source == 'profile' and config.atmos_clim.module == 'dummy':
@@ -244,6 +276,7 @@ def test_transit_depth_spectrum_format(dummy_run_with_observe):
             result = transit_depth(hf_row, config, source, runner.directories)
             if result is None:
                 continue
+            checked += 1
 
             # Validate return format: [wavelength, depth]
             assert isinstance(result, np.ndarray), (
@@ -269,6 +302,8 @@ def test_transit_depth_spectrum_format(dummy_run_with_observe):
             if 'Could not read atmosphere data' not in str(e):
                 raise
 
+    _require_checked(checked, 'transit spectrum')
+
 
 @pytest.mark.integration
 @pytest.mark.physics_invariant
@@ -288,6 +323,7 @@ def test_eclipse_depth_spectrum_format(dummy_run_with_observe):
     # Calculate spectra
     from proteus.observe.petitRADTRANS import eclipse_depth
 
+    checked = 0
     for source in OBS_SOURCES:
         # Skip unsupported sources
         if source == 'profile' and config.atmos_clim.module == 'dummy':
@@ -299,6 +335,7 @@ def test_eclipse_depth_spectrum_format(dummy_run_with_observe):
             result = eclipse_depth(hf_row, config, source, runner.directories)
             if result is None:
                 continue
+            checked += 1
 
             # Validate return format: [wavelength, depth]
             assert isinstance(result, np.ndarray), (
@@ -323,6 +360,8 @@ def test_eclipse_depth_spectrum_format(dummy_run_with_observe):
             # Some sources might not be available, which is ok
             if 'Could not read atmosphere data' not in str(e):
                 raise
+
+    _require_checked(checked, 'eclipse spectrum')
 
 
 @pytest.mark.integration
@@ -356,6 +395,8 @@ def test_observe_files_persist(dummy_run_with_observe):
             data2 = read_transit(output_dir, source, 'synthesis')
             assert data1.equals(data2), f'Data inconsistency on re-read: {source}'
             spectra_data[source] = data1
+
+    _require_checked(len(spectra_data), 'transit spectrum')
 
 
 @pytest.mark.integration
@@ -454,6 +495,11 @@ def test_transit_eclipse_depth_ratio(dummy_run_with_observe):
     try:
         transit_result = transit_depth(hf_row, config, 'outgas', runner.directories)
         eclipse_result = eclipse_depth(hf_row, config, 'outgas', runner.directories)
+
+        _require_checked(
+            int(transit_result is not None and eclipse_result is not None),
+            'transit and eclipse spectrum pair',
+        )
 
         if transit_result is not None and eclipse_result is not None:
             transit_wl = transit_result[:, 0]

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -2901,6 +2901,7 @@ def test_get_sufficient_agni_skips_group_band_lookup_when_spectral_file_set(monk
         ),
         interior_energetics=SimpleNamespace(module='dummy'),
         interior_struct=SimpleNamespace(module='dummy'),
+        observe=SimpleNamespace(module=None),
     )
 
     data_mod._get_sufficient(config, clean=False)
@@ -2953,6 +2954,7 @@ def test_get_sufficient_agni_downloads_group_and_bands_when_no_spectral_file(mon
         ),
         interior_energetics=SimpleNamespace(module='dummy'),
         interior_struct=SimpleNamespace(module='dummy'),
+        observe=SimpleNamespace(module=None),
     )
 
     data_mod._get_sufficient(config, clean=False)
@@ -3007,6 +3009,7 @@ def test_get_sufficient_janus_always_downloads_group_and_bands(monkeypatch):
         atmos_clim=SimpleNamespace(module='janus', aerosols_enabled=False),
         interior_energetics=SimpleNamespace(module='dummy'),
         interior_struct=SimpleNamespace(module='dummy'),
+        observe=SimpleNamespace(module=None),
     )
 
     data_mod._get_sufficient(config, clean=False)
@@ -5438,6 +5441,7 @@ def test_get_sufficient_mors_solar_spectrum_only(monkeypatch):
         atmos_clim=SimpleNamespace(module='dummy', aerosols_enabled=False),
         interior_energetics=SimpleNamespace(module='dummy'),
         interior_struct=SimpleNamespace(module='dummy'),
+        observe=SimpleNamespace(module=None),
     )
 
     data_mod._get_sufficient(config)
@@ -5484,6 +5488,7 @@ def test_get_sufficient_mors_muscles_spectrum_only(monkeypatch):
         atmos_clim=SimpleNamespace(module='dummy', aerosols_enabled=False),
         interior_energetics=SimpleNamespace(module='dummy'),
         interior_struct=SimpleNamespace(module='dummy'),
+        observe=SimpleNamespace(module=None),
     )
 
     data_mod._get_sufficient(config)
@@ -5527,6 +5532,7 @@ def test_get_sufficient_agni_aerosols_downloads_scattering(monkeypatch):
         ),
         interior_energetics=SimpleNamespace(module='dummy'),
         interior_struct=SimpleNamespace(module='dummy'),
+        observe=SimpleNamespace(module=None),
     )
 
     surface_calls = []

--- a/tests/utils/test_prt_data.py
+++ b/tests/utils/test_prt_data.py
@@ -1,0 +1,368 @@
+"""Unit tests for ``proteus.utils.prt_data``.
+
+Covers the reference-data plumbing behind the optional observe module:
+
+- the opacity tables PROTEUS asks for are named explicitly, and completeness is judged
+  against that set rather than against whatever is in the directory
+- a partly-fetched tree is not mistaken for a complete one
+- an interrupted transfer leaves no truncated table behind
+- the petitRADTRANS configuration names one file per species, which is what keeps the
+  library from stopping to ask which to use
+- writing a configuration against an incomplete tree is refused
+
+The module is structural plumbing (path resolution, HTTP fetching, config writing) and
+computes no physical quantity, so the physics-invariant requirement does not apply.
+
+Testing standards:
+  - docs/How-to/test_infrastructure.md
+  - docs/How-to/test_categorization.md
+  - docs/How-to/test_building.md
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from proteus.utils import prt_data
+from proteus.utils.constants import prt_cia_species
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+# A stand-in for the named table set, small enough to reason about and shaped like the
+# real one: two line species under different directories, plus a collision pair.
+FAKE_FILES = {
+    'opacities/lines/correlated_k/H2O/1H2-16O': 'water.ktable.petitRADTRANS.h5',
+    'opacities/lines/correlated_k/CO2/12C-16O2': 'co2.ktable.petitRADTRANS.h5',
+    'opacities/continuum/collision_induced_absorptions/H2--He/H2--He-NatAbund': (
+        'h2he.ciatable.petitRADTRANS.h5'
+    ),
+}
+
+
+@pytest.fixture
+def tree(monkeypatch, tmp_path):
+    """Point the module at a temporary data directory with a known table set."""
+    monkeypatch.setattr(prt_data, 'GetFWLData', lambda: tmp_path)
+    monkeypatch.setattr(prt_data, 'PRT_DEFAULT_FILES', dict(FAKE_FILES))
+    monkeypatch.setattr(prt_data, '_config_path', lambda: tmp_path / 'cfg' / 'prt.ini')
+    return tmp_path / 'prt' / 'input_data'
+
+
+def _place(root, sub):
+    """Put one named table on disk."""
+    dest = root / sub / FAKE_FILES[sub]
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(b'\x89HDF\r\n\x1a\n' + b'x' * 8)
+    return dest
+
+
+def _raise(exc):
+    """Return a stand-in transfer that fails."""
+
+    def fail(*_args, **_kwargs):
+        raise exc
+
+    return fail
+
+
+class _FakeResponse:
+    """Stand-in for a urlopen response, so the real transfer can be driven."""
+
+    def __init__(self, body, content_type='application/octet-stream', fail_after=None):
+        self._body = body
+        self._pos = 0
+        self._fail_after = fail_after
+        self.headers = {'Content-Type': content_type}
+
+    def read(self, size=-1):
+        if self._fail_after is not None and self._pos >= self._fail_after:
+            raise OSError('connection reset mid-transfer')
+        chunk = self._body[
+            self._pos : self._pos + (size if size and size > 0 else len(self._body))
+        ]
+        self._pos += len(chunk)
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def _serve(response):
+    """Patch urlopen to return one prepared response."""
+
+    def opener(*_args, **_kwargs):
+        return response
+
+    return opener
+
+
+def test_completeness_is_judged_against_the_named_tables(tree):
+    """A tree counts as present only when every named table is there, not when some are.
+
+    Judging by "is any table on disk" would call a run that stopped after the first table
+    complete, and nothing would then fetch the rest: petitRADTRANS would go looking for
+    them over the network mid-run. Two of the three tables are placed to make the
+    difference visible, since a check that answered for the directory as a whole would
+    pass at that point.
+    """
+    assert prt_data.opacities_present() is False
+
+    _place(tree, 'opacities/lines/correlated_k/H2O/1H2-16O')
+    _place(tree, 'opacities/lines/correlated_k/CO2/12C-16O2')
+    assert prt_data.opacities_present() is False, 'a partly-fetched tree is not complete'
+    assert [p.name for p in prt_data.missing_tables()] == ['h2he.ciatable.petitRADTRANS.h5']
+
+    _place(tree, 'opacities/continuum/collision_induced_absorptions/H2--He/H2--He-NatAbund')
+    assert prt_data.opacities_present() is True
+    assert prt_data.missing_tables() == []
+
+
+def test_only_the_absent_tables_are_fetched(tree, monkeypatch):
+    """A fetch collects what is missing and leaves what is already there.
+
+    These tables run to gigabytes, so re-fetching a present one is not a harmless
+    inefficiency. The already-present table is asserted untouched rather than only
+    checking the outcome, because a fetch that downloaded everything and then reported
+    success would satisfy an outcome check while costing the whole transfer again.
+    """
+    _place(tree, 'opacities/lines/correlated_k/H2O/1H2-16O')
+
+    fetched = []
+
+    def fake_download(library_path, destination):
+        fetched.append(library_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b'\x89HDF\r\n\x1a\n')
+
+    monkeypatch.setattr(prt_data, '_download', fake_download)
+
+    assert prt_data.download_prt_opacities() is True
+    assert sorted(fetched) == [
+        '/opacities/continuum/collision_induced_absorptions/H2--He/H2--He-NatAbund/h2he.ciatable.petitRADTRANS.h5',
+        '/opacities/lines/correlated_k/CO2/12C-16O2/co2.ktable.petitRADTRANS.h5',
+    ], 'the table already on disk should not have been fetched again'
+    assert prt_data.opacities_present() is True
+
+
+def test_a_complete_tree_is_left_alone(tree, monkeypatch):
+    """Nothing is fetched when every table is already in place."""
+    for sub in FAKE_FILES:
+        _place(tree, sub)
+
+    def refuse(*_a, **_k):
+        raise AssertionError('fetch attempted for a tree that is already complete')
+
+    monkeypatch.setattr(prt_data, '_download', refuse)
+
+    assert prt_data.download_prt_opacities() is True
+    # The configuration is written even so: the tables are useless if the library cannot
+    # be told where they are, and a machine may have the tables from an earlier run.
+    assert (tree.parent.parent / 'cfg' / 'prt.ini').is_file()
+
+
+def test_clean_refetches_tables_that_are_already_present(tree, monkeypatch):
+    """Asking for a clean fetch collects every table again, not just the absent ones.
+
+    This is the path for replacing a tree that is present but suspect, so skipping the
+    tables already on disk would make the option do nothing.
+    """
+    _place(tree, 'opacities/lines/correlated_k/H2O/1H2-16O')
+
+    fetched = []
+    monkeypatch.setattr(
+        prt_data,
+        '_download',
+        lambda lib, dest: (
+            fetched.append(lib),
+            dest.parent.mkdir(parents=True, exist_ok=True),
+            dest.write_bytes(b'\x89HDF\r\n\x1a\n'),
+        ),
+    )
+
+    assert prt_data.download_prt_opacities(clean=True) is True
+    assert len(fetched) == len(FAKE_FILES)
+
+
+def test_a_failed_transfer_is_reported_to_the_caller(tree, monkeypatch):
+    """A transfer that raises stops the fetch and reports failure.
+
+    The caller decides from this answer whether synthesis can go ahead, so the failure
+    has to reach it rather than be logged and forgotten. This covers the reporting
+    contract only; what the transfer itself leaves on disk is checked against the real
+    function below, since a stand-in cannot demonstrate the real one's cleanup.
+    """
+    monkeypatch.setattr(prt_data, '_download', _raise(OSError('connection reset')))
+
+    assert prt_data.download_prt_opacities() is False
+    assert prt_data.opacities_present() is False
+
+
+def test_a_transfer_that_delivers_nothing_is_reported_as_failure(tree, monkeypatch):
+    """A fetch that claims success while writing no table reports failure.
+
+    Returning success over an empty directory would push the problem into petitRADTRANS,
+    where it surfaces as a download attempt mid-run instead of a plain message here.
+    """
+    monkeypatch.setattr(prt_data, '_download', lambda lib, dest: None)
+
+    assert prt_data.download_prt_opacities() is False
+
+
+def test_config_names_one_file_per_species_under_the_right_headings(tree):
+    """The configuration records the data path and names a file for every species.
+
+    A configuration carrying the path but no names would load, and petitRADTRANS would
+    then stop to ask on the first species offering more than one table, so both halves
+    are checked. The names must also precede the [Paths] heading: this is read as an ini
+    file, and a name landing in the wrong section is ignored without complaint.
+    """
+    for sub in FAKE_FILES:
+        _place(tree, sub)
+
+    text = prt_data.write_prt_config().read_text()
+    lines = text.splitlines()
+
+    assert lines[0] == '[Default files]'
+    assert f'prt_input_data_path = {tree}' in lines
+
+    named = [line for line in lines if line.startswith('opacities/')]
+    assert len(named) == len(FAKE_FILES)
+    assert 'opacities/lines/correlated_k/H2O/1H2-16O = water.ktable.petitRADTRANS.h5' in named
+    assert max(lines.index(n) for n in named) < lines.index('[Paths]')
+
+
+def test_config_is_refused_while_any_table_is_missing(tree):
+    """Writing a configuration against an incomplete tree is refused, and says which.
+
+    Naming a file that is not on disk is how petitRADTRANS ends up fetching it mid-run,
+    which is the behaviour this module exists to prevent. The message names the directory
+    and one absent table, because the usual causes are a data directory pointing
+    somewhere unexpected and a fetch that did not finish.
+    """
+    _place(tree, 'opacities/lines/correlated_k/H2O/1H2-16O')
+
+    with pytest.raises(FileNotFoundError, match=re.escape(str(tree))) as excinfo:
+        prt_data.write_prt_config()
+    assert 'co2.ktable.petitRADTRANS.h5' in str(excinfo.value) or 'h2he' in str(excinfo.value)
+
+    for sub in FAKE_FILES:
+        _place(tree, sub)
+    assert prt_data.write_prt_config().is_file()
+
+
+def test_every_gas_proteus_models_has_a_named_table(monkeypatch):
+    """The shipped table set covers every gas the observe module may ask for.
+
+    A gas with no named table is dropped from the transfer and its opacity is silently
+    absent from the spectrum, so the two lists are checked against each other rather than
+    left to drift apart. This reads the real constants, not the fixture, because the
+    point is the shipped set.
+    """
+    assert prt_data.uncovered_species() == []
+
+    # A gas added to the model but not to the table set is reported, not hidden.
+    monkeypatch.setattr(prt_data, 'PRT_LINE_SPECIES', prt_data.PRT_LINE_SPECIES + ('XeF6',))
+    assert prt_data.uncovered_species() == ['XeF6']
+
+
+def test_named_tables_sit_where_petitradtrans_looks_for_them():
+    """Every named table is keyed by a path petitRADTRANS recognises.
+
+    petitRADTRANS reads line opacities and collision-induced absorption from two separate
+    roots, and a name filed under the wrong one is silently ignored: the species then
+    resolves to a prompt at run time. Checking the keys catches that here rather than on
+    an unattended machine.
+    """
+    line_root = 'opacities/lines/correlated_k/'
+    cia_root = 'opacities/continuum/collision_induced_absorptions/'
+
+    for sub, name in prt_data.PRT_DEFAULT_FILES.items():
+        assert sub.startswith((line_root, cia_root)), f'unrecognised location: {sub}'
+        # Species directory plus isotopologue directory, which is the depth the library
+        # stores tables at and the depth the config keys off.
+        assert len(sub.removeprefix(line_root).removeprefix(cia_root).split('/')) == 2, sub
+        assert name.endswith('.petitRADTRANS.h5'), f'not a petitRADTRANS table: {name}'
+
+    # Every collision pair the observe module asks for is named, and none beyond them.
+    cia_named = {
+        sub.split('/')[3] for sub in prt_data.PRT_DEFAULT_FILES if sub.startswith(cia_root)
+    }
+    assert cia_named == set(prt_cia_species)
+
+
+def test_the_transfer_rejects_a_web_page_served_in_place_of_a_table(tree, monkeypatch):
+    """A web page returned where a table was asked for is refused, not saved.
+
+    This is the shape of an upstream rename: the library answers a path it no longer holds
+    with a page and a success status, so nothing raises on its own and the staging rename
+    offers no protection. Saved unchecked, the page would sit at the table's name, satisfy
+    every completeness check, be named in the configuration, and finally fail inside
+    petitRADTRANS while parsing it, a long way from the cause. Both the declared type and
+    the opening bytes are checked, since a library that mislabels its response would slip
+    past the first on its own.
+    """
+    page = b'\n\n<!DOCTYPE html>\n<html>KEEPER</html>'
+    dest = (
+        tree
+        / 'opacities/lines/correlated_k/H2O/1H2-16O'
+        / FAKE_FILES['opacities/lines/correlated_k/H2O/1H2-16O']
+    )
+
+    monkeypatch.setattr(
+        prt_data.urllib.request,
+        'urlopen',
+        _serve(_FakeResponse(page, content_type='text/html')),
+    )
+    with pytest.raises(OSError, match='web page'):
+        prt_data._download('/some/renamed/path.h5', dest)
+    assert not dest.exists()
+
+    # Same page, but the library calls it a table: the opening bytes still give it away.
+    monkeypatch.setattr(
+        prt_data.urllib.request,
+        'urlopen',
+        _serve(_FakeResponse(page, content_type='application/octet-stream')),
+    )
+    with pytest.raises(OSError, match='not an HDF5 table'):
+        prt_data._download('/some/renamed/path.h5', dest)
+    assert not dest.exists()
+    assert list(tree.rglob('*.part')) == []
+
+
+def test_the_transfer_stages_the_table_and_clears_up_after_itself(tree, monkeypatch):
+    """A table arrives at its final name only once it is complete, and a transfer that
+    dies part-way leaves neither a staged file nor a truncated table.
+
+    A half-written table is worse than an absent one: it satisfies a file-exists check and
+    then fails deep inside petitRADTRANS. This drives the real transfer rather than a
+    stand-in, because the staging and the clean-up are the behaviour in question and a
+    stand-in could only demonstrate itself.
+    """
+    body = prt_data.HDF5_MAGIC + b'table contents'
+    dest = (
+        tree
+        / 'opacities/lines/correlated_k/H2O/1H2-16O'
+        / FAKE_FILES['opacities/lines/correlated_k/H2O/1H2-16O']
+    )
+
+    monkeypatch.setattr(prt_data.urllib.request, 'urlopen', _serve(_FakeResponse(body)))
+    prt_data._download('/opacities/lines/correlated_k/H2O/1H2-16O/water.h5', dest)
+    assert dest.read_bytes() == body
+    assert list(tree.rglob('*.part')) == [], 'the staged file is cleared once it lands'
+
+    # A transfer that dies after the first chunk: nothing survives, not even a stub.
+    dest.unlink()
+    monkeypatch.setattr(
+        prt_data.urllib.request,
+        'urlopen',
+        _serve(_FakeResponse(body, fail_after=4)),
+    )
+    with pytest.raises(OSError, match='connection reset'):
+        prt_data._download('/opacities/lines/correlated_k/H2O/1H2-16O/water.h5', dest)
+    assert not dest.exists()
+    assert list(tree.rglob('*.part')) == []

--- a/tools/get_prt.sh
+++ b/tools/get_prt.sh
@@ -1,132 +1,51 @@
 #!/bin/bash
-# Download and install petitRADTRANS
+# Configure petitRADTRANS to read the opacity tables PROTEUS installs.
+#
+# The package itself comes from the observe extra:
+#     pip install -e ".[observe]"
+# and the opacity tables come from the FWL data distribution, like every other PROTEUS
+# dataset:
+#     python -c "from proteus.utils.prt_data import download_prt_opacities; download_prt_opacities()"
+#
+# This script only writes the configuration file that points petitRADTRANS at those
+# tables and pins one default file per species, so the library never stops to ask which
+# file to use. The species come from proteus.utils.constants, so adding a gas there
+# carries through without editing this script.
 
-# Load shell-defined environment variables such as FWL_DATA.
-if [ -z "${FWL_DATA:-}" ] && [ -f "$HOME/.bashrc" ]; then
-    # shellcheck disable=SC1090
-    source "$HOME/.bashrc"
-fi
+set -euo pipefail
 
-echo "Installing petitRADTRANS into Python environment..."
-
-# Installing meson first
-python -m pip install numpy meson meson-python ninja
-
-# Make room
-workpath="prt/"
-rm -rf $workpath
-
-# Download
-echo "Cloning from GitHub"
-uri="https://github.com/FormingWorlds/petitRADTRANS.git"
-echo "    $uri -> $workpath"
-git clone "$uri" "$workpath"
-
-# Change dir and install
-olddir=$(pwd)
-cd $workpath
-python -m pip install -U -e . --no-build-isolation
+echo "Configuring petitRADTRANS..."
 
 python - <<'PY'
-from pathlib import Path
-import shutil
+import sys
 
-targets = [
-    Path('petitRADTRANS/__file_conversion.py'),
-    Path('petitRADTRANS/opacities/opacities.py'),
-]
-
-needle = '    except ImportError:\n'
-replacement = '    except Exception:\n'
-
-for path in targets:
-    text = path.read_text(encoding='utf-8')
-    shutil.copy2(path, Path(str(path) + '.bak'))
-    idx = text.find(needle)
-    if idx != -1:
-        text = text[:idx] + replacement + text[idx + len(needle) :]
-    path.write_text(text, encoding='utf-8')
-PY
-
-echo "Installing petitRADTRANS opacity tables..."
-prt_input_data_path="$(pwd)/input_data"
-if [ -n "${FWL_DATA:-}" ]; then
-    prt_input_data_path="${FWL_DATA%/}/prt/input_data"
-fi
-config_file="$HOME/.petitradtrans/petitradtrans_config_file.ini"
-if [ -f "$config_file" ]; then
-    mv "$config_file" "${config_file}.bak"
-fi
-rm -rf ~/.petitradtrans/petitradtrans_config_file.ini
-
-python - <<'PY'
-from petitRADTRANS.radtrans import Radtrans
-
-Radtrans(line_species=['Ti_+'])
-PY
-
-export PRT_INPUT_DATA_PATH="$prt_input_data_path"
-python - <<'PY'
-from pathlib import Path
-import os
-import shutil
-
-config_path = Path.home() / '.petitradtrans' / 'petitradtrans_config_file.ini'
-text = config_path.read_text(encoding='utf-8')
-shutil.copy2(config_path, Path(str(config_path) + '.bak'))
-
-# Update prt_input_data_path line.
-new_lines = []
-for line in text.splitlines(keepends=True):
-    if line.startswith('prt_input_data_path = '):
-        new_lines.append(f"prt_input_data_path = {os.environ['PRT_INPUT_DATA_PATH']}\n")
-    else:
-        new_lines.append(line)
-text = ''.join(new_lines)
-
-# Insert opacity aliases before [Paths] section, matching previous sed behavior.
-aliases = [
-    'opacities/lines/correlated_k/H2O/1H2-16O = 1H2-16O__HITEMP.R1000_0.1-250mu.ktable.petitRADTRANS.h5\n',
-    'opacities/lines/correlated_k/TiO/48Ti-16O = 48Ti-16O__McKemmish.R1000_0.1-250mu.ktable.petitRADTRANS.h5\n',
-    'opacities/lines/correlated_k/VO/51V-16O = 51V-16O__Plez.R1000_0.1-250mu.ktable.petitRADTRANS.h5\n',
-    'opacities/lines/correlated_k/Na/23Na = 23Na__Allard.R1000_0.1-250mu.ktable.petitRADTRANS.h5\n',
-    'opacities/lines/correlated_k/K/39K = 39K__Allard.R1000_0.1-250mu.ktable.petitRADTRANS.h5\n',
-    'opacities/lines/correlated_k/CH4/12C-1H4 = 12C-1H4__HITEMP.R1000_0.1-250mu.ktable.petitRADTRANS.h5\n',
-    'opacities/continuum/collision_induced_absorptions/H2--H2/H2--H2-NatAbund = H2--H2-NatAbund__BoRi.R831_0.6-250mu.ciatable.petitRADTRANS.h5\n',
-    'opacities/continuum/collision_induced_absorptions/H2--He/H2--He-NatAbund = H2--He-NatAbund__BoRi.DeltaWavenumber2_0.5-500mu.ciatable.petitRADTRANS.h5\n',
-]
-
-paths_idx = text.find('[Paths]')
-if paths_idx != -1:
-    text = text[:paths_idx] + ''.join(aliases) + text[paths_idx:]
-
-config_path.write_text(text, encoding='utf-8')
-PY
-
-python - <<'PY'
-from petitRADTRANS.radtrans import Radtrans
-from proteus.utils.constants import prt_cia_species, prt_rayleigh_species
-
-line_species = [
-    'H2O',
-    'H2',
-    'CO2',
-    'CO',
-    'CH4',
-    'SO2',
-    'H2S',
-    'O2',
-    'NH3',
-    'OH',
-]
-
-radtrans = Radtrans(
-    line_species=line_species,
-    rayleigh_species=prt_rayleigh_species,
-    gas_continuum_contributors=prt_cia_species,
+from proteus.utils.prt_data import (
+    opacities_present,
+    prt_input_data_dir,
+    uncovered_species,
+    write_prt_config,
 )
+
+if not opacities_present():
+    sys.exit(
+        f"No opacity tables under {prt_input_data_dir()}.\n"
+        "Fetch them first:\n"
+        "    python -c \"from proteus.utils.prt_data import download_prt_opacities; "
+        "download_prt_opacities()\""
+    )
+
+# Every species that does have a table is pinned to one file, so petitRADTRANS never
+# stops to ask which to use. A species with no table at all is dropped from the transfer
+# by the observe module, so it is reported rather than treated as a failure.
+path = write_prt_config()
+print(f"Wrote {path}")
+
+uncovered = uncovered_species()
+if uncovered:
+    print(
+        "No opacity tables installed for: " + ", ".join(uncovered) + "\n"
+        "Spectra will be computed without their contribution."
+    )
 PY
 
-cd $olddir
-
-echo "Done!!"
+echo "Done."


### PR DESCRIPTION
## Description

Synthetic observations need petitRADTRANS and about 5.6 GB of opacity tables, and neither was reachable from a clean install. The package was not a dependency at all, and the only route to the tables was `tools/get_prt.sh`, which drove a headless browser at the library hosting them, reported success whether or not anything arrived, and was wired into nothing: not CI, not `install-all`, not the docs.

This makes petitRADTRANS an opt-in extra and fetches the tables the way every other PROTEUS dataset is fetched.

**Changes**

- `pip install "fwl-proteus[observe]"` installs petitRADTRANS, pinned to a commit because the fork publishes no releases. It builds Fortran, C and C++ extensions, so the host needs gfortran and a C/C++ toolchain; the install guide now says so.
- Nothing else depends on it. It is absent from the core install, no module imports it unless a config selects `observe.module = "petitRADTRANS"`, and a machine without it is a supported machine.
- `proteus.utils.prt_data` fetches the tables over plain HTTP from the library the petitRADTRANS team publishes, which stays the source of truth. Only the tables PROTEUS asks for are fetched, and only those not already present, so an interrupted run resumes.
- `PRT_DEFAULT_FILES` names the file used for each species. Several species publish more than one line list over different wavelength ranges and they do not give the same spectrum, so the choice is written down rather than left implicit in an install script. The entries reproduce what PROTEUS has been running with.
- The install guide gains the line-list reference for each species, read out of the tables themselves, so anyone publishing spectra can cite the groups whose data produced them.
- `tools/get_prt.sh` now only writes the configuration file.

**Two things worth a reviewer's attention**

The library answers a request for a path it no longer holds with a web page and an HTTP 200, so nothing raises. A table renamed upstream would have been saved under the name of the table it replaced and counted as installed, with petitRADTRANS failing much later while parsing it. Each table is now staged under a temporary name and moved into place only once it has arrived in full and been recognised as HDF5.

The observe integration tests could not fail. The fixture caught every exception and turned it into a skip, and the tests walked over whatever spectra a run produced, so a run producing none left them green having checked nothing. They now skip when there is nothing to check and say why, and a failure of the run is a failure. Seven of the eight report themselves as not-run until the fixture uses an atmosphere module that writes a profile (a separate change); the eighth passes on its own merits. That is a smaller green number than before and a truthful one.

## Validation of changes

macOS 15 (arm64), Python 3.12, petitRADTRANS 3.3.3 and the full 5.6 GB table set installed locally.

- All 20 modelled species fetch and load: petitRADTRANS constructs a `Radtrans` over the 19 line species it asks for, plus 3 Rayleigh scatterers and 10 collision pairs, from the configuration this code writes. `uncovered_species()` returns empty.
- The rejection path was reproduced against the live library: a renamed path previously wrote a 4411-byte web page to disk as an opacity table and passed every completeness check; it now raises and leaves nothing behind. A real table still downloads and verifies as HDF5.
- 2671 unit tests pass. 12 cover the new module, two of them driving the real transfer against a stubbed HTTP response rather than a stand-in, since the staging and clean-up are the behaviour in question.
- `tools/get_prt.sh` runs against the real tree and writes 30 named files.
- Every reference in the docs table was extracted from the tables with h5py and resolved against doi.org: 14 cited, 14 extracted, none invented. Where a table records no usable reference, or records petitRADTRANS in place of the data's own source, the docs say so instead of guessing.
- `ruff check`, `ruff format --check`, and `bash tools/validate_test_structure.sh` clean.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
