### PR TITLE
Configure the fwl logger at CLI entry points (#708)

### DIFF
--- a/src/proteus/cli.py
+++ b/src/proteus/cli.py
@@ -68,7 +68,7 @@ from proteus import __version__ as proteus_version  # noqa: E402
 from proteus.config import read_config_object  # noqa: E402
 from proteus.utils.data import download_sufficient_data  # noqa: E402
 from proteus.utils.helper import get_proteus_dir, resolve_fwl_data_dir  # noqa: E402
-from proteus.utils.logs import setup_logger  # noqa: E402
+from proteus.utils.logs import bootstrap_logger, setup_logger  # noqa: E402
 
 config_option = click.option(
     '-c',
@@ -92,7 +92,13 @@ output_option = click.option(
 @click.group()
 @click.version_option(version=proteus_version)
 def cli():
-    pass
+    # Ensure the 'fwl' logger has a handler as early as possible, before any
+    # subcommand constructs Proteus() or calls into modules that log. Without
+    # this, log records emitted before a command's own setup_logger call (e.g.
+    # from Proteus.__init__ -> set_directories, or from commands like
+    # grid-summarise / grid-pack that never call setup_logger) fall through to
+    # logging.lastResort and INFO/DEBUG messages are dropped. See issue #708.
+    bootstrap_logger()
 
 
 # ----------------

--- a/src/proteus/grid/manage.py
+++ b/src/proteus/grid/manage.py
@@ -11,7 +11,6 @@ import multiprocessing
 import os
 import shutil
 import subprocess
-import sys
 import time
 from copy import deepcopy
 from datetime import datetime
@@ -22,63 +21,11 @@ import toml
 
 from proteus.config import Config, read_config_object
 from proteus.utils.helper import get_proteus_dir, recursive_setattr
+from proteus.utils.logs import setup_logger
 
 PROTEUS_DIR = get_proteus_dir()
 
 log = logging.getLogger('fwl.' + __name__)
-
-
-# Custom logger instance
-def setup_logger(logpath: str = 'new.log', level=1, logterm=True):
-    # https://stackoverflow.com/a/61457119
-
-    custom_logger = logging.getLogger()
-    custom_logger.handlers.clear()
-
-    if os.path.exists(logpath):
-        os.remove(logpath)
-
-    fmt = logging.Formatter('[%(asctime)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-
-    level_code = logging.INFO
-    match level:
-        case 0:
-            level_code = logging.DEBUG
-        case 2:
-            level_code = logging.WARNING
-        case 3:
-            level_code = logging.ERROR
-        case 4:
-            level_code = logging.CRITICAL
-
-    # Add terminal output to logger
-    if logterm:
-        sh = logging.StreamHandler(sys.stdout)
-        sh.setFormatter(fmt)
-        sh.setLevel(level_code)
-        custom_logger.addHandler(sh)
-
-    # Add file output to logger
-    fh = logging.FileHandler(logpath)
-    fh.setFormatter(fmt)
-    fh.setLevel(level)
-    custom_logger.addHandler(fh)
-    custom_logger.setLevel(level_code)
-
-    # Capture unhandled exceptions
-    # https://stackoverflow.com/a/16993115
-    def handle_exception(exc_type, exc_value, exc_traceback):
-        if issubclass(exc_type, KeyboardInterrupt):
-            custom_logger.error('KeyboardInterrupt')
-            sys.__excepthook__(exc_type, exc_value, exc_traceback)
-            return
-        custom_logger.critical(
-            'Uncaught exception', exc_info=(exc_type, exc_value, exc_traceback)
-        )
-
-    sys.excepthook = handle_exception
-
-    return
 
 
 # Thread target
@@ -170,8 +117,15 @@ class Grid:
         # Make copy of REFERENCE config file
         shutil.copyfile(self.conf, os.path.join(self.outdir, 'ref_config.toml'))
 
-        # Setup logging
-        setup_logger(logpath=os.path.join(self.outdir, 'manager.log'), logterm=True, level=1)
+        # Setup logging. Keep the plain timestamped layout the grid manager has
+        # always written to manager.log, via the shared setup_logger.
+        setup_logger(
+            logpath=os.path.join(self.outdir, 'manager.log'),
+            logterm=True,
+            level='INFO',
+            fmt='[%(asctime)s] %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+        )
 
         log.info("Grid '%s' initialised empty" % self.name)
 

--- a/src/proteus/utils/logs.py
+++ b/src/proteus/utils/logs.py
@@ -57,6 +57,30 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+def _resolve_level(level: str) -> int:
+    """Normalise and validate a log-level string, returning its numeric code.
+
+    Shared by setup_logger and bootstrap_logger so the accepted level names and
+    the error message stay identical between the two entry points.
+    """
+    level = str(level).strip().upper()
+    if level not in ['INFO', 'DEBUG', 'ERROR', 'WARNING']:
+        raise ValueError(f'Invalid log level: {level}')
+    return logging.getLevelNamesMapping()[level]
+
+
+def _console_handler(level_code: int) -> logging.StreamHandler:
+    """Build a stdout handler using the PROTEUS colour formatter.
+
+    Shared by setup_logger and bootstrap_logger so terminal output looks the
+    same whichever installs the console handler.
+    """
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(CustomFormatter())
+    sh.setLevel(level_code)
+    return sh
+
+
 # Custom logger instance
 def setup_logger(logpath: str = 'new.log', level: str = 'INFO', logterm: bool = True):
     logger_name = 'fwl'
@@ -71,23 +95,17 @@ def setup_logger(logpath: str = 'new.log', level: str = 'INFO', logterm: bool = 
     if os.path.exists(logpath):
         os.remove(logpath)
 
-    level = str(level).strip().upper()
-    if level not in ['INFO', 'DEBUG', 'ERROR', 'WARNING']:
-        raise ValueError(f'Invalid log level: {level}')
-    level_code = logging.getLevelNamesMapping()[level]
+    level_code = _resolve_level(level)
 
     # Add terminal output to logger
     if logterm:
-        sh = logging.StreamHandler(sys.stdout)
-        sh.setFormatter(CustomFormatter())
-        sh.setLevel(level_code)
-        custom_logger.addHandler(sh)
+        custom_logger.addHandler(_console_handler(level_code))
 
     # Add file output to logger
     fh = logging.FileHandler(logpath)
     fh.setFormatter(logging.Formatter('[ %(levelname)-5s ] %(message)s'))
 
-    fh.setLevel(level)
+    fh.setLevel(level_code)
     custom_logger.addHandler(fh)
     custom_logger.setLevel(level_code)
 
@@ -142,15 +160,8 @@ def bootstrap_logger(level: str = 'INFO'):
     if custom_logger.handlers:
         return custom_logger
 
-    level = str(level).strip().upper()
-    if level not in ['INFO', 'DEBUG', 'ERROR', 'WARNING']:
-        raise ValueError(f'Invalid log level: {level}')
-    level_code = logging.getLevelNamesMapping()[level]
-
-    sh = logging.StreamHandler(sys.stdout)
-    sh.setFormatter(CustomFormatter())
-    sh.setLevel(level_code)
-    custom_logger.addHandler(sh)
+    level_code = _resolve_level(level)
+    custom_logger.addHandler(_console_handler(level_code))
     custom_logger.setLevel(level_code)
 
     return custom_logger

--- a/src/proteus/utils/logs.py
+++ b/src/proteus/utils/logs.py
@@ -107,6 +107,55 @@ def setup_logger(logpath: str = 'new.log', level: str = 'INFO', logterm: bool = 
     return custom_logger
 
 
+def bootstrap_logger(level: str = 'INFO'):
+    """Attach a console-only handler to the top-level 'fwl' logger if it has none.
+
+    ``setup_logger`` can only run once the output directory is known (it opens a
+    logfile there), but the 'fwl' logger is already used before that point --
+    e.g. by the directory-setting functions called from ``Proteus.__init__``,
+    and by CLI commands such as ``grid-summarise`` / ``grid-pack`` that never
+    call ``setup_logger`` at all. Without a handler those records fall through to
+    ``logging.lastResort``, which only emits WARNING and above, so INFO/DEBUG
+    messages are silently dropped (see issue #708).
+
+    This installs a lightweight stdout handler so those early messages reach the
+    terminal. It is idempotent and non-destructive: if the logger already has a
+    handler (e.g. from a previous ``setup_logger`` call) it does nothing, so it
+    never clobbers a fully configured file-backed logger. When a command later
+    calls ``setup_logger``, that function clears handlers and re-adds its own
+    terminal + file handlers, so there is no duplicate output.
+
+    Parameters
+    ----------
+    level : str
+        Log level for the bootstrap handler. Defaults to 'INFO', matching the
+        level at which the pre-config directory messages are emitted.
+
+    Returns
+    -------
+    logging.Logger
+        The 'fwl' logger.
+    """
+    custom_logger = logging.getLogger('fwl')
+
+    # Do not touch an already-configured logger.
+    if custom_logger.handlers:
+        return custom_logger
+
+    level = str(level).strip().upper()
+    if level not in ['INFO', 'DEBUG', 'ERROR', 'WARNING']:
+        raise ValueError(f'Invalid log level: {level}')
+    level_code = logging.getLevelNamesMapping()[level]
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(CustomFormatter())
+    sh.setLevel(level_code)
+    custom_logger.addHandler(sh)
+    custom_logger.setLevel(level_code)
+
+    return custom_logger
+
+
 def GetCurrentLogfileIndex(output_dir: str):
     """
     Get the index of the current logfile, returning -1 if none exists

--- a/src/proteus/utils/logs.py
+++ b/src/proteus/utils/logs.py
@@ -69,20 +69,49 @@ def _resolve_level(level: str) -> int:
     return logging.getLevelNamesMapping()[level]
 
 
-def _console_handler(level_code: int) -> logging.StreamHandler:
-    """Build a stdout handler using the PROTEUS colour formatter.
+def _console_handler(
+    level_code: int, formatter: logging.Formatter | None = None
+) -> logging.StreamHandler:
+    """Build a stdout handler.
 
-    Shared by setup_logger and bootstrap_logger so terminal output looks the
-    same whichever installs the console handler.
+    Uses the PROTEUS colour formatter by default; callers that want a plain,
+    logfile-style line (e.g. the grid manager) pass their own formatter. Shared
+    by setup_logger and bootstrap_logger so terminal output stays consistent
+    whichever installs the console handler.
     """
     sh = logging.StreamHandler(sys.stdout)
-    sh.setFormatter(CustomFormatter())
+    sh.setFormatter(formatter if formatter is not None else CustomFormatter())
     sh.setLevel(level_code)
     return sh
 
 
 # Custom logger instance
-def setup_logger(logpath: str = 'new.log', level: str = 'INFO', logterm: bool = True):
+def setup_logger(
+    logpath: str = 'new.log',
+    level: str = 'INFO',
+    logterm: bool = True,
+    fmt: str | None = None,
+    datefmt: str | None = None,
+):
+    """Configure the top-level 'fwl' logger with terminal and file handlers.
+
+    Parameters
+    ----------
+    logpath : str
+        Path of the logfile to (re)create.
+    level : str
+        Log level name: 'INFO', 'DEBUG', 'ERROR', or 'WARNING'.
+    logterm : bool
+        Whether to also emit to the terminal (stdout).
+    fmt : str | None
+        Optional logging format string. When given, both the terminal and file
+        handlers use a plain (uncoloured) ``logging.Formatter(fmt, datefmt)``;
+        for example the grid manager passes ``'[%(asctime)s] %(message)s'`` for a
+        clean, timestamped logfile. When None, the terminal uses the coloured
+        CustomFormatter and the file uses the '[ LEVEL ] message' layout.
+    datefmt : str | None
+        Date format for %(asctime)s, applied only when ``fmt`` is given.
+    """
     logger_name = 'fwl'
 
     # https://stackoverflow.com/a/61457119
@@ -97,13 +126,15 @@ def setup_logger(logpath: str = 'new.log', level: str = 'INFO', logterm: bool = 
 
     level_code = _resolve_level(level)
 
+    plain_formatter = logging.Formatter(fmt, datefmt=datefmt) if fmt is not None else None
+
     # Add terminal output to logger
     if logterm:
-        custom_logger.addHandler(_console_handler(level_code))
+        custom_logger.addHandler(_console_handler(level_code, plain_formatter))
 
     # Add file output to logger
     fh = logging.FileHandler(logpath)
-    fh.setFormatter(logging.Formatter('[ %(levelname)-5s ] %(message)s'))
+    fh.setFormatter(plain_formatter or logging.Formatter('[ %(levelname)-5s ] %(message)s'))
 
     fh.setLevel(level_code)
     custom_logger.addHandler(fh)

--- a/tests/grid/test_manage.py
+++ b/tests/grid/test_manage.py
@@ -2,8 +2,8 @@
 
 The grid manager is plumbing-heavy: file IO, subprocess dispatch, TOML
 parsing, and a multiprocessing-driven worker loop. The tests below cover
-the public surface (``Grid``, ``setup_logger``, ``_thread_target``,
-``grid_from_config``) with all heavy callouts mocked. Each test pins at
+the public surface (``Grid``, ``_thread_target``, ``grid_from_config``)
+with all heavy callouts mocked. Each test pins at
 least two discriminating post-state facts so that a regression which
 silently no-ops one branch cannot pass.
 
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 from unittest import mock
 
 import numpy as np
@@ -28,7 +27,6 @@ from proteus.grid.manage import (
     Grid,
     _thread_target,
     grid_from_config,
-    setup_logger,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
@@ -73,89 +71,6 @@ def grid_with_mocks(fake_proteus_dir, base_config_path, monkeypatch):
         base_config_path=str(base_config_path),
     )
     return g
-
-
-# ---------------------------------------------------------------------------
-# setup_logger
-# ---------------------------------------------------------------------------
-
-
-class TestSetupLogger:
-    """Verify the custom logger setup: file handler, level mapping,
-    pre-existing log removal, and excepthook installation.
-    """
-
-    def test_creates_log_file_and_attaches_handlers(self, tmp_path):
-        """A fresh logger writes its log to logpath and attaches at least
-        one file handler. Default level=1 maps to INFO.
-        """
-        logpath = tmp_path / 'mgr.log'
-        # Run setup, then write a record and force a flush.
-        setup_logger(logpath=str(logpath), level=1, logterm=False)
-        root = logging.getLogger()
-        root.info('hello unit-test world')
-        for h in root.handlers:
-            h.flush()
-        assert logpath.exists()
-        # File contains the message (discriminates against an empty-flush bug)
-        contents = logpath.read_text()
-        assert 'hello unit-test world' in contents
-        # Level was mapped to INFO (not DEBUG / WARNING). Verify root level.
-        assert root.level == logging.INFO
-
-    def test_pre_existing_log_is_removed(self, tmp_path):
-        """If logpath exists at entry, ``setup_logger`` deletes it before
-        re-creating; old content is gone after the call.
-        """
-        logpath = tmp_path / 'stale.log'
-        logpath.write_text('STALE_CONTENT_DO_NOT_KEEP\n')
-        setup_logger(logpath=str(logpath), level=1, logterm=False)
-        root = logging.getLogger()
-        for h in root.handlers:
-            h.flush()
-        contents = logpath.read_text()
-        # The stale content must be gone (file was deleted and recreated).
-        assert 'STALE_CONTENT_DO_NOT_KEEP' not in contents
-        # And the file must still exist (recreated by FileHandler).
-        assert logpath.exists()
-
-    @pytest.mark.parametrize(
-        'level_arg,expected_level',
-        [
-            (0, logging.DEBUG),
-            (2, logging.WARNING),
-            (3, logging.ERROR),
-            (4, logging.CRITICAL),
-        ],
-        ids=['debug', 'warning', 'error', 'critical'],
-    )
-    def test_level_mapping(self, tmp_path, level_arg, expected_level):
-        """Each numeric level argument maps to the documented logging
-        level constant. The default branch (1 -> INFO) is covered by
-        ``test_creates_log_file_and_attaches_handlers``.
-        """
-        logpath = tmp_path / f'level_{level_arg}.log'
-        setup_logger(logpath=str(logpath), level=level_arg, logterm=False)
-        root = logging.getLogger()
-        # Discriminating across all four levels: each is distinct.
-        assert root.level == expected_level
-        # File handler still present (level argument should not disable IO).
-        assert any(isinstance(h, logging.FileHandler) for h in root.handlers)
-
-    def test_excepthook_installed(self, tmp_path):
-        """``setup_logger`` replaces ``sys.excepthook`` so unhandled
-        exceptions get logged. The hook must be callable and distinct
-        from the pre-call value (default ``sys.__excepthook__``).
-        """
-        logpath = tmp_path / 'hook.log'
-        original = sys.excepthook
-        try:
-            setup_logger(logpath=str(logpath), level=1, logterm=False)
-            new_hook = sys.excepthook
-            assert callable(new_hook)
-            assert new_hook is not original
-        finally:
-            sys.excepthook = original
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -515,12 +515,24 @@ class TestBootstrapLogger:
     logging.lastResort and are dropped.
     """
 
-    def _reset_fwl(self):
-        """Return the shared 'fwl' singleton to a pristine, handler-free state."""
+    @pytest.fixture(autouse=True)
+    def pristine_fwl(self):
+        """Give each test a handler-free 'fwl' singleton and restore it after.
+
+        'fwl' is a process-wide logging singleton, so a test that installs a
+        handler would leak it into later tests and files. Snapshot the handler
+        list and level, hand each test a pristine WARNING-level logger with no
+        handlers, then restore the snapshot on teardown so no state escapes the
+        class. This is why the tests below can assert exact handler counts.
+        """
         logger = logging.getLogger('fwl')
+        saved_handlers = logger.handlers[:]
+        saved_level = logger.level
         logger.handlers.clear()
         logger.setLevel(logging.WARNING)
-        return logger
+        yield logger
+        logger.handlers[:] = saved_handlers
+        logger.setLevel(saved_level)
 
     @pytest.mark.unit
     def test_adds_single_stdout_handler_at_info(self):
@@ -530,7 +542,6 @@ class TestBootstrapLogger:
         the default INFO level matches the level of the pre-config directory
         messages the fix targets.
         """
-        self._reset_fwl()
         logger = bootstrap_logger()
         assert logger.name == 'fwl'
         stdout_handlers = [
@@ -552,7 +563,6 @@ class TestBootstrapLogger:
         CLI group callbacks and Proteus construction can both reach this code
         in one process; repeated calls must not duplicate terminal output.
         """
-        self._reset_fwl()
         bootstrap_logger()
         n_after_first = len(logging.getLogger('fwl').handlers)
         bootstrap_logger()
@@ -570,7 +580,6 @@ class TestBootstrapLogger:
         bootstrap_logger afterwards must leave that configuration untouched so a
         real run keeps logging to its proteus_XX.log file.
         """
-        self._reset_fwl()
         with tempfile.TemporaryDirectory() as tmpdir:
             logpath = os.path.join(tmpdir, 'test.log')
             setup_logger(logpath=logpath, logterm=False)
@@ -594,7 +603,6 @@ class TestBootstrapLogger:
         setup_logger clears handlers before adding its own, so the bootstrap
         console handler must not survive to double every terminal line.
         """
-        self._reset_fwl()
         bootstrap_logger()
         with tempfile.TemporaryDirectory() as tmpdir:
             logpath = os.path.join(tmpdir, 'test.log')
@@ -618,7 +626,6 @@ class TestBootstrapLogger:
         """
         import io
 
-        self._reset_fwl()
         bootstrap_logger()
         buf = io.StringIO()
         logging.getLogger('fwl').handlers[0].stream = buf
@@ -632,7 +639,6 @@ class TestBootstrapLogger:
         Mirrors setup_logger's contract so a typo in a level string fails fast
         instead of quietly falling back to INFO.
         """
-        self._reset_fwl()
         with pytest.raises(ValueError, match='Invalid log level'):
             bootstrap_logger(level='INVALID')
 

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -21,6 +21,7 @@ from proteus.utils.logs import (
     GetCurrentLogfileIndex,
     GetLogfilePath,
     StreamToLogger,
+    bootstrap_logger,
     setup_logger,
 )
 
@@ -502,6 +503,139 @@ class TestSetupLogger:
             # check but break on the first uncaught exception.
             assert callable(sys.excepthook)
             sys.excepthook = original_hook  # Restore original hook
+
+
+class TestBootstrapLogger:
+    """Test suite for bootstrap_logger early console fallback.
+
+    bootstrap_logger guarantees the 'fwl' logger has a handler at CLI entry,
+    before any command constructs Proteus() or calls setup_logger. Without it,
+    INFO/DEBUG records emitted early (e.g. from Proteus.__init__ ->
+    set_directories, or from grid-summarise / grid-pack) fall through to
+    logging.lastResort and are dropped.
+    """
+
+    def _reset_fwl(self):
+        """Return the shared 'fwl' singleton to a pristine, handler-free state."""
+        logger = logging.getLogger('fwl')
+        logger.handlers.clear()
+        logger.setLevel(logging.WARNING)
+        return logger
+
+    @pytest.mark.unit
+    def test_adds_single_stdout_handler_at_info(self):
+        """Verify a handler-free 'fwl' logger gains exactly one stdout handler.
+
+        This is the contract that keeps early INFO messages from being dropped:
+        the default INFO level matches the level of the pre-config directory
+        messages the fix targets.
+        """
+        self._reset_fwl()
+        logger = bootstrap_logger()
+        assert logger.name == 'fwl'
+        stdout_handlers = [
+            h
+            for h in logger.handlers
+            if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
+        ]
+        assert len(stdout_handlers) == 1
+        # Discrimination: level must be INFO (20), not left at the pre-existing
+        # WARNING (30). A regression that skipped setLevel would drop the very
+        # INFO messages this function exists to preserve.
+        assert logger.level == logging.INFO
+        assert stdout_handlers[0].level == logging.INFO
+
+    @pytest.mark.unit
+    def test_idempotent_no_duplicate_handler(self):
+        """A second call must not stack a second handler on the singleton.
+
+        CLI group callbacks and Proteus construction can both reach this code
+        in one process; repeated calls must not duplicate terminal output.
+        """
+        self._reset_fwl()
+        bootstrap_logger()
+        n_after_first = len(logging.getLogger('fwl').handlers)
+        bootstrap_logger()
+        assert len(logging.getLogger('fwl').handlers) == n_after_first
+        # Discrimination: pin the count to exactly one so a regression that
+        # appended on every call (rather than guarding on existing handlers)
+        # is caught rather than merely "did not grow unboundedly".
+        assert n_after_first == 1
+
+    @pytest.mark.unit
+    def test_noop_when_handler_already_present(self):
+        """bootstrap_logger must not clobber a configured file logger.
+
+        If setup_logger has already installed a file handler, calling
+        bootstrap_logger afterwards must leave that configuration untouched so a
+        real run keeps logging to its proteus_XX.log file.
+        """
+        self._reset_fwl()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logpath = os.path.join(tmpdir, 'test.log')
+            setup_logger(logpath=logpath, logterm=False)
+            handlers_before = list(logging.getLogger('fwl').handlers)
+            bootstrap_logger()
+            assert logging.getLogger('fwl').handlers == handlers_before
+            # Discrimination: the file handler must survive so file logging is
+            # unaffected. A regression that added a stdout handler anyway would
+            # change the handler list identity checked above.
+            file_handlers = [
+                h
+                for h in logging.getLogger('fwl').handlers
+                if isinstance(h, logging.FileHandler)
+            ]
+            assert len(file_handlers) == 1
+
+    @pytest.mark.unit
+    def test_setup_logger_after_bootstrap_has_no_duplicate_stdout(self):
+        """setup_logger after bootstrap yields exactly one stdout handler.
+
+        setup_logger clears handlers before adding its own, so the bootstrap
+        console handler must not survive to double every terminal line.
+        """
+        self._reset_fwl()
+        bootstrap_logger()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logpath = os.path.join(tmpdir, 'test.log')
+            setup_logger(logpath=logpath, logterm=True, level='INFO')
+            logger = logging.getLogger('fwl')
+            stdout_handlers = [
+                h
+                for h in logger.handlers
+                if type(h) is logging.StreamHandler
+                and getattr(h, 'stream', None) is sys.stdout
+            ]
+            assert len(stdout_handlers) == 1
+
+    @pytest.mark.unit
+    def test_info_record_reaches_handler(self):
+        """A child-logger INFO record is emitted, not dropped.
+
+        The fix exists so that records from 'fwl.<module>' children (e.g.
+        'fwl.proteus.utils.coupler') are handled instead of hitting
+        logging.lastResort. Route the handler to a buffer and confirm the text
+        arrives.
+        """
+        import io
+
+        self._reset_fwl()
+        bootstrap_logger()
+        buf = io.StringIO()
+        logging.getLogger('fwl').handlers[0].stream = buf
+        logging.getLogger('fwl.proteus.utils.coupler').info('Temporary-file working dir: /x')
+        assert 'Temporary-file working dir: /x' in buf.getvalue()
+
+    @pytest.mark.unit
+    def test_invalid_level_raises(self):
+        """An unrecognised level must raise rather than silently default.
+
+        Mirrors setup_logger's contract so a typo in a level string fails fast
+        instead of quietly falling back to INFO.
+        """
+        self._reset_fwl()
+        with pytest.raises(ValueError, match='Invalid log level'):
+            bootstrap_logger(level='INVALID')
 
 
 class TestGetCurrentLogfileIndex:

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -603,8 +603,7 @@ class TestBootstrapLogger:
             stdout_handlers = [
                 h
                 for h in logger.handlers
-                if type(h) is logging.StreamHandler
-                and getattr(h, 'stream', None) is sys.stdout
+                if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
             ]
             assert len(stdout_handlers) == 1
 

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -504,6 +504,58 @@ class TestSetupLogger:
             assert callable(sys.excepthook)
             sys.excepthook = original_hook  # Restore original hook
 
+    @pytest.mark.unit
+    def test_plain_fmt_writes_uncoloured_timestamped_file(self):
+        """An explicit fmt makes the file use that plain layout.
+
+        The grid manager passes a timestamped, colourless format so its
+        manager.log stays clean; verify the file carries the requested
+        timestamp layout and not the default level tag.
+        """
+        import re
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logpath = os.path.join(tmpdir, 'plain.log')
+            setup_logger(
+                logpath=logpath,
+                level='INFO',
+                logterm=False,
+                fmt='[%(asctime)s] %(message)s',
+                datefmt='%Y-%m-%d %H:%M:%S',
+            )
+            logging.getLogger('fwl').info('PLAINMARK')
+            for h in logging.getLogger('fwl').handlers:
+                h.flush()
+            contents = open(logpath).read().strip()
+        assert 'PLAINMARK' in contents
+        # The plain layout must NOT carry the default '[ LEVEL ]' tag; this
+        # discriminates the fmt path from the default-formatter path.
+        assert '[ INFO' not in contents
+        # And the line must match the requested datefmt exactly (a regression
+        # that ignored datefmt would emit the default comma-millisecond stamp).
+        assert re.match(r'^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] PLAINMARK$', contents)
+
+    @pytest.mark.unit
+    def test_default_fmt_keeps_level_tag(self):
+        """Without fmt, the file keeps the default '[ LEVEL ] message' layout.
+
+        This pins that the new fmt parameter is opt-in and does not change the
+        layout of existing (non-grid) logs.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logpath = os.path.join(tmpdir, 'tagged.log')
+            setup_logger(logpath=logpath, level='INFO', logterm=False)
+            logging.getLogger('fwl').info('TAGMARK')
+            for h in logging.getLogger('fwl').handlers:
+                h.flush()
+            contents = open(logpath).read().strip()
+        assert 'TAGMARK' in contents
+        # Default layout carries the level tag...
+        assert '[ INFO' in contents
+        # ...and must NOT look like the timestamped grid layout, so the two
+        # code paths are distinguishable.
+        assert not contents.startswith('[20')
+
 
 class TestBootstrapLogger:
     """Test suite for bootstrap_logger early console fallback.

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -526,7 +526,8 @@ class TestSetupLogger:
             logging.getLogger('fwl').info('PLAINMARK')
             for h in logging.getLogger('fwl').handlers:
                 h.flush()
-            contents = open(logpath).read().strip()
+            with open(logpath) as f:
+                contents = f.read().strip()
         assert 'PLAINMARK' in contents
         # The plain layout must NOT carry the default '[ LEVEL ]' tag; this
         # discriminates the fmt path from the default-formatter path.
@@ -548,7 +549,8 @@ class TestSetupLogger:
             logging.getLogger('fwl').info('TAGMARK')
             for h in logging.getLogger('fwl').handlers:
                 h.flush()
-            contents = open(logpath).read().strip()
+            with open(logpath) as f:
+                contents = f.read().strip()
         assert 'TAGMARK' in contents
         # Default layout carries the level tag...
         assert '[ INFO' in contents


### PR DESCRIPTION
## Description
The `fwl` logger only received handlers inside `Proteus.start()` and a few CLI commands, but records are emitted earlier: `Proteus.__init__` calls `set_directories()`, which logs at INFO, and the `grid-summarise` / `grid-pack` commands never configure logging at all. With no handler on `fwl`, those records fall through to `logging.lastResort`, which emits only WARNING and above, so INFO/DEBUG output was silently lost.

This adds `bootstrap_logger()`, which attaches a stdout handler to `fwl` only when it has none, and calls it from the top-level CLI group callback so every subcommand has console logging active before it runs. It is idempotent and non-destructive: `setup_logger()` still clears handlers and installs the file-backed logger once the output directory is known, so there is no duplicate output and file logging is unchanged.

Closes #708

### Two loggers, two purposes (note for reviewers)
`bootstrap_logger` is deliberately **not** a replacement for `setup_logger`; they play complementary roles:

- `bootstrap_logger`: the lightweight, **non-destructive** fallback installed at CLI entry. Its job is to guarantee there is at least *something* catching console output before a command knows its output directory. It no-ops if a handler already exists and never opens a logfile, so it cannot clobber a real configuration.
- `setup_logger`: the **authoritative** configuration, used once the output directory is known, both from the CLI and from the Python API. It clears handlers, installs the file-backed logger, and sets the exception hook.

`setup_logger` cannot simply be called at CLI entry in place of `bootstrap_logger` because it unconditionally opens a `FileHandler` at a path that is not known until the config is parsed inside the subcommand. The shared console-handler and level-validation code is factored into two private helpers (`_resolve_level`, `_console_handler`) so the two entry points stay consistent without duplication.

### Grid manager logging: merged into the shared setup_logger (input wanted)
Harrison, Tim: while wiring `bootstrap_logger` in, I found that `proteus grid` doubled every log line, and I would like your read on the fix.

Root cause: `grid/manage.py` had its **own** local `setup_logger` that configured the **root** logger, whereas `bootstrap_logger` and the main `setup_logger` configure the `fwl` logger. Once `bootstrap_logger` installs a handler on `fwl` at CLI entry, a grid log record (emitted on `fwl.proteus.grid.manage`) was handled by the `fwl` handler **and** propagated up to the root handler the grid installed, so it printed twice. Measured: 1 line before this PR, 2 lines with `bootstrap_logger` and the old grid function.

Fix in this PR: point the grid manager at the shared `proteus.utils.logs.setup_logger` and delete the local copy. Because the shared function clears the `fwl` handlers before installing its own, the bootstrap console handler is replaced rather than stacked, so grid logs print exactly once again (verified).

The old grid function differed from the shared one in three ways. Two are now preserved, one is a genuine behaviour change I want you to sanity-check:

- **Log format** (preserved): the grid logfile used a plain, timestamped, colourless layout `[%(asctime)s] %(message)s`. I added an optional `fmt` / `datefmt` to `setup_logger` and the grid passes that exact format, so `manager.log` is byte-for-byte the same style as before. This one looked intentional to me (clean, timestamped logs are useful), which is why I kept it rather than dropping it.
- **Level API** (preserved in effect): the local function took an int level (`1` -> INFO via a `match`); the shared one takes the string names used everywhere else. The only call site passed `1`, now `level='INFO'`.
- **Target logger** (changed): the local function configured the **root** logger, so `manager.log` also captured records from non-`fwl` (third-party) loggers. The shared function configures `fwl` only. Configuring `fwl` is what removes the double-logging and matches the rest of PROTEUS, but it does narrow what `manager.log` captures.

~~Question: were these divergences (root logger, int levels, the timestamped format) intended design choices, or incidental historical drift from before the `fwl` convention settled? In particular, does the grid rely on `manager.log` capturing root-level / third-party logs, or is narrowing to `fwl` fine? If capturing root is wanted, I will keep it on `fwl` for de-duplication but can widen capture another way.~~

✅ Resolved (verified by Harrison): not intended design choices, just historical drift from when the grid was a standalone script that predated the CLI and unified logging. Narrowing `manager.log` to `fwl` is fine; only `fwl-`named loggers need capturing, and other sources (AGNI, FastChem) are already fed into `fwl-` loggers.

## Validation of changes
- `tests/utils/test_logs.py` (49 tests) and `tests/grid/test_manage.py` (44 tests): all pass locally. The logs file adds 6 tests for `bootstrap_logger` and 2 for the new `fmt` / `datefmt` path; the grid file drops the tests for the removed local `setup_logger`.
- The `bootstrap_logger` tests use an autouse fixture that snapshots and restores the shared `fwl` singleton so logger state does not leak between tests.
- Behaviour verified directly: `bootstrap_logger` then `setup_logger` yields exactly one stdout handler (no duplicate); a grid-style `bootstrap_logger` + `setup_logger(fmt=...)` sequence prints a grid record once (the double-logging fix) in the preserved timestamped format.
- `ruff check` and `ruff format --check` pass on `src/` and `tests/` (ruff 0.15.22).
- Not run to completion: the `@pytest.mark.slow` `tests/grid/test_grid.py`. Its `test_grid_pack` fails on a missing per-case `runtime_helpfile.csv`, which is produced by the `proteus start` subprocess and is unavailable in this environment; it is unrelated to logging (the `manager.log` assertions in the same test pass, and `manager.log` has the correct timestamped format). This tier runs nightly, not in the PR checks.

Test configuration: macOS; PROTEUS conda environment (Python 3.12, the supported version).

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
