### PR TITLE
Configurable output root via PROTEUS_OUTPUT_PATH (revives #692)

### DIFF
--- a/docs/How-to/usage_running.md
+++ b/docs/How-to/usage_running.md
@@ -100,6 +100,16 @@ To make every available plot:
 proteus plot -c input/all_options.toml all
 ```
 
+## Relocating the output root
+
+By default every run is written under the `output/` folder inside your PROTEUS installation, so `params.out.path` names a subfolder of `<PROTEUS>/output/`. Set the `PROTEUS_OUTPUT_PATH` environment variable to write runs somewhere else instead, for example onto fast scratch storage on a cluster or into a shared area used by several checkouts:
+
+```console
+export PROTEUS_OUTPUT_PATH=/scratch/$USER/proteus_output
+```
+
+With that set, a run whose `params.out.path` is `trial1` lands in `/scratch/$USER/proteus_output/trial1/`, and its `data/`, `observe/`, `offchem/`, and `plots/` subfolders follow. Use an absolute path; `~` and `$VAR` references are expanded. Leaving the variable unset (or empty) keeps the default `<PROTEUS>/output/` location, so existing setups are unaffected. Only the run output moves: input files and the code tree are unchanged. When resuming or plotting a relocated run, keep the same `PROTEUS_OUTPUT_PATH` in the environment so PROTEUS looks in the right place.
+
 ## Archiving output files
 
 A simulation can generate a large number of files, which becomes a problem when running large [parameter grids](usage_grids.md). The `params.out.archive_mod` configuration option tells PROTEUS when to gather a run's output files into `.tar` archives.

--- a/src/proteus/inference/gen_D_init.py
+++ b/src/proteus/inference/gen_D_init.py
@@ -55,7 +55,7 @@ def create_init(config):
         if init_samps < 1:
             init_samps = int(config['n_workers'])
     else:
-        init_grid = os.path.join(get_proteus_directories()['proteus'], 'output', init_grid)
+        init_grid = get_proteus_directories(init_grid)['output']
         init_samps = None
 
     # create new initial guess data by sampling bounds

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -1611,6 +1611,35 @@ def remove_excess_files(outdir: str, rm_spectralfiles: bool = False):
         safe_rm(f)
 
 
+def get_output_root(root_dir: str) -> str:
+    """Resolve the root directory under which per-run output is written.
+
+    Defaults to ``<root_dir>/output``, keeping output alongside the code.
+    If the ``PROTEUS_OUTPUT_PATH`` environment variable is set to a
+    non-empty value, that path is used instead, so simulation output can be
+    relocated off the code tree (for example onto scratch storage on a
+    cluster, or to run several checkouts against a shared output area). A
+    value that is empty or only whitespace is treated as unset. User (``~``)
+    and environment-variable references in the value are expanded; an
+    absolute path is recommended, since a relative value is resolved against
+    the current working directory each time the paths are queried.
+
+    Parameters
+    ----------
+    root_dir : str
+        The PROTEUS installation root directory.
+
+    Returns
+    -------
+    str
+        The output root directory.
+    """
+    env_value = os.environ.get('PROTEUS_OUTPUT_PATH')
+    if env_value is None or not env_value.strip():
+        return os.path.join(root_dir, 'output')
+    return os.path.expanduser(os.path.expandvars(env_value))
+
+
 def get_proteus_directories(outdir='_unset') -> dict[str, str]:
     """Create dict of proteus directories from root dir.
 
@@ -1625,6 +1654,7 @@ def get_proteus_directories(outdir='_unset') -> dict[str, str]:
         Proteus directories dict
     """
     root_dir = get_proteus_dir()
+    output_root = get_output_root(root_dir)
 
     return {
         'proteus': root_dir,
@@ -1637,11 +1667,11 @@ def get_proteus_directories(outdir='_unset') -> dict[str, str]:
         'vulcan': os.path.join(root_dir, 'VULCAN'),
         'tools': os.path.join(root_dir, 'tools'),
         'utils': os.path.join(root_dir, 'src', 'proteus', 'utils'),
-        'output': os.path.join(root_dir, 'output', outdir),
-        'output/data': os.path.join(root_dir, 'output', outdir, 'data'),
-        'output/observe': os.path.join(root_dir, 'output', outdir, 'observe'),
-        'output/offchem': os.path.join(root_dir, 'output', outdir, 'offchem'),
-        'output/plots': os.path.join(root_dir, 'output', outdir, 'plots'),
+        'output': os.path.join(output_root, outdir),
+        'output/data': os.path.join(output_root, outdir, 'data'),
+        'output/observe': os.path.join(output_root, outdir, 'observe'),
+        'output/offchem': os.path.join(output_root, outdir, 'offchem'),
+        'output/plots': os.path.join(output_root, outdir, 'plots'),
     }
 
 

--- a/tests/inference/test_gen_D_init.py
+++ b/tests/inference/test_gen_D_init.py
@@ -84,11 +84,18 @@ def test_create_init_routes_to_sample_from_bounds(monkeypatch):
 @pytest.mark.unit
 def test_create_init_routes_to_sample_from_grid(monkeypatch, tmp_path):
     """``create_init`` with a non-'none' ``init_grid`` dispatches to
-    ``sample_from_grid`` and resolves the grid path via
-    ``proteus_directories.output``.
+    ``sample_from_grid`` and resolves the grid path through the output root,
+    so a relocated output root (PROTEUS_OUTPUT_PATH) is honoured rather than
+    hard-coding ``<proteus>/output``.
     """
     observed = {}
-    monkeypatch.setattr(init_mod, 'get_proteus_directories', lambda: {'proteus': str(tmp_path)})
+    # Model the output root as <tmp_path>/output; the grid name is appended to
+    # it, mirroring get_proteus_directories(outdir)['output'].
+    monkeypatch.setattr(
+        init_mod,
+        'get_proteus_directories',
+        lambda outdir: {'output': str(tmp_path / 'output' / outdir)},
+    )
 
     def fake_sample_from_grid(output, params, observables, grid_dir):
         observed['grid_dir'] = grid_dir
@@ -105,6 +112,10 @@ def test_create_init_routes_to_sample_from_grid(monkeypatch, tmp_path):
     }
 
     assert init_mod.create_init(config) == 6
+    # The grid dir is resolved through get_proteus_directories(grid)['output'],
+    # i.e. the (possibly relocated) output root joined with the grid name, not a
+    # hard-coded <proteus>/output. Pinning the full path discriminates a
+    # regression that ignored the grid name or reintroduced the hard-coded root.
     assert observed['grid_dir'] == str(tmp_path / 'output' / 'my_grid')
 
 

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -1612,6 +1612,136 @@ def test_get_proteus_directories_editable_submodule_paths():
 
 
 # ============================================================================
+# Configurable output root (PROTEUS_OUTPUT_PATH)
+# ============================================================================
+
+
+@pytest.mark.unit
+def test_get_output_root_defaults_to_output_under_root_when_env_unset(monkeypatch):
+    """With PROTEUS_OUTPUT_PATH unset, output stays at <root>/output.
+
+    This is the historical default; nothing may change for users who never
+    set the variable, so the resolved root must be exactly the ``output``
+    subdirectory of the installation root.
+    """
+    monkeypatch.delenv('PROTEUS_OUTPUT_PATH', raising=False)
+    root = '/some/proteus/root'
+    result = coupler_mod.get_output_root(root)
+    assert result == os.path.join(root, 'output')
+    # A regression that dropped the join and returned the bare root, or one
+    # that appended a doubled 'output/output', would both fail this.
+    assert os.path.basename(result) == 'output'
+    assert os.path.dirname(result) == root
+
+
+@pytest.mark.unit
+def test_get_output_root_uses_env_var_verbatim_when_set(monkeypatch):
+    """A set PROTEUS_OUTPUT_PATH overrides the default, ignoring <root>.
+
+    The override must win regardless of the installation root, and the
+    installation root must NOT appear anywhere in the resolved path: the
+    whole point is to relocate output off the code tree.
+    """
+    override = '/scratch/user/proteus_output'
+    monkeypatch.setenv('PROTEUS_OUTPUT_PATH', override)
+    root = '/opt/PROTEUS'
+    result = coupler_mod.get_output_root(root)
+    assert result == override
+    # Precedence guard: the code root must not be spliced in front of or
+    # behind the override (a naive os.path.join(root, env) bug would do this).
+    assert root not in result
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'blank',
+    ['', '   ', '\t', '\n'],
+    ids=['empty', 'spaces', 'tab', 'newline'],
+)
+def test_get_output_root_treats_blank_env_as_unset(monkeypatch, blank):
+    """An empty or whitespace-only value falls back to the default.
+
+    Edge case: shell scripts frequently export ``PROTEUS_OUTPUT_PATH=""``.
+    Honouring that literally would send all output to a path rooted at the
+    empty string (cwd), silently scattering results; it must instead behave
+    as if the variable were never set.
+    """
+    monkeypatch.setenv('PROTEUS_OUTPUT_PATH', blank)
+    root = '/opt/PROTEUS'
+    result = coupler_mod.get_output_root(root)
+    assert result == os.path.join(root, 'output')
+    # Discrimination guard: a literal-empty-string bug would yield 'output'
+    # relative to cwd (dirname == '' or cwd), not anchored at the code root.
+    assert os.path.dirname(result) == root
+
+
+@pytest.mark.unit
+def test_get_output_root_expands_user_and_env_references(monkeypatch):
+    """~ and $VAR references in the override are expanded, not left literal.
+
+    Cluster users set values like ``$TMPDIR/proteus`` or ``~/runs``; passing
+    those through unexpanded would create directories with literal ``~`` or
+    ``$TMPDIR`` names.
+    """
+    monkeypatch.setenv('HOME', '/home/tester')
+    monkeypatch.setenv('MY_SCRATCH', '/scratch/tester')
+    monkeypatch.setenv('PROTEUS_OUTPUT_PATH', '~/runs')
+    assert coupler_mod.get_output_root('/opt/PROTEUS') == '/home/tester/runs'
+    # Environment-variable reference in the value must also expand.
+    monkeypatch.setenv('PROTEUS_OUTPUT_PATH', '$MY_SCRATCH/proteus')
+    result = coupler_mod.get_output_root('/opt/PROTEUS')
+    assert result == '/scratch/tester/proteus'
+    # Guard: the raw sentinel must not survive expansion.
+    assert '$MY_SCRATCH' not in result and '~' not in result
+
+
+@pytest.mark.unit
+def test_get_proteus_directories_routes_all_output_subdirs_through_env(monkeypatch):
+    """Every output* key is rooted at PROTEUS_OUTPUT_PATH, code keys are not.
+
+    Verifies the wiring end to end: when the override is set, the run
+    directory and each of its data/observe/offchem/plots subdirectories must
+    live under the override joined with the run name, while source-tree keys
+    (proteus, input, ...) stay anchored at the installation root.
+    """
+    override = '/scratch/user/out'
+    monkeypatch.setenv('PROTEUS_OUTPUT_PATH', override)
+    dirs = get_proteus_directories(outdir='run-42')
+
+    run_dir = os.path.join(override, 'run-42')
+    assert dirs['output'] == run_dir
+    # Each subdirectory is the run dir plus its fixed leaf name; a swapped or
+    # dropped leaf (e.g. plots written under data) would fail here.
+    assert dirs['output/data'] == os.path.join(run_dir, 'data')
+    assert dirs['output/observe'] == os.path.join(run_dir, 'observe')
+    assert dirs['output/offchem'] == os.path.join(run_dir, 'offchem')
+    assert dirs['output/plots'] == os.path.join(run_dir, 'plots')
+    # Code-tree keys are unaffected by the output override.
+    assert dirs['output'].startswith(override)
+    assert not dirs['proteus'].startswith(override)
+    assert not dirs['input'].startswith(override)
+    assert dirs['input'] == os.path.join(dirs['proteus'], 'input')
+
+
+@pytest.mark.unit
+def test_get_proteus_directories_unset_env_matches_legacy_layout(monkeypatch):
+    """With the override unset, output* keys keep the <root>/output/<run> layout.
+
+    Back-compatibility contract: the presence of the new code path must not
+    perturb the default paths that existing runs and resume logic depend on.
+    """
+    monkeypatch.delenv('PROTEUS_OUTPUT_PATH', raising=False)
+    dirs = get_proteus_directories(outdir='run-legacy')
+
+    expected_root = os.path.join(dirs['proteus'], 'output')
+    assert dirs['output'] == os.path.join(expected_root, 'run-legacy')
+    assert dirs['output/data'] == os.path.join(expected_root, 'run-legacy', 'data')
+    # The run subtree is nested exactly one 'output' level under the code root,
+    # not doubled (a '<root>/output/output/<run>' regression would fail).
+    assert dirs['output'].count(os.sep + 'output' + os.sep) == 1
+
+
+# ============================================================================
 # Issue #677 mass-conservation invariant tests
 # ============================================================================
 


### PR DESCRIPTION
## Description

Lets the output root directory be set with the `PROTEUS_OUTPUT_PATH` environment variable. By default every run is still written under `<proteus>/output`; when the variable is set to a non-empty value, that path is used as the output root instead, so simulation results can live off the code tree (cluster scratch storage, or a shared output area used by several checkouts). Leaving the variable unset (or empty) keeps the previous behaviour exactly.

This revives #692, which added the same `PROTEUS_OUTPUT_PATH` override but was closed as stale pending tests and documentation. Both are included here.

What changed:
- New helper `get_output_root(root_dir)` in `utils/coupler.py` resolves the root: `<root>/output` when unset, otherwise the env value. Empty or whitespace-only values are treated as unset (this avoids sending output to a path rooted at the empty string), and `~` and `$VAR` references are expanded.
- `get_proteus_directories` routes the `output` and `output/*` keys through that root, so every per-run subdirectory (`data`, `observe`, `offchem`, `plots`) follows it. Source-tree keys (`proteus`, `input`, submodule paths) are unaffected.
- `inference/gen_D_init.py` resolved the init-grid path from a hard-coded `<proteus>/output`; it now goes through the same output root, matching the idiom already used elsewhere in that file, so init grids are found under a relocated root too.
- Usage docs gain a short "Relocating the output root" section.

Naming: the variable is `PROTEUS_OUTPUT_PATH`, keeping the name from #692.

## Validation of changes

Tested on macOS with Python 3.12.

- Unit tests for `get_output_root` (unset default, set override, blank/whitespace fallback, `~` and `$VAR` expansion) and for `get_proteus_directories` (all output subdirs routed through the override; code-tree keys unaffected; unset case matches the legacy `<root>/output/<run>` layout). `tests/utils/test_coupler.py`: 124 passed.
- Updated `tests/inference/test_gen_D_init.py::test_create_init_routes_to_sample_from_grid` to pin the grid path through the output root: passes.
- `ruff check` and `ruff format --check` clean on the changed files; `tools/check_test_quality.py --check` reports no new violations; `tools/validate_test_structure.sh` passes.
- Not run locally: `smoke`/`integration`/`slow` tiers and a full end-to-end run, which need the compiled binaries (SOCRATES, AGNI, SPIDER) and full data. One pre-existing failure in `tests/inference/test_gen_D_init.py::test_sample_from_grid_builds_and_saves_dataset` reproduces on an unmodified `main` in this environment (a local NumPy/torch mismatch) and is unrelated to this change.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
