### PR TITLE
Fix doctor update hints for tag-pinned modules on a detached HEAD

### DIFF
--- a/docs/How-to/doctor.md
+++ b/docs/How-to/doctor.md
@@ -152,7 +152,8 @@ This lists the fixable issues and their commands but does not execute anything.
 | Issue | Fix action |
 |-------|-----------|
 | Missing Python package | `pip install <name>` |
-| Outdated Python package (editable) | `cd <checkout> && git pull && pip install -e .` |
+| Outdated Python package (editable, tag-pinned: aragog, zalmoxis) | `bash tools/get_<name>.sh` |
+| Outdated Python package (editable, tracking branch) | `cd <checkout> && git pull && pip install -e .` |
 | Outdated Python package (wheel) | `pip install -U "<name>>=<version>"` |
 | Missing AGNI | `bash tools/get_agni.sh` |
 | AGNI commit drift from pin | `bash tools/get_agni.sh` |
@@ -225,8 +226,11 @@ proteus update
 ```
 
 This updates any submodules whose installed version no longer satisfies the
-new bounds. For editable checkouts, it runs `git pull && pip install -e .` in
-each checkout directory.
+new bounds. For editable checkouts installed by a `tools/get_<name>.sh` script
+(aragog, zalmoxis), it re-runs that script, which fetches and checks out the
+pinned version tag; those checkouts sit on a detached HEAD where `git pull`
+would fail. For editable checkouts on a tracking branch, it runs
+`git pull && pip install -e .` in the checkout directory.
 
 ### Before submitting a simulation
 

--- a/docs/How-to/update_module_pins.md
+++ b/docs/How-to/update_module_pins.md
@@ -120,8 +120,12 @@ proteus update          # pulls the new release into the active environment
 proteus doctor          # fwl-calliope now reports ok
 ```
 
-For an editable checkout, `proteus update` runs `git pull && pip install -e .`
-in the CALLIOPE checkout instead of fetching a wheel.
+For an editable checkout on a tracking branch (such as CALLIOPE), `proteus
+update` runs `git pull && pip install -e .` in the checkout instead of fetching
+a wheel. Packages installed by a `tools/get_<name>.sh` script (aragog,
+zalmoxis) are pinned to a version tag and so sit on a detached HEAD, where
+`git pull` cannot advance; for those `proteus update` re-runs the setup script,
+which fetches and checks out the tag matching the new floor.
 
 ### Case 2: move a git module to a new commit
 

--- a/src/proteus/doctor.py
+++ b/src/proteus/doctor.py
@@ -135,6 +135,32 @@ def _dependency_specs() -> dict[str, Requirement | None]:
     return result
 
 
+def _get_script_for_package(dist_name: str) -> str | None:
+    """Return the ``tools/get_<name>.sh`` setup script for an FWL package.
+
+    Some FWL packages (aragog, zalmoxis, vulcan, boreas) are installed as
+    editable siblings by a dedicated ``tools/get_<name>.sh`` script that checks
+    the clone out to the pinned version tag, i.e. a detached HEAD. On a detached
+    HEAD ``git pull`` has no upstream to advance and fails, so the update must
+    re-fetch and re-checkout the tag the way the installer does.
+    Re-running the setup script is exactly that path (it reads the version floor
+    from ``pyproject.toml`` and checks out ``tags/<floor>``), so it is the
+    correct fix for those packages.
+
+    Returns the repo-relative script path when it exists, else None. Packages
+    without a setup script are cloned on a tracking branch, where a plain
+    ``git pull`` is the right update, so None signals that fallback.
+    """
+    short = dist_name.lower()
+    prefix = 'fwl-'
+    if short.startswith(prefix):
+        short = short[len(prefix) :]
+    script_rel = f'tools/get_{short}.sh'
+    if (_repo_root() / script_rel).is_file():
+        return script_rel
+    return None
+
+
 def _editable_checkout_path(dist_name: str) -> str | None:
     """Return the local path of an editable install, or None."""
     try:
@@ -429,7 +455,17 @@ def check_python_package(name: str, spec: Requirement | None) -> CheckResult:
         if not spec.specifier.contains(installed, prereleases=True):
             fix = f'pip install -U "{spec}"'
             if checkout:
