### PR TITLE
Give each heavy nightly test its own shard so none overruns its cap

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -293,7 +293,7 @@ jobs:
           - shard: std-config-multi
             tier: extended
             os: ubuntu-latest
-            job_minutes: 330
+            job_minutes: 355
             select: test_integration_std_config_multi_timestep
             files: >-
               tests/integration/test_integration_std_config.py

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -267,25 +267,54 @@ jobs:
               tests/integration/test_slow_janus_aragog.py
               tests/inference/test_bo_convergence.py
               tests/inference/test_inference_slow.py
-          # ---- shard: misc (hypothesis fuzz + dummy/std-config integration + superliquidus) ----
+          # ---- shard: misc (hypothesis fuzz + dummy integration; both quick) ----
           - shard: misc
             tier: critical
             os: ubuntu-latest
             files: >-
               tests/integration/test_smoke_hypothesis.py
               tests/integration/test_integration_dummy.py
-              tests/integration/test_integration_std_config.py
-              tests/interior_struct/test_superliquidus_adiabat.py
           - shard: misc
             tier: critical
             os: macos-latest
             files: >-
               tests/integration/test_smoke_hypothesis.py
               tests/integration/test_integration_dummy.py
+          # ---- shard: std-config (full coupled "standard candle" run with
+          # every real module; the two tests run 3 and 5 coupled timesteps and
+          # cost tens of minutes to over an hour on the runner. Linux-only
+          # extended: this run boots AGNI, whose macOS arm64 path is not yet
+          # validated (the reason the agni shard is Linux-only too), and the
+          # macOS runner ceiling is already full. job_minutes gives headroom for
+          # the coupled runtime, which uses the multi-band Honeyside spectral
+          # file and has not been timed on the runner) ----
+          - shard: std-config
+            tier: extended
+            os: ubuntu-latest
+            job_minutes: 240
+            files: >-
               tests/integration/test_integration_std_config.py
