### PR TITLE
Ignore local scratch dirs and pin the doctor support address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,7 @@ src/proteus/_version.py
 # Editor / IDE
 .vscode/
 .pip-cache
+
+# Local scratch directories (not part of the project)
+/.playwright-mcp/
+/platon/

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from proteus.doctor import (
+    _SUPPORT_EMAIL,
     FAIL,
     PASS,
     PYTHON_PACKAGES,
@@ -1396,6 +1397,18 @@ class TestSupportPromptAndCliExit:
         assert 'dev@proteus-framework.org' in out
         assert 'github.com/FormingWorlds/PROTEUS/issues' in out
         assert 'discussions' in out
+
+    def test_support_email_constant_is_exact_and_rendered_verbatim(self, tmp_path, capsys):
+        """The support address is pinned to its exact value, and the failure
+        prompt renders that exact constant exactly once. A stray leading or
+        trailing character, whitespace, or a duplicate copy in the constant
+        fails the equality check. The exact count also catches the address
+        being rendered more than once, which the substring checks elsewhere
+        cannot tell apart from a single occurrence."""
+        assert _SUPPORT_EMAIL == 'dev@proteus-framework.org'
+        _print_support_prompt('doctor', tmp_path / 'proteus_doctor.log')
+        out = capsys.readouterr().out
+        assert out.count(_SUPPORT_EMAIL) == 1
 
     def test_prompt_handles_a_missing_log_path(self, capsys):
         """With no log written the prompt says so and tells the user to copy the


### PR DESCRIPTION
## Description

Two small hardening changes around the recent support-email move (#769):

- Add `/.playwright-mcp/` and `/platon/` to `.gitignore`, anchored to the repo root. These are local scratch directories that sit untracked in working copies; without an ignore rule, a stray `git add -A` from the repo root could stage them, and one of them still holds an old-address snapshot from before #769. The patterns are root-anchored so they never hide a same-named directory nested deeper in the tree.
- Add a doctor test that pins `_SUPPORT_EMAIL` to its exact value and checks that the failure prompt renders that exact address exactly once. A stray character or duplicate in the constant fails the equality check; a prompt that stops printing the address, or prints it twice, fails the render check that the existing substring assertions would miss.

## Validation of changes

Ran the doctor suite on macOS with Python 3.12.11: 83 tests pass (82 previously plus the new one). `ruff check` and the repo test-quality check are clean. Confirmed `git check-ignore` matches the two directories only at the repo root (not nested), and that no tracked file is named `platon` or `.playwright-mcp`.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