-                fix = f'cd {shlex.quote(checkout)} && git pull && pip install -e .'
+                # An editable checkout installed by a tools/get_<name>.sh script
+                # sits on a detached HEAD (pinned to the version tag), where
+                # `git pull` fails. Re-run the setup script, which fetches and
+                # re-checks-out the pinned tag exactly as the installer does.
+                # Packages without such a script are on a tracking branch, so
+                # the plain `git pull` update applies.
+                script = _get_script_for_package(name)
+                if script:
+                    fix = f'bash {script}'
+                else:
+                    fix = f'cd {shlex.quote(checkout)} && git pull && pip install -e .'
             return CheckResult(
                 name=name,
                 category='versions',

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -609,6 +609,18 @@ class TestGetScriptForPackage:
         the helper must not depend on that)."""
         assert _get_script_for_package('FWL-Zalmoxis') == 'tools/get_zalmoxis.sh'
 
+    def test_name_without_fwl_prefix_is_used_verbatim(self):
+        """The fwl- strip is conditional: a name lacking the prefix is looked up
+        as-is, not mangled. 'aragog' resolves to the same script as
+        'fwl-aragog', while a prefixless name with no script is still None."""
+        # Prefix absent, so no strip happens; the bare stem is used directly.
+        assert _get_script_for_package('aragog') == 'tools/get_aragog.sh'
+        # Discrimination: the with- and without-prefix forms agree, confirming
+        # the strip only removes a leading 'fwl-' and never truncates the stem.
+        assert _get_script_for_package('aragog') == _get_script_for_package('fwl-aragog')
+        # A prefixless name with no matching script returns None, not a path.
+        assert _get_script_for_package('calliope') is None
+
     def test_returns_none_for_branch_tracking_package(self):
         """calliope has no setup script (it is cloned on a tracking branch), so
         the helper returns None and the caller falls back to git pull."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -29,6 +29,7 @@ from proteus.doctor import (
     _collect_environment_info,
     _conda_build_lines,
     _editable_checkout_path,
+    _get_script_for_package,
     _git_dirty,
     _git_head,
     _git_short_head,
@@ -262,6 +263,72 @@ class TestCheckPythonPackage:
                 r = check_python_package('fwl-aragog', spec)
         assert r.status == FAIL
         assert 'requires' in r.message