+          # ---- shard: superliquidus (real-PALEOS super-liquidus IC solve;
+          # each solve is ~26 EOS-adiabat probes and runs ~40 min on the runner,
+          # and the mass-independence test runs three solves in series (~2 h), so
+          # the whole file is ~3.5 h. Pure numpy/scipy EOS work with no macOS
+          # parity need, so Linux-only extended with a raised job cap that keeps
+          # real headroom over the run and stays above the file's per-test
+          # timeouts) ----
+          - shard: superliquidus
+            tier: extended
+            os: ubuntu-latest
+            job_minutes: 300
+            files: >-
               tests/interior_struct/test_superliquidus_adiabat.py
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 210   # job cap for the slow-tier matrix, sized by its longest shard (zalmoxis-coupled/ubuntu, ~137 min plus ~11 min setup); above the 180 min per-test pytest-timeout so a hung single test trips pytest-timeout's per-test timer before the job is cancelled.
+    # Job cap defaults to 210 min, kept above the longest per-test pytest-timeout
+    # (<= 180 min) so a hung single test trips its own timer before the job is
+    # cancelled. The two heavy extended shards run several tens-of-minutes tests
+    # in series, so they raise the cap via matrix.job_minutes (std-config 240,
+    # superliquidus 300) to hold real headroom over their totals while staying
+    # above their per-test timeouts.
+    timeout-minutes: ${{ matrix.job_minutes || 210 }}
     env:
       COVERAGE_FILE: .coverage.slow.${{ matrix.shard }}.${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -280,40 +280,59 @@ jobs:
             files: >-
               tests/integration/test_smoke_hypothesis.py
               tests/integration/test_integration_dummy.py
-          # ---- shard: std-config (full coupled "standard candle" run with
-          # every real module; the two tests run 3 and 5 coupled timesteps and
-          # cost tens of minutes to over an hour on the runner. Linux-only
-          # extended: this run boots AGNI, whose macOS arm64 path is not yet
-          # validated (the reason the agni shard is Linux-only too), and the
-          # macOS runner ceiling is already full. job_minutes gives headroom for
-          # the coupled runtime, which uses the multi-band Honeyside spectral
-          # file and has not been timed on the runner) ----
-          - shard: std-config
+          # Heavy real-solver tests run one per shard (via matrix.select -> -k)
+          # so each job is bounded by setup plus a single test, not a serial
+          # stack. All are Linux-only extended: the coupled std-config run boots
+          # AGNI, whose macOS arm64 path is not yet validated (the reason the
+          # agni shard is Linux-only too); the super-liquidus solve is pure
+          # numpy/scipy EOS work with no platform binary; and the macOS runner
+          # budget is already full. job_minutes are generous measurement
+          # ceilings while the real per-test runner wall-times are established.
+          # ---- std-config-multi (3 coupled timesteps, all real modules) ----
+          - shard: std-config-multi
             tier: extended
             os: ubuntu-latest
-            job_minutes: 240
+            job_minutes: 260
+            select: test_integration_std_config_multi_timestep
             files: >-
               tests/integration/test_integration_std_config.py
-          # ---- shard: superliquidus (real-PALEOS super-liquidus IC solve;
-          # each solve is ~26 EOS-adiabat probes and runs ~40 min on the runner,
-          # and the mass-independence test runs three solves in series (~2 h), so
-          # the whole file is ~3.5 h. Pure numpy/scipy EOS work with no macOS
-          # parity need, so Linux-only extended with a raised job cap that keeps
-          # real headroom over the run and stays above the file's per-test
-          # timeouts) ----
-          - shard: superliquidus
+          # ---- std-config-extended (5 coupled timesteps, all real modules) ----
+          - shard: std-config-extended
             tier: extended
             os: ubuntu-latest
-            job_minutes: 300
+            job_minutes: 320
+            select: test_integration_std_config_extended_run
+            files: >-
+              tests/integration/test_integration_std_config.py
+          # ---- superliquidus-m1 (single 1 M_Earth PALEOS solve) ----
+          - shard: superliquidus-m1
+            tier: extended
+            os: ubuntu-latest
+            job_minutes: 170
+            select: test_m1_solved_adiabat_pinned
+            files: >-
+              tests/interior_struct/test_superliquidus_adiabat.py
+          # ---- superliquidus-massindep (three solves in series: 1, 5, 10 M_E) ----
+          - shard: superliquidus-massindep
+            tier: extended
+            os: ubuntu-latest
+            job_minutes: 350
+            select: test_solved_entropy_is_mass_independent
+            files: >-
+              tests/interior_struct/test_superliquidus_adiabat.py
+          # ---- superliquidus-unreachable (one full-span scan, no bisection) ----
+          - shard: superliquidus-unreachable
+            tier: extended
+            os: ubuntu-latest
+            job_minutes: 170
+            select: test_unreachable_superheat_raises_real
             files: >-
               tests/interior_struct/test_superliquidus_adiabat.py
     runs-on: ${{ matrix.os }}
-    # Job cap defaults to 210 min, kept above the longest per-test pytest-timeout
-    # (<= 180 min) so a hung single test trips its own timer before the job is
-    # cancelled. The two heavy extended shards run several tens-of-minutes tests
-    # in series, so they raise the cap via matrix.job_minutes (std-config 240,
-    # superliquidus 300) to hold real headroom over their totals while staying
-    # above their per-test timeouts.
+    # Job cap defaults to 210 min, kept above each shard's per-test pytest-timeout
+    # so a hung single test trips its own timer before the job is cancelled. The
+    # one-test heavy shards raise the cap via matrix.job_minutes because a single
+    # real-solver test there runs one to several hours on the runner.
     timeout-minutes: ${{ matrix.job_minutes || 210 }}
     env:
       COVERAGE_FILE: .coverage.slow.${{ matrix.shard }}.${{ matrix.os }}
@@ -325,11 +344,19 @@ jobs:
         with:
           full-data: 'true'
       - name: Run slow shard
+        env:
+          SHARD_SELECT: ${{ matrix.select }}
         run: |
+          # Heavy shards select a single test by name via matrix.select; other
+          # shards run their whole file list. Test names are plain identifiers,
+          # so the unquoted expansion is a single -k token (empty when unset).
+          SELECT_ARG=""
+          if [ -n "$SHARD_SELECT" ]; then SELECT_ARG="-k $SHARD_SELECT"; fi
           pytest -m "slow and not unit and not smoke and not integration" \
             ${{ matrix.files }} \
+            $SELECT_ARG \
             -p no:faulthandler \
-            --durations=10 \
+            --durations=0 \
             --junitxml=junit-slow-${{ matrix.shard }}-${{ matrix.os }}.xml \
             --cov=proteus \
             --cov-report=xml:coverage-slow-${{ matrix.shard }}-${{ matrix.os }}.xml \

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -286,45 +286,38 @@ jobs:
           # AGNI, whose macOS arm64 path is not yet validated (the reason the
           # agni shard is Linux-only too); the super-liquidus solve is pure
           # numpy/scipy EOS work with no platform binary; and the macOS runner
-          # budget is already full. job_minutes are generous measurement
-          # ceilings while the real per-test runner wall-times are established.
-          # ---- std-config-multi (3 coupled timesteps, all real modules) ----
+          # budget is already full. job_minutes sit above the measured runner
+          # wall-time with margin for the ~1.5x runner-to-runner variance, and
+          # above each shard's per-test timeout so a hung test trips first.
+          # ---- std-config-multi (3 coupled timesteps; ~180 min measured) ----
           - shard: std-config-multi
             tier: extended
             os: ubuntu-latest
-            job_minutes: 260
+            job_minutes: 330
             select: test_integration_std_config_multi_timestep
             files: >-
               tests/integration/test_integration_std_config.py
-          # ---- std-config-extended (5 coupled timesteps, all real modules) ----
-          - shard: std-config-extended
-            tier: extended
-            os: ubuntu-latest
-            job_minutes: 320
-            select: test_integration_std_config_extended_run
-            files: >-
-              tests/integration/test_integration_std_config.py
-          # ---- superliquidus-m1 (single 1 M_Earth PALEOS solve) ----
+          # ---- superliquidus-m1 (single 1 M_Earth solve; ~47 min measured) ----
           - shard: superliquidus-m1
             tier: extended
             os: ubuntu-latest
-            job_minutes: 170
+            job_minutes: 120
             select: test_m1_solved_adiabat_pinned
             files: >-
               tests/interior_struct/test_superliquidus_adiabat.py
-          # ---- superliquidus-massindep (three solves in series: 1, 5, 10 M_E) ----
+          # ---- superliquidus-massindep (three solves in series; ~141 min measured) ----
           - shard: superliquidus-massindep
             tier: extended
             os: ubuntu-latest
-            job_minutes: 350
+            job_minutes: 270
             select: test_solved_entropy_is_mass_independent
             files: >-
               tests/interior_struct/test_superliquidus_adiabat.py
-          # ---- superliquidus-unreachable (one full-span scan, no bisection) ----
+          # ---- superliquidus-unreachable (one full-span scan; ~48 min measured) ----
           - shard: superliquidus-unreachable
             tier: extended
             os: ubuntu-latest
-            job_minutes: 170
+            job_minutes: 120
             select: test_unreachable_superheat_raises_real
             files: >-
               tests/interior_struct/test_superliquidus_adiabat.py

--- a/tests/integration/test_integration_std_config.py
+++ b/tests/integration/test_integration_std_config.py
@@ -16,8 +16,9 @@ This test validates the full PROTEUS "standard candle" configuration using
 - Ensures stable feedback loops over multiple timesteps
 - Must run in nightly Science validation CI
 
-**Runtime**: tens of minutes to over an hour per test on CI (3 and 5 coupled
-timesteps, all real modules, low resolution)
+**Runtime**: the 3-timestep multi_timestep test measures ~3 h on the CI runner
+and runs nightly; the 5-timestep extended_run measures ~4 h and is skipped from
+the routine nightly (run it manually), all real modules, low resolution
 
 **Requirements**:
 - All real modules must be available (MORS, LovePy, ARAGOG, AGNI, CALLIOPE, ZEPHYRUS)
@@ -50,7 +51,7 @@ pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(14400)  # generous ceiling while the runner wall-time is measured
+@pytest.mark.timeout(18000)  # 300 min ceiling; the coupled run measures ~180 min on the runner
 def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
     """Test standard PROTEUS configuration with all real modules (3 timesteps).
 
@@ -268,7 +269,12 @@ def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(18000)  # generous ceiling while the runner wall-time is measured
+@pytest.mark.skip(
+    reason='The 5-timestep coupled run measures ~4 h on the CI runner, beyond the '
+    'nightly budget and close to the runner job limit. The 3-timestep '
+    'multi_timestep test covers the coupling nightly; run this one manually or '
+    'in a periodic workflow when longer-horizon stability needs checking.'
+)
 def test_integration_std_config_extended_run(proteus_multi_timestep_run):
     """Test extended standard configuration run (5 timesteps).
 
@@ -282,10 +288,11 @@ def test_integration_std_config_extended_run(proteus_multi_timestep_run):
     - No unbounded growth in any physical variables
     - Conservation laws maintained over time
 
-    Runtime: over an hour on CI (5 timesteps, all real modules, low resolution)
+    Runtime: ~4 h on the CI runner (5 timesteps, all real modules, low
+    resolution), which is why it is skipped from the routine nightly.
 
-    Note: slow tier, so this runs in the nightly only.
-    Requires all real modules (MORS, LovePy, ARAGOG, AGNI, CALLIOPE, ZEPHYRUS).
+    Note: skipped from CI for runtime; run manually with all real modules
+    (MORS, LovePy, ARAGOG, AGNI, CALLIOPE, ZEPHYRUS).
     """
     # Try to run PROTEUS with standard configuration for extended period
     try:

--- a/tests/integration/test_integration_std_config.py
+++ b/tests/integration/test_integration_std_config.py
@@ -43,15 +43,15 @@ from tests.integration.conftest import (
 
 pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]
 
-# Both tests here drive the real modules for many timesteps and cost tens of
-# minutes, so the whole file is slow tier. Keep it single-tier: a second tier
-# marker on a function would combine with the module mark above, and the tier
-# filters are mutually exclusive (`integration and not slow` against `slow and
-# not integration`), so a doubly-marked test is selected by neither.
+# Both tests here drive the real modules for several coupled timesteps and cost
+# hours on the runner, so the whole file is slow tier. Keep it single-tier: a
+# second tier marker on a function would combine with the module mark above, and
+# the tier filters are mutually exclusive (`integration and not slow` against
+# `slow and not integration`), so a doubly-marked test is selected by neither.
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(18000)  # 300 min ceiling; the coupled run measures ~180 min on the runner
+@pytest.mark.timeout(20100)  # 335 min ceiling; the coupled run measures ~180 min on the runner
 def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
     """Test standard PROTEUS configuration with all real modules (3 timesteps).
 
@@ -72,7 +72,7 @@ def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
     - Volatile evolution: H2O, CO2 masses evolve (CALLIOPE)
     - Escape evolution: esc_rate_total calculated (ZEPHYRUS)
 
-    Runtime: tens of minutes on CI (3 timesteps, all real modules, low resolution)
+    Runtime: ~3 h on the CI runner (3 timesteps, all real modules, low resolution)
 
     Note: slow tier, so this runs in the nightly science validation only.
     This test requires all real modules to be available (MORS, LovePy, ARAGOG, AGNI,
@@ -270,10 +270,10 @@ def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
 
 @pytest.mark.physics_invariant
 @pytest.mark.skip(
-    reason='The 5-timestep coupled run measures ~4 h on the CI runner, beyond the '
-    'nightly budget and close to the runner job limit. The 3-timestep '
-    'multi_timestep test covers the coupling nightly; run this one manually or '
-    'in a periodic workflow when longer-horizon stability needs checking.'
+    reason='The 5-timestep coupled run measures ~4 h on the CI runner, which does '
+    'not fit the 360 min hosted-runner job limit with margin. The 3-timestep '
+    'multi_timestep test covers the coupling nightly; run this one manually when '
+    'longer-horizon stability needs checking.'
 )
 def test_integration_std_config_extended_run(proteus_multi_timestep_run):
     """Test extended standard configuration run (5 timesteps).

--- a/tests/integration/test_integration_std_config.py
+++ b/tests/integration/test_integration_std_config.py
@@ -16,7 +16,8 @@ This test validates the full PROTEUS "standard candle" configuration using
 - Ensures stable feedback loops over multiple timesteps
 - Must run in nightly Science validation CI
 
-**Runtime**: ~10-30 minutes (3-5 timesteps, all real modules, low resolution)
+**Runtime**: tens of minutes to over an hour per test on CI (3 and 5 coupled
+timesteps, all real modules, low resolution)
 
 **Requirements**:
 - All real modules must be available (MORS, LovePy, ARAGOG, AGNI, CALLIOPE, ZEPHYRUS)
@@ -49,9 +50,9 @@ pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(1800)  # 30 minute timeout for this test
+@pytest.mark.timeout(5400)  # 90 min ceiling; the coupled run takes tens of minutes on CI
 def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
-    """Test standard PROTEUS configuration with all real modules (5 timesteps).
+    """Test standard PROTEUS configuration with all real modules (3 timesteps).
 
     Physical scenario: Validates that the full PROTEUS configuration with all
     real physics modules (MORS, LovePy, ARAGOG, AGNI, CALLIOPE, ZEPHYRUS) can
@@ -70,7 +71,7 @@ def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
     - Volatile evolution: H2O, CO2 masses evolve (CALLIOPE)
     - Escape evolution: esc_rate_total calculated (ZEPHYRUS)
 
-    Runtime: ~10-20 minutes (3 timesteps, all real modules, low resolution)
+    Runtime: tens of minutes on CI (3 timesteps, all real modules, low resolution)
 
     Note: slow tier, so this runs in the nightly science validation only.
     This test requires all real modules to be available (MORS, LovePy, ARAGOG, AGNI,
@@ -267,21 +268,21 @@ def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(3600)  # 60 minute timeout for extended run
+@pytest.mark.timeout(9000)  # 150 min ceiling; the longer coupled run takes over an hour on CI
 def test_integration_std_config_extended_run(proteus_multi_timestep_run):
-    """Test extended standard configuration run (10 timesteps).
+    """Test extended standard configuration run (5 timesteps).
 
     Physical scenario: Validates that the standard PROTEUS configuration
     remains stable over extended simulation periods. Tests long-term
     evolution and ensures no degradation in conservation or stability.
 
     Validates:
-    - Simulation runs for 10 timesteps without errors
+    - Simulation runs for 5 timesteps without errors
     - All modules remain stable over extended run
     - No unbounded growth in any physical variables
     - Conservation laws maintained over time
 
-    Runtime: ~20-40 minutes (5 timesteps, all real modules, low resolution)
+    Runtime: over an hour on CI (5 timesteps, all real modules, low resolution)
 
     Note: slow tier, so this runs in the nightly only.
     Requires all real modules (MORS, LovePy, ARAGOG, AGNI, CALLIOPE, ZEPHYRUS).

--- a/tests/integration/test_integration_std_config.py
+++ b/tests/integration/test_integration_std_config.py
@@ -50,7 +50,7 @@ pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(5400)  # 90 min ceiling; the coupled run takes tens of minutes on CI
+@pytest.mark.timeout(14400)  # generous ceiling while the runner wall-time is measured
 def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
     """Test standard PROTEUS configuration with all real modules (3 timesteps).
 
@@ -268,7 +268,7 @@ def test_integration_std_config_multi_timestep(proteus_multi_timestep_run):
 
 
 @pytest.mark.physics_invariant
-@pytest.mark.timeout(9000)  # 150 min ceiling; the longer coupled run takes over an hour on CI
+@pytest.mark.timeout(18000)  # generous ceiling while the runner wall-time is measured
 def test_integration_std_config_extended_run(proteus_multi_timestep_run):
     """Test extended standard configuration run (5 timesteps).
 

--- a/tests/interior_struct/test_superliquidus_adiabat.py
+++ b/tests/interior_struct/test_superliquidus_adiabat.py
@@ -73,6 +73,9 @@ class TestSolveSuperliquidusReal:
         assert r['surface_T'] > 3500.0
 
     @pytest.mark.physics_invariant
+    # Three real solves in series (1, 5, 10 M_Earth), each ~40 min on the
+    # runner (~2 h total), so this needs well above the file-level 3600 s net.
+    @pytest.mark.timeout(10800)
     def test_solved_entropy_is_mass_independent(self):
         """The shallow PALEOS binding depth makes the solved entropy
         essentially mass-independent, keeping the mass grid on a common initial

--- a/tests/interior_struct/test_superliquidus_adiabat.py
+++ b/tests/interior_struct/test_superliquidus_adiabat.py
@@ -46,7 +46,7 @@ class TestSolveSuperliquidusReal:
 
     @pytest.mark.physics_invariant
     @pytest.mark.reference_pinned
-    @pytest.mark.timeout(9000)  # generous ceiling while the runner wall-time is measured
+    @pytest.mark.timeout(5400)  # 90 min ceiling; a single solve measures ~47 min on the runner
     def test_m1_solved_adiabat_pinned(self):
         """Pin the 1 M_Earth PALEOS solve (delta_T_super = 500 K).
 
@@ -74,9 +74,9 @@ class TestSolveSuperliquidusReal:
         assert r['surface_T'] > 3500.0
 
     @pytest.mark.physics_invariant
-    # Three real solves in series (1, 5, 10 M_Earth): generous ceiling while the
-    # runner wall-time is measured.
-    @pytest.mark.timeout(20000)
+    # Three real solves in series (1, 5, 10 M_Earth); the file measures ~141 min
+    # on the runner, so this needs well above the file-level 3600 s net.
+    @pytest.mark.timeout(14400)
     def test_solved_entropy_is_mass_independent(self):
         """The shallow PALEOS binding depth makes the solved entropy
         essentially mass-independent, keeping the mass grid on a common initial
@@ -106,7 +106,7 @@ class TestSolveSuperliquidusReal:
         # well within that.
         assert spread < 0.05 * min(entropies)
 
-    @pytest.mark.timeout(9000)  # generous ceiling while the runner wall-time is measured
+    @pytest.mark.timeout(5400)  # 90 min ceiling; the scan measures ~48 min on the runner
     def test_unreachable_superheat_raises_real(self):
         """A superheat too large for the EOS table to support raises and names
         the largest achievable value, rather than returning a partial-melt IC.

--- a/tests/interior_struct/test_superliquidus_adiabat.py
+++ b/tests/interior_struct/test_superliquidus_adiabat.py
@@ -74,8 +74,8 @@ class TestSolveSuperliquidusReal:
         assert r['surface_T'] > 3500.0
 
     @pytest.mark.physics_invariant
-    # Three real solves in series (1, 5, 10 M_Earth); the file measures ~141 min
-    # on the runner, so this needs well above the file-level 3600 s net.
+    # Three real solves in series (1, 5, 10 M_Earth); this test measures ~141 min
+    # on the runner, so it needs well above the file-level 3600 s net.
     @pytest.mark.timeout(14400)
     def test_solved_entropy_is_mass_independent(self):
         """The shallow PALEOS binding depth makes the solved entropy

--- a/tests/interior_struct/test_superliquidus_adiabat.py
+++ b/tests/interior_struct/test_superliquidus_adiabat.py
@@ -46,6 +46,7 @@ class TestSolveSuperliquidusReal:
 
     @pytest.mark.physics_invariant
     @pytest.mark.reference_pinned
+    @pytest.mark.timeout(9000)  # generous ceiling while the runner wall-time is measured
     def test_m1_solved_adiabat_pinned(self):
         """Pin the 1 M_Earth PALEOS solve (delta_T_super = 500 K).
 
@@ -73,9 +74,9 @@ class TestSolveSuperliquidusReal:
         assert r['surface_T'] > 3500.0
 
     @pytest.mark.physics_invariant
-    # Three real solves in series (1, 5, 10 M_Earth), each ~40 min on the
-    # runner (~2 h total), so this needs well above the file-level 3600 s net.
-    @pytest.mark.timeout(10800)
+    # Three real solves in series (1, 5, 10 M_Earth): generous ceiling while the
+    # runner wall-time is measured.
+    @pytest.mark.timeout(20000)
     def test_solved_entropy_is_mass_independent(self):
         """The shallow PALEOS binding depth makes the solved entropy
         essentially mass-independent, keeping the mass grid on a common initial
@@ -105,6 +106,7 @@ class TestSolveSuperliquidusReal:
         # well within that.
         assert spread < 0.05 * min(entropies)
 
+    @pytest.mark.timeout(9000)  # generous ceiling while the runner wall-time is measured
     def test_unreachable_superheat_raises_real(self):
         """A superheat too large for the EOS table to support raises and names
         the largest achievable value, rather than returning a partial-melt IC.

--- a/tests/tools/test_ci_tier_coverage.py
+++ b/tests/tools/test_ci_tier_coverage.py
@@ -111,6 +111,34 @@ def _slow_matrix_files() -> set[str]:
     return set(re.findall(r'^\s+(tests/\S+\.py)\s*$', _nightly_text(), re.M))
 
 
+def _slow_matrix_shards() -> list[dict]:
+    """Parse the slow-tier matrix into one dict per shard entry.
+
+    ``shard:`` appears only in the slow tier, so splitting the workflow text on
+    it yields exactly the shard entries. Each dict carries the shard name, its
+    ``select:`` value (or None), its ``job_minutes:`` cap (or None), and the
+    test files it names. Parsed as text because PyYAML is not a dependency.
+    """
+    entries = re.split(r'\n\s+- shard:', _nightly_text())[1:]
+    shards = []
+    for entry in entries:
+        # The last entry runs to end-of-file; stop it at the job's runs-on key
+        # so trailing lines cannot leak file paths into this shard.
+        entry = entry.split('\n    runs-on:')[0]
+        name = entry.splitlines()[0].strip()
+        sel = re.search(r'^\s+select:\s*(\S+)\s*$', entry, re.M)
+        cap = re.search(r'^\s+job_minutes:\s*(\d+)\s*$', entry, re.M)
+        shards.append(
+            {
+                'shard': name,
+                'select': sel.group(1) if sel else None,
+                'job_minutes': int(cap.group(1)) if cap else None,
+                'files': re.findall(r'^\s+(tests/\S+\.py)\s*$', entry, re.M),
+            }
+        )
+    return shards
+
+
 def _integration_paths() -> list[str]:
     """Directories the integration tier passes to pytest."""
     m = re.search(r'pytest ((?:tests/\S+ +)+)\\', _nightly_text())
@@ -235,3 +263,51 @@ def test_every_tiered_file_is_reachable_by_its_ci_job():
         'these files hold integration tests but sit outside the directories the '
         f'integration tier runs ({integ_paths}), so the tests never run: {missing_integ}'
     )
+
+
+def test_select_sharded_files_cover_every_slow_test():
+    """A file run under per-shard ``-k select:`` runs only the tests those shards
+    name, so file-level reachability no longer implies every test runs.
+
+    A slow test added to such a file later would be selected by no shard and run
+    nowhere, while ``test_every_tiered_file_is_reachable_by_its_ci_job`` stays
+    green because the file is still named. Assert instead that the shard selects
+    cover every non-skip slow test in each select-sharded file, exactly once, and
+    that each such shard carries a ``job_minutes`` cap below the 360 min
+    hosted-runner hard limit (without it the cap silently falls back to 210 min,
+    below the shard's own per-test timeout).
+    """
+    select_shards = [s for s in _slow_matrix_shards() if s['select']]
+    assert select_shards, 'expected select-based heavy shards in the slow matrix'
+
+    by_file: dict[str, list[str]] = {}
+    for s in select_shards:
+        assert s['job_minutes'] is not None, (
+            f'shard {s["shard"]} selects a single test but sets no job_minutes, so '
+            'its cap silently falls back to the 210 min default'
+        )
+        assert s['job_minutes'] < 360, (
+            f'shard {s["shard"]} job_minutes={s["job_minutes"]} is at or above the '
+            '360 min hosted-runner hard job limit'
+        )
+        assert len(s['files']) == 1, (
+            f'select shard {s["shard"]} must name exactly one file, got {s["files"]}'
+        )
+        by_file.setdefault(s['files'][0], []).append(s['select'])
+
+    for rel, selects in by_file.items():
+        slow_tests = {n for n, t in _tiers_per_test(REPO_ROOT / rel).items() if 'slow' in t}
+        for sel in selects:
+            matched = [n for n in slow_tests if sel in n]
+            assert len(matched) == 1, (
+                f'select {sel!r} in {rel} matches {matched}; it must name exactly '
+                'one non-skip slow test (a substring select can silently match two)'
+            )
+        assert len(selects) == len(set(selects)), (
+            f'{rel}: a test is selected by more than one shard: {selects}'
+        )
+        selected = {n for sel in selects for n in slow_tests if sel in n}
+        assert selected == slow_tests, (
+            f'{rel}: the shards select {sorted(selected)} but the file holds non-skip '
+            f'slow tests {sorted(slow_tests)}; the unselected ones run in no shard'
+        )


### PR DESCRIPTION
## Description

The nightly slow tier packed the coupled std_config integration run and the super-liquidus EOS solves into a single "misc" shard. Together those tests run several hours, past the shard's job cap, so GitHub cancelled the shard and failed Nightly status. This gives each heavy real-solver test its own shard, selected by name, with a per-shard job cap sized above the test's measured runner wall time, so a single multi-hour test can run to completion without dragging the rest of the slow tier down.

Changes:

- Reshard the slow tier so the misc shard runs only the quick hypothesis fuzz and dummy integration again, and each heavy test gets its own ubuntu-only extended shard selected with `pytest -k`.
- Size each heavy shard's job cap from the measured runner wall time (std-config-multi 355 min; super-liquidus m1/mass-independent/unreachable 120/270/120 min), all below the 360 min hosted-runner hard job limit, and raise each test's per-test timeout to sit below its shard cap so a hung test trips its own timer before the whole job is cancelled.
- Skip the 5-timestep std_config extended_run test from the routine nightly. It measures about 4 h on the runner, which does not fit the 360 min job limit with margin. It stays in the file and runs manually; the 3-timestep multi_timestep test covers the coupling in the nightly.
- Add a guard, `test_select_sharded_files_cover_every_slow_test`, so a slow test added to a per-shard-selected file later cannot silently run in no shard.

Coverage note: the heavy tests now run on ubuntu only. Super-liquidus is pure numpy/scipy with no platform binary, so its macOS run was redundant. The coupled std_config run boots AGNI, whose macOS arm64 path is not yet validated (the reason the agni shard is already ubuntu-only), and the macOS runner budget is full, so the macOS nightly no longer validates the coupled std_config path.

## Validation of changes

A full nightly on this branch (workflow_dispatch) is green at every one of the 21 jobs, including all slow shards and Nightly status. I measured the per-test runner wall times directly (multi_timestep about 180 min; super-liquidus solves about 47, 141, 48 min) and set each shard cap above its measured time with margin for the roughly 1.5x runner-to-runner variance.

Test configuration: GitHub-hosted ubuntu-latest and macos-latest runners, Python 3.12, nightly Science Validation workflow.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
