### PR TITLE
Update support email to dev@proteus-framework.org

### DIFF
--- a/docs/Community/contact.md
+++ b/docs/Community/contact.md
@@ -6,4 +6,4 @@ We encourage you to reach out! Choose the most appropriate channel below.
 |---------|---------|
 | [GitHub Discussions](https://github.com/orgs/FormingWorlds/discussions) | Questions, installation help, feature suggestions |
 | [GitHub Issues](https://github.com/FormingWorlds/PROTEUS/issues) | Bug reports, specific feature requests |
-| [proteus_dev@formingworlds.space](mailto:proteus_dev@formingworlds.space) | General enquiries |
+| [dev@proteus-framework.org](mailto:dev@proteus-framework.org) | General enquiries |

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ die() {
     echo ""
     if [ -n "${LOGFILE:-}" ] && [ -f "${LOGFILE:-}" ]; then
         echo "A full log was written to: $LOGFILE"
-        echo "If you need help, send that log file to proteus_dev@formingworlds.space,"
+        echo "If you need help, send that log file to dev@proteus-framework.org,"
         echo "or open an issue or discussion at:"
         echo "  https://github.com/FormingWorlds/PROTEUS/issues"
         echo "  https://github.com/orgs/FormingWorlds/discussions"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,7 +179,7 @@ extra:
       link: https://proteus-framework.org/
       name: PROTEUS website
     - icon: material/email
-      link: mailto:proteus_dev@formingworlds.space
+      link: mailto:dev@proteus-framework.org
       name: Mail PROTEUS developers
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/fwl-proteus/

--- a/src/proteus/doctor.py
+++ b/src/proteus/doctor.py
@@ -652,7 +652,7 @@ def run_all_checks() -> list[CheckResult]:
 
 # ─── Run logging and support prompt ──────────────────────────────────
 
-_SUPPORT_EMAIL = 'proteus_dev@formingworlds.space'
+_SUPPORT_EMAIL = 'dev@proteus-framework.org'
 _ISSUES_URL = 'https://github.com/FormingWorlds/PROTEUS/issues'
 _DISCUSSIONS_URL = 'https://github.com/orgs/FormingWorlds/discussions'
 _ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1205,7 +1205,7 @@ class TestRunLogging:
         out = capsys.readouterr().out
         # the user is told the exact file to send and where to send it
         assert str(logs[0]) in out
-        assert 'proteus_dev@formingworlds.space' in out
+        assert 'dev@proteus-framework.org' in out
         assert 'github.com/FormingWorlds/PROTEUS/issues' in out
         assert 'discussions' in out
 
@@ -1218,7 +1218,7 @@ class TestRunLogging:
         assert result is True
         assert list(tmp_path.glob('proteus_*.log')) == []
         out = capsys.readouterr().out
-        assert 'proteus_dev@formingworlds.space' not in out
+        assert 'dev@proteus-framework.org' not in out
 
     def test_doctor_json_mode_is_not_logged(self, tmp_path, monkeypatch, capsys):
         """JSON output is for scripts: no log file and no prompt, just JSON."""
@@ -1256,7 +1256,7 @@ class TestRunLogging:
         assert 'exit 7' in log_text
         out = capsys.readouterr().out
         assert str(logs[0]) in out
-        assert 'proteus_dev@formingworlds.space' in out
+        assert 'dev@proteus-framework.org' in out
 
     def test_doctor_crash_is_logged_with_traceback_and_prompt(
         self, tmp_path, monkeypatch, capsys
@@ -1275,7 +1275,7 @@ class TestRunLogging:
         # The traceback and the exception message are in the log.
         assert 'Traceback' in log_text and 'boom_xyz_123' in log_text
         captured = capsys.readouterr()
-        assert 'proteus_dev@formingworlds.space' in captured.out
+        assert 'dev@proteus-framework.org' in captured.out
         # The crash is surfaced to the user too, not buried only in the log.
         assert 'boom_xyz_123' in (captured.out + captured.err)
 
@@ -1294,7 +1294,7 @@ class TestRunLogging:
         out = capsys.readouterr().out
         # The fallback message and the support channel are both shown.
         assert 'could not be written' in out
-        assert 'proteus_dev@formingworlds.space' in out
+        assert 'dev@proteus-framework.org' in out
 
 
 class TestTee:
@@ -1393,7 +1393,7 @@ class TestSupportPromptAndCliExit:
         _print_support_prompt('doctor', log)
         out = capsys.readouterr().out
         assert str(log) in out
-        assert 'proteus_dev@formingworlds.space' in out
+        assert 'dev@proteus-framework.org' in out
         assert 'github.com/FormingWorlds/PROTEUS/issues' in out
         assert 'discussions' in out
 
@@ -1421,7 +1421,7 @@ class TestSupportPromptAndCliExit:
         # Exit code 1 specifically (a click usage error would be 2), and the
         # failure path actually ran, so the support prompt is in the output.
         assert result.exit_code == 1
-        assert 'proteus_dev@formingworlds.space' in result.output
+        assert 'dev@proteus-framework.org' in result.output
 
     def test_doctor_cli_exits_zero_when_clean(self, tmp_path, monkeypatch):
         """A clean diagnose exits zero, so a passing check does not break a
@@ -1436,4 +1436,4 @@ class TestSupportPromptAndCliExit:
             result = CliRunner().invoke(doctor_cmd, [])
         assert result.exit_code == 0
         # Discrimination: no failure exit means no support prompt was printed.
-        assert 'proteus_dev@formingworlds.space' not in result.output
+        assert 'dev@proteus-framework.org' not in result.output


### PR DESCRIPTION
## Description

Move the PROTEUS support and general-enquiries address from proteus_dev@formingworlds.space to dev@proteus-framework.org, so the contact point sits on the project's own proteus-framework.org domain. This updates the contact page, the installer help message, the doctor tool's support prompt, the site footer link, and the doctor tests that pin the support prompt content.

The old address still forwards to the new one, so nothing breaks for anyone who mails the previous address while it is retired.

## Validation of changes

Ran the doctor test suite on macOS with Python 3.12.11: all 82 tests pass. These tests pin the support address across the run-log, crash, clean-exit, JSON-mode, and fallback paths, so they exercise every surface where the doctor prints the contact prompt. Also confirmed no tracked file still references the old address.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