+
+    def test_below_spec_editable_tag_module_fix_reruns_setup_script(self):
+        """A tag-pinned editable checkout (aragog, zalmoxis) sits on a detached
+        HEAD, so the fix must re-run tools/get_<name>.sh, not `git pull`, which
+        cannot advance a detached HEAD. This is the issue #779 regression."""
+        from packaging.requirements import Requirement
+
+        spec = Requirement('fwl-zalmoxis>=26.07.17')
+        with (
+            patch('proteus.doctor.importlib.metadata.version', return_value='26.5.13'),
+            patch(
+                'proteus.doctor._editable_checkout_path',
+                return_value='/home/u/PROTEUS/Zalmoxis',
+            ),
+            patch('proteus.doctor._git_short_head', return_value='c0b8412'),
+            patch('proteus.doctor._git_dirty', return_value=False),
+            patch('proteus.doctor._imported_package_dir', return_value=None),
+        ):
+            r = check_python_package('fwl-zalmoxis', spec)
+        assert r.status == FAIL
+        # The setup script re-fetches and re-checks-out the pinned tag.
+        assert r.fix_cmd == 'bash tools/get_zalmoxis.sh'
+        # The broken advice must be gone: `git pull` fails on a detached HEAD.
+        assert 'git pull' not in r.fix_cmd
+
+    def test_below_spec_editable_branch_module_fix_keeps_git_pull(self):
+        """A package without a tools/get_<name>.sh script (calliope) is cloned on
+        a tracking branch, where `git pull && pip install -e .` is the correct
+        update. The detached-HEAD path must not swallow this case."""
+        from packaging.requirements import Requirement
+
+        spec = Requirement('fwl-calliope>=99.0.0')
+        with (
+            patch('proteus.doctor.importlib.metadata.version', return_value='26.6.1'),
+            patch(
+                'proteus.doctor._editable_checkout_path',
+                return_value='/home/u/PROTEUS/CALLIOPE',
+            ),
+            patch('proteus.doctor._git_short_head', return_value='1e3ad73'),
+            patch('proteus.doctor._git_dirty', return_value=False),
+            patch('proteus.doctor._imported_package_dir', return_value=None),
+        ):
+            r = check_python_package('fwl-calliope', spec)
+        assert r.status == FAIL
+        assert 'git pull' in r.fix_cmd
+        assert 'pip install -e .' in r.fix_cmd
+        # The checkout path is quoted into the cd target, not replaced by a script.
+        assert 'CALLIOPE' in r.fix_cmd
+        assert not r.fix_cmd.startswith('bash tools/get_')
+
+    def test_below_spec_wheel_install_fix_upgrades_via_pip(self):
+        """With no editable checkout (a wheel install), neither branch applies:
+        the fix upgrades from PyPI against the version bound."""
+        from packaging.requirements import Requirement
+
+        spec = Requirement('fwl-aragog>=26.07.04')
+        with (
+            patch('proteus.doctor.importlib.metadata.version', return_value='26.5.13'),
+            patch('proteus.doctor._editable_checkout_path', return_value=None),
+        ):
+            r = check_python_package('fwl-aragog', spec)
+        assert r.status == FAIL
+        assert r.fix_cmd.startswith('pip install -U')
+        # No git operation is offered when there is no checkout to operate on.
+        assert 'git pull' not in r.fix_cmd
+        assert 'get_aragog.sh' not in r.fix_cmd
 
     def test_pass_when_editable_dev_version_above_bound(self):
         """A setuptools-scm dev version a few commits past the tagged release
@@ -516,6 +583,40 @@ class TestEditableCheckoutPath:
         # Discrimination: malformed JSON is swallowed (returns None) only
         # after the helper read and tried to parse direct_url.json.
         assert dist.read_text.call_count == 1
+
+
+class TestGetScriptForPackage:
+    """Mapping from an FWL package to its tools/get_<name>.sh setup script.
+
+    The mapping decides whether `proteus doctor`/`update` offers a `git pull`
+    (tracking-branch checkout) or a re-run of the setup script (tag-pinned,
+    detached-HEAD checkout). See issue #779.
+    """
+
+    def test_returns_script_for_tag_pinned_packages(self):
+        """aragog and zalmoxis are installed by a setup script that pins to a
+        version tag; the helper resolves each to its real script path."""
+        # These scripts exist in the repo, so the helper returns the path.
+        assert _get_script_for_package('fwl-aragog') == 'tools/get_aragog.sh'
+        assert _get_script_for_package('fwl-zalmoxis') == 'tools/get_zalmoxis.sh'
+        # The fwl- prefix is stripped: the script is get_aragog.sh, not
+        # get_fwl-aragog.sh.
+        assert 'fwl-' not in _get_script_for_package('fwl-aragog')
+
+    def test_case_insensitive_prefix_strip(self):
+        """The distribution name is lowercased before the script lookup, so a
+        mixed-case name still resolves (dist names are normally lowercase, but
+        the helper must not depend on that)."""
+        assert _get_script_for_package('FWL-Zalmoxis') == 'tools/get_zalmoxis.sh'
+
+    def test_returns_none_for_branch_tracking_package(self):
+        """calliope has no setup script (it is cloned on a tracking branch), so
+        the helper returns None and the caller falls back to git pull."""
+        # No tools/get_calliope.sh exists, so None signals the git-pull path.
+        assert _get_script_for_package('fwl-calliope') is None
+        # A package name that maps to no script at all is also None, not a
+        # path to a nonexistent file.
+        assert _get_script_for_package('fwl-not-a-real-package') is None
 
 
 class TestRunAllChecks:


### PR DESCRIPTION
## Description

`proteus doctor` and `proteus update` suggested `cd <checkout> && git pull && pip install -e .` to update an outdated editable module. For modules installed by a `tools/get_<name>.sh` script (aragog, zalmoxis), that script checks the clone out to the pinned version tag, leaving it on a detached HEAD, where `git pull` has no upstream to advance and fails. The hint (and the `proteus update` implementation that runs it) therefore could not fix those two modules.

The fix routes those packages to `bash tools/get_<name>.sh`, which fetches and checks out the tag matching the version floor, exactly as `install.sh` does. Modules cloned on a tracking branch (calliope, janus, mors, zephyrus) keep the `git pull && pip install -e .` update, and wheel installs keep `pip install -U`.

A new helper `_get_script_for_package()` decides which path applies by checking whether a matching `tools/get_<name>.sh` exists. Docs updated in `doctor.md` and `update_module_pins.md`.

closes #779

## Validation of changes

Reproduced the issue scenario from the bug report: with aragog and zalmoxis below their floors as editable checkouts, the fix hint is now `bash tools/get_aragog.sh` / `bash tools/get_zalmoxis.sh`, and `git pull` no longer appears. Confirmed `install.sh` invokes those same two commands, so the hint routes to the canonical install path.

Added unit tests covering the tag-pinned (setup-script) path, the tracking-branch (`git pull`) fallback, the wheel (`pip install -U`) path, and the `_get_script_for_package` mapping including the prefixless lookup branch. Full `tests/test_doctor.py` passes (90 tests); `ruff check` and `ruff format --check` clean; test-structure check passes.

Not verified end to end: the `get_*.sh` re-clone was not run against a live detached checkout in this environment (needs network and a real clone). That path rests on the script's own `git checkout tags/<floor>` logic and on `install.sh` using the identical command.

Test configuration: macOS, Python 3.12, conda `proteus` environment.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
