### PR TITLE
Verify Baraffe track provisioning at the fwl-io versioned path

### DIFF
--- a/src/proteus/utils/data.py
+++ b/src/proteus/utils/data.py
@@ -1492,16 +1492,21 @@ def download_stellar_tracks(track: str, use_osf_fallback: bool = True):
     use_osf_fallback : bool
         If True, attempt OSF download if MORS download fails
     """
-    from mors.data import DownloadEvolutionTracks
+    from mors import data as mors_data
 
     log.debug(f'Downloading stellar evolution tracks: {track}')
 
     # Try MORS download first
     try:
-        DownloadEvolutionTracks(track)
-        # Verify download succeeded by checking if tracks directory exists
-        fwl_data = GetFWLData()
-        tracks_path = fwl_data / 'stellar_evolution_tracks' / track
+        mors_data.DownloadEvolutionTracks(track)
+        # Verify the download landed. A migrated MORS fetches Baraffe through
+        # fwl-io into its versioned directory and exposes baraffe_data_dir to
+        # resolve it; an older MORS wrote Baraffe to the legacy path, like Spada.
+        # Verify wherever this MORS version actually placed the tracks.
+        if track == 'Baraffe' and hasattr(mors_data, 'baraffe_data_dir'):
+            tracks_path = mors_data.baraffe_data_dir()
+        else:
+            tracks_path = GetFWLData() / 'stellar_evolution_tracks' / track
         if tracks_path.exists() and any(tracks_path.iterdir()):
             log.info(f'Successfully downloaded {track} tracks via MORS')
             return
@@ -1511,7 +1516,9 @@ def download_stellar_tracks(track: str, use_osf_fallback: bool = True):
     except Exception as e:
         log.warning(f'MORS download failed for {track} tracks: {e}')
 
-        if not use_osf_fallback:
+        # Baraffe is hash-verified by fwl-io and has no OSF mirror, so a failure
+        # is authoritative; only Spada has a legacy OSF fallback.
+        if track == 'Baraffe' or not use_osf_fallback:
             raise
 
         # Fallback to OSF if available

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -4656,6 +4656,107 @@ def test_download_stellar_tracks_mors_success(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
+def test_download_stellar_tracks_baraffe_verifies_versioned_path(tmp_path, monkeypatch):
+    """Baraffe success is verified at the fwl-io versioned path, not the legacy dir."""
+    import sys
+    import types
+
+    import proteus.utils.data as data_mod
+
+    monkeypatch.setattr(data_mod, 'GetFWLData', lambda: tmp_path)
+
+    # The versioned Baraffe directory holds the tracks; the legacy dir is absent.
+    versioned = tmp_path / 'star' / 'tracks' / 'baraffe_2015' / 'r15729114'
+    versioned.mkdir(parents=True)
+    (versioned / 'BHAC15-M1p000.txt').write_text('track')
+
+    checked = []
+    fake_mors_data = types.ModuleType('mors.data')
+    fake_mors_data.DownloadEvolutionTracks = lambda track: None
+    fake_mors_data.baraffe_data_dir = lambda: checked.append(versioned) or versioned
+    fake_mors = types.ModuleType('mors')
+    fake_mors.data = fake_mors_data
+    monkeypatch.setitem(sys.modules, 'mors', fake_mors)
+    monkeypatch.setitem(sys.modules, 'mors.data', fake_mors_data)
+
+    osf_calls = []
+    monkeypatch.setattr(data_mod, 'download_OSF_folder', lambda **k: osf_calls.append(k))
+
+    data_mod.download_stellar_tracks('Baraffe')
+
+    # Discrimination: verification consulted the versioned resolver, not the
+    # legacy path (which never exists here), so the fetch succeeded and no OSF
+    # fallback ran.
+    assert checked == [versioned]
+    assert osf_calls == []
+
+
+@pytest.mark.unit
+def test_download_stellar_tracks_baraffe_legacy_mors_uses_legacy_path(tmp_path, monkeypatch):
+    """A pre-migration MORS (no baraffe_data_dir) verifies Baraffe at the legacy path."""
+    import sys
+    import types
+
+    import proteus.utils.data as data_mod
+
+    monkeypatch.setattr(data_mod, 'GetFWLData', lambda: tmp_path)
+
+    # An older MORS writes Baraffe to the legacy path and exposes no resolver.
+    legacy = tmp_path / 'stellar_evolution_tracks' / 'Baraffe'
+    legacy.mkdir(parents=True)
+    (legacy / 'BHAC15-M1p000.txt').write_text('track')
+
+    fake_mors_data = types.ModuleType('mors.data')
+    fake_mors_data.DownloadEvolutionTracks = lambda track: None
+    # Deliberately no baraffe_data_dir attribute (pre-migration MORS).
+    fake_mors = types.ModuleType('mors')
+    fake_mors.data = fake_mors_data
+    monkeypatch.setitem(sys.modules, 'mors', fake_mors)
+    monkeypatch.setitem(sys.modules, 'mors.data', fake_mors_data)
+
+    osf_calls = []
+    monkeypatch.setattr(data_mod, 'download_OSF_folder', lambda **k: osf_calls.append(k))
+
+    data_mod.download_stellar_tracks('Baraffe')
+
+    # Discrimination: provisioning succeeds via the legacy path even though the
+    # versioned directory is never created, so PROTEUS works with both MORS
+    # versions; no OSF fallback runs.
+    assert not (tmp_path / 'star' / 'tracks' / 'baraffe_2015').exists()
+    assert osf_calls == []
+
+
+@pytest.mark.unit
+def test_download_stellar_tracks_baraffe_failure_reraises_without_osf(tmp_path, monkeypatch):
+    """A genuine Baraffe failure re-raises; Baraffe has no OSF fallback mirror."""
+    import sys
+    import types
+
+    import proteus.utils.data as data_mod
+
+    monkeypatch.setattr(data_mod, 'GetFWLData', lambda: tmp_path)
+
+    # baraffe_data_dir resolves to an empty directory: the fetch produced nothing.
+    empty = tmp_path / 'star' / 'tracks' / 'baraffe_2015' / 'r15729114'
+    empty.mkdir(parents=True)
+    fake_mors_data = types.ModuleType('mors.data')
+    fake_mors_data.DownloadEvolutionTracks = lambda track: None
+    fake_mors_data.baraffe_data_dir = lambda: empty
+    fake_mors = types.ModuleType('mors')
+    fake_mors.data = fake_mors_data
+    monkeypatch.setitem(sys.modules, 'mors', fake_mors)
+    monkeypatch.setitem(sys.modules, 'mors.data', fake_mors_data)
+
+    osf_calls = []
+    monkeypatch.setattr(data_mod, 'download_OSF_folder', lambda **k: osf_calls.append(k))
+
+    with pytest.raises(FileNotFoundError, match='empty or missing'):
+        data_mod.download_stellar_tracks('Baraffe', use_osf_fallback=True)
+    # Even with use_osf_fallback=True, Baraffe does not attempt the OSF fallback.
+    assert osf_calls == []
+
+
+@pytest.mark.unit
 def test_download_stellar_tracks_mors_completes_but_tracks_missing(tmp_path, monkeypatch):
     """MORS download claims success but tracks dir is empty: triggers OSF fallback."""
     import sys
@@ -4747,20 +4848,20 @@ def test_download_stellar_tracks_osf_fallback_succeeds(tmp_path, monkeypatch):
 
     def fake_osf_folder(*, storage, folders, data_dir):
         # Create the expected tracks directory
-        target = Path(data_dir) / 'Baraffe'
+        target = Path(data_dir) / 'Spada'
         target.mkdir(parents=True, exist_ok=True)
-        (target / 'baraffe_track.dat').write_text('data')
+        (target / 'spada_track.dat').write_text('data')
 
     monkeypatch.setattr(data_mod, 'download_OSF_folder', fake_osf_folder)
     monkeypatch.setattr(data_mod, 'get_osf', lambda osf_id: MagicMock())
 
-    # Should not raise
-    data_mod.download_stellar_tracks('Baraffe', use_osf_fallback=True)
+    # Spada keeps the legacy OSF fallback; the failed MORS fetch is recovered.
+    data_mod.download_stellar_tracks('Spada', use_osf_fallback=True)
     # Discrimination: the OSF fallback produced the expected track file
-    # at the canonical location.
-    tracks_dir = tmp_path / 'stellar_evolution_tracks' / 'Baraffe'
+    # at the canonical legacy location.
+    tracks_dir = tmp_path / 'stellar_evolution_tracks' / 'Spada'
     assert tracks_dir.is_dir()
-    assert (tracks_dir / 'baraffe_track.dat').exists()
+    assert (tracks_dir / 'spada_track.dat').exists()
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

MORS is migrating to fetch the Baraffe stellar-evolution tracks through fwl-io, into a versioned directory (`star/tracks/baraffe_2015/r<record-id>`) instead of the legacy `stellar_evolution_tracks/Baraffe` path. PROTEUS keeps its own track-provisioning function (`download_stellar_tracks`), which verified success at the legacy path; after the migration a successful fetch was read as a failure, triggering a fruitless OSF fallback and aborting provisioning.

This makes `download_stellar_tracks` verify Baraffe wherever the installed MORS actually placed it. A migrated MORS exposes `baraffe_data_dir` and the tracks land in the versioned directory; an older MORS writes them to the legacy path. Using `hasattr` to pick the right one means PROTEUS works with both MORS versions, so there is no hard version-ordering requirement.

This is the PROTEUS leg of a three-repo migration: FormingWorlds/MORS#52 (MORS fetches Baraffe through fwl-io) and FormingWorlds/fwl-io#17 (drops Baraffe from the shared manifest). The three can land in any order.

- `download_stellar_tracks` verifies Baraffe via `mors.data.baraffe_data_dir` when available, else the legacy path; Spada is unchanged.
- Baraffe is hash-verified by fwl-io and has no OSF mirror, so a genuine Baraffe failure re-raises directly instead of attempting the dead fallback.

## Validation of changes

Verified `download_stellar_tracks` for Baraffe against a migrated MORS (verification follows the versioned directory; no OSF fallback), a pre-migration MORS (verification falls back to the legacy path), and a genuine failure (re-raises without an OSF attempt); Spada still lands at the legacy path and keeps its OSF fallback. Test configuration: macOS, Python 3.12; the eight `download_stellar_tracks` unit tests pass.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
