### PR TITLE
Use the transparent logo lockups in the README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus-lockup-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus-lockup-light.png">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus-lockup-dark-transparent.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus-lockup-light-transparent.png">
     <img alt="PROTEUS framework lockup: the wordmark with the phase glyph as the O" src="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus-lockup-light.png" width="480">
   </picture>
 </div>


### PR DESCRIPTION
## Description
The README header logo now uses the transparent lockup variants instead of the baked panels, so the wordmark sits directly on GitHub's page background in both light and dark mode rather than inside a grey or navy box. Only the two picture sources change; the plain img fallback keeps the opaque panel so renderers that strip picture tags, including the PyPI project page, still show a self-contained legible image. Both transparent assets already exist on main under docs/assets, so no new files are added and the raw URLs resolve as is.

## Validation of changes
I confirmed both transparent PNGs are present on main at the exact referenced paths, checked that they carry a real alpha channel rather than a re-exported background, and verified the dark source maps to the light-ink artwork and the light source to the dark-ink artwork. I rendered the header in a local mock of GitHub's README card in both colour modes to confirm the logo reads cleanly on each background, and checked that the fallback img line is byte-identical to main so the PyPI rendering is unchanged. The docs landing page already uses the same transparent variants, so the README now matches it.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
