### PR TITLE
Move the Bayesian-optimisation stack into an optional extra

### DIFF
--- a/.github/.claude/rules/proteus-tests.md
+++ b/.github/.claude/rules/proteus-tests.md
@@ -188,7 +188,7 @@ pytest.importorskip('boreas')
 
 Optional deps that have hit this trap on `tl/interior-refactor`: `hypothesis` (three times), `boreas`, `atmodeller`, `lovepy`, `mors`, `vulcan`, `zalmoxis` (when not installed via editable).
 
-The lint script (`tools/check_test_quality.py`) enforces this. Rule key `missing_importorskip`: any module-top `import <optional_dep>` or `from <optional_dep> import ...` that is not preceded by a module-scope `pytest.importorskip('<optional_dep>')` is flagged. The check covers `hypothesis`, `boreas`, `atmodeller`, `lovepy`, `mors`, `vulcan`, `zalmoxis`.
+The lint script (`tools/check_test_quality.py`) enforces this. Rule key `missing_importorskip`: any module-top `import <optional_dep>` or `from <optional_dep> import ...` that is not preceded by a module-scope `pytest.importorskip('<optional_dep>')` is flagged. The check covers `hypothesis`, `boreas`, `atmodeller`, `lovepy`, `mors`, `vulcan`, `zalmoxis`, `torch`, `botorch`, `gpytorch`.
 
 ---
 

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -457,10 +457,11 @@ runs:
       run: |
         set -euo pipefail
         python -m pip install --upgrade pip
-        # Install the optional vulcan + atmodeller backends alongside the
-        # develop extras so their tests run in CI rather than skip. They
-        # are optional for end users (a standard run uses calliope).
-        pip install -e ".[develop,vulcan,atmodeller]"
+        # Install the optional vulcan + atmodeller backends and the
+        # inference extra alongside the develop extras so their tests run
+        # in CI rather than skip. All three are optional for end users (a
+        # standard run uses calliope and no Bayesian optimisation).
+        pip install -e ".[develop,vulcan,atmodeller,inference]"
 
     # ------------------------------------------------------------------
     # 8b. Paired-branch submodules (aragog, Zalmoxis). When PROTEUS is on a

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -402,7 +402,7 @@ The new markers are registered in `pyproject.toml`. They do not gate CI by thems
 
 ### Optional-dependency imports
 
-Any test that imports an optional dependency (`hypothesis`, `boreas`, `atmodeller`, `lovepy`, `mors`, `vulcan`, also `zalmoxis` when not installed via editable) MUST call `pytest.importorskip('<dep>')` at module top. The PR Docker image is built with `pip install --no-deps`; tests that import optional deps unconditionally will fail to collect on CI even though they run locally. This trap has recurred multiple times and is now lint-enforced.
+Any test that imports an optional dependency (`hypothesis`, `boreas`, `atmodeller`, `lovepy`, `mors`, `vulcan`, the `inference` extra's `torch` / `botorch` / `gpytorch`, also `zalmoxis` when not installed via editable) MUST call `pytest.importorskip('<dep>')` at module top. The PR Docker image is built with `pip install --no-deps`; tests that import optional deps unconditionally will fail to collect on CI even though they run locally. This trap has recurred multiple times and is now lint-enforced.
 
 ### Module-level constants and `monkeypatch`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -597,9 +597,10 @@ Do not introduce a new in-repo "memory" or "decisions log" file. The four channe
 ## Quick Reference
 
 ```bash
-# Setup
+# Setup ("[develop]" alone leaves the optional backends and the inference
+# stack out, and their tests then skip; the extras below match CI)
 conda activate proteus
-pip install -e ".[develop]"
+pip install -e ".[develop,vulcan,atmodeller,inference]"
 
 # Test
 pytest -m unit

--- a/docs/How-to/inference.md
+++ b/docs/How-to/inference.md
@@ -2,6 +2,16 @@
 
 This project implements parallel-asynchronous Bayesian Optimization (BO) for parameter inference using PROTEUS as the  'simulator'. It uses multiple workers to efficiently explore the parameter space and find optimal matches between simulated and observed planetary characteristics. You can also run this BO inference scheme to refine the results of a grid.
 
+!!! info "Requires the `inference` extra"
+    The scheme is built on PyTorch, BoTorch and GPyTorch, which install
+    separately from the rest of PROTEUS:
+
+    ```console
+    pip install "fwl-proteus[inference]"
+    ```
+
+    See [optional modules](optionalmodules_installation.md#parameter-inference-bayesian-optimisation).
+
 ## Overview
 
 The system performs Bayesian optimization to infer planetary formation parameters by:

--- a/docs/How-to/manual_installation.md
+++ b/docs/How-to/manual_installation.md
@@ -264,6 +264,13 @@ bash tools/get_zalmoxis.sh
 python -m pip install -e ".[develop]"
 ```
 
+The optional backends and the parameter-inference stack are not part of this
+install, and their tests skip without them. To match what CI runs:
+
+```console
+python -m pip install -e ".[develop,vulcan,atmodeller,inference]"
+```
+
 ## 9. Enable pre-commit hooks
 
 ```console

--- a/docs/How-to/optionalmodules_installation.md
+++ b/docs/How-to/optionalmodules_installation.md
@@ -69,6 +69,21 @@ pip install "fwl-proteus[atmodeller]"
     atmodeller is distributed under the GPL-3.0 license; review its terms
     before installing.
 
+## Parameter inference (Bayesian optimisation)
+
+`proteus infer` runs the Bayesian-optimisation scheme, which is built on
+PyTorch, BoTorch and GPyTorch. Those three are a several-hundred-megabyte
+install that nothing else in PROTEUS uses, so a forward model or a
+`proteus grid` sweep does not need them:
+
+```console
+pip install "fwl-proteus[inference]"
+```
+
+Without the extra, `proteus infer` stops with a message naming the missing
+package; every other command is unaffected. See the
+[inference guide](inference.md) for how to configure a run.
+
 ## Atmospheric chemistry (VULCAN)
 
 VULCAN is an optional atmospheric-photochemistry backend, selected with

--- a/docs/How-to/optionalmodules_installation.md
+++ b/docs/How-to/optionalmodules_installation.md
@@ -80,6 +80,15 @@ install that nothing else in PROTEUS uses, so a forward model or a
 pip install "fwl-proteus[inference]"
 ```
 
+On Linux the default PyTorch wheel also pulls in the CUDA runtime packages.
+The scheme runs on CPU, so install PyTorch from its CPU index first if you do
+not want them:
+
+```console
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install "fwl-proteus[inference]"
+```
+
 Without the extra, `proteus infer` stops with a message naming the missing
 package; every other command is unaffected. See the
 [inference guide](inference.md) for how to configure a run.

--- a/docs/How-to/testing.md
+++ b/docs/How-to/testing.md
@@ -18,6 +18,14 @@ pytest --cov=src --cov-report=html      # Generate coverage report
 open htmlcov/index.html                 # View coverage in browser
 ```
 
+Tests covering an optional backend skip when that backend is absent, so
+`[develop]` alone runs fewer tests than CI does. To match the CI selection
+locally, install the optional extras as well:
+
+```bash
+pip install -e ".[develop,vulcan,atmodeller,inference]"
+```
+
 Before committing:
 
 1. `pytest -m "unit and not skip and not slow and not integration"` must pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ dependencies = [
     "ruff",
     "sympy",
     "astropy",
-    "torch",
-    "botorch",
-    "gpytorch",
     "toml",
     # 26.7.25 bounds the time a fetch can take: every request carries an
     # explicit connect and read timeout, and a transient failure is retried
@@ -122,6 +119,18 @@ atmodeller = ["atmodeller>=1.0.2"]
 # atmos_chem.module = "vulcan". Also installable editable via
 # tools/get_vulcan.sh.
 vulcan = ["fwl-vulcan>=26.04.22"]
+
+# inference: the Bayesian-optimisation parameter inference run by
+# `proteus infer`. PyTorch and the two BoTorch/GPyTorch layers on top of
+# it are a several-hundred-megabyte dependency stack (larger on Linux,
+# where torch also pulls in the CUDA runtime packages) that nothing else
+# in the package imports, so a forward model or a grid does not pull them
+# in. Install on demand, e.g. `pip install "fwl-proteus[inference]"`.
+inference = [
+    "torch",
+    "botorch",
+    "gpytorch",
+]
 
 develop = [
     # coverage[toml] enables standalone coverage tool with TOML config support (used by ratcheting script)

--- a/src/proteus/cli.py
+++ b/src/proteus/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 from difflib import get_close_matches
@@ -687,9 +688,47 @@ def grid(config_path: Path, dry_run: bool):
 
 
 # Distributions that only the inference scheme needs, shipped as the
-# `inference` extra. Used to tell a missing extra apart from a genuine
-# import error inside the inference package.
+# `inference` extra. `[project.optional-dependencies].inference` in
+# pyproject.toml is the authority; a test pins the two together.
 INFERENCE_DISTRIBUTIONS = ('torch', 'botorch', 'gpytorch')
+
+
+def _absent_inference_distribution(exc: ImportError) -> str | None:
+    """Name the inference distribution whose absence raised ``exc``.
+
+    Parameters
+    ----------
+    exc : ImportError
+        Error raised while importing the inference entry point.
+
+    Returns
+    -------
+    str or None
+        The missing distribution, or None when the error came from anything
+        else: a failure inside a package that is present, an unrelated
+        module, or one of the three sitting installed but failing to import
+        one of its own submodules.
+
+    Notes
+    -----
+    Absence is confirmed against the import system instead of being inferred
+    from the error alone, so the advice to install the extra is never given
+    for a package that is already in the environment.
+    """
+    if not isinstance(exc, ModuleNotFoundError):
+        # The module was found and something inside it failed: a version
+        # mismatch or a broken install, not a missing extra.
+        return None
+    root = (exc.name or '').split('.')[0]
+    if root not in INFERENCE_DISTRIBUTIONS:
+        return None
+    try:
+        if importlib.util.find_spec(root) is not None:
+            return None
+    except (ImportError, ValueError):
+        # Present but unusable: a broken install, not a missing extra.
+        return None
+    return root
 
 
 @click.command()
@@ -699,8 +738,8 @@ def infer(config_path: Path):
     try:
         from proteus.inference.inference import infer_from_config
     except ImportError as exc:
-        missing = (exc.name or '').split('.')[0]
-        if missing not in INFERENCE_DISTRIBUTIONS:
+        missing = _absent_inference_distribution(exc)
+        if missing is None:
             raise
         raise click.ClickException(
             f"Parameter inference needs '{missing}', which is not installed. "

--- a/src/proteus/cli.py
+++ b/src/proteus/cli.py
@@ -686,11 +686,27 @@ def grid(config_path: Path, dry_run: bool):
     grid_from_config(config_path, test_run=dry_run)
 
 
+# Distributions that only the inference scheme needs, shipped as the
+# `inference` extra. Used to tell a missing extra apart from a genuine
+# import error inside the inference package.
+INFERENCE_DISTRIBUTIONS = ('torch', 'botorch', 'gpytorch')
+
+
 @click.command()
 @config_option
 def infer(config_path: Path):
     """Use Bayesian optimisation to infer parameters from observables"""
-    from proteus.inference.inference import infer_from_config
+    try:
+        from proteus.inference.inference import infer_from_config
+    except ImportError as exc:
+        missing = (exc.name or '').split('.')[0]
+        if missing not in INFERENCE_DISTRIBUTIONS:
+            raise
+        raise click.ClickException(
+            f"Parameter inference needs '{missing}', which is not installed. "
+            'The optimisation stack ships as an optional extra: '
+            'pip install "fwl-proteus[inference]"'
+        ) from exc
 
     infer_from_config(config_path)
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 import numpy as np
 
-# ensure juliacall is imported before torch
+# juliacall has to load before torch does. Nothing here imports torch, but the
+# inference scheme brings it into the same process later, and the two clash if
+# torch wins the race.
 # see issue here: https://github.com/pytorch/pytorch/issues/78829
 from juliacall import Main  # noqa: F401
 

--- a/tests/inference/test_async_bo.py
+++ b/tests/inference/test_async_bo.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.async_BO as async_mod  # noqa: E402
 

--- a/tests/inference/test_async_bo.py
+++ b/tests/inference/test_async_bo.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
-import torch
 
-import proteus.inference.async_BO as async_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
+
+import proteus.inference.async_BO as async_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_bo.py
+++ b/tests/inference/test_bo.py
@@ -21,11 +21,13 @@ References:
 from __future__ import annotations
 
 import pytest
-import torch
 
-import proteus.inference.BO as bo_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
 
-from ._bo_helpers import make_quadratic_objective
+import proteus.inference.BO as bo_mod  # noqa: E402
+
+from ._bo_helpers import make_quadratic_objective  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_bo.py
+++ b/tests/inference/test_bo.py
@@ -22,8 +22,12 @@ from __future__ import annotations
 
 import pytest
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.BO as bo_mod  # noqa: E402
 

--- a/tests/inference/test_bo_convergence.py
+++ b/tests/inference/test_bo_convergence.py
@@ -24,8 +24,11 @@ import threading
 import numpy as np
 import pytest
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('gpytorch')
 pytest.importorskip('botorch')
 
 from botorch.exceptions.warnings import OptimizationWarning  # noqa: E402

--- a/tests/inference/test_bo_convergence.py
+++ b/tests/inference/test_bo_convergence.py
@@ -23,13 +23,17 @@ import threading
 
 import numpy as np
 import pytest
-import torch
-from botorch.exceptions.warnings import OptimizationWarning
 
-from proteus.inference import BO as bo_mod
-from proteus.inference.utils import get_kernel_w_prior
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
 
-from ._bo_helpers import make_quadratic_objective
+from botorch.exceptions.warnings import OptimizationWarning  # noqa: E402
+
+from proteus.inference import BO as bo_mod  # noqa: E402
+from proteus.inference.utils import get_kernel_w_prior  # noqa: E402
+
+from ._bo_helpers import make_quadratic_objective  # noqa: E402
 
 pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]
 

--- a/tests/inference/test_gen_D_init.py
+++ b/tests/inference/test_gen_D_init.py
@@ -12,9 +12,11 @@ import numpy as np
 import pandas as pd
 import pytest
 import toml
-import torch
 
-import proteus.inference.gen_D_init as init_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
+
+import proteus.inference.gen_D_init as init_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_gen_D_init.py
+++ b/tests/inference/test_gen_D_init.py
@@ -13,8 +13,12 @@ import pandas as pd
 import pytest
 import toml
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.gen_D_init as init_mod  # noqa: E402
 

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -14,8 +14,12 @@ import multiprocessing as mp
 import pytest
 import toml
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.inference as inference_mod  # noqa: E402
 

--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -14,7 +14,10 @@ import multiprocessing as mp
 import pytest
 import toml
 
-import proteus.inference.inference as inference_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+pytest.importorskip('torch')
+
+import proteus.inference.inference as inference_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_inference_slow.py
+++ b/tests/inference/test_inference_slow.py
@@ -31,6 +31,9 @@ import pandas as pd
 import pytest
 from helpers import PROTEUS_ROOT
 
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+pytest.importorskip('torch')
+
 from proteus.inference.inference import infer_from_config
 
 pytestmark = [pytest.mark.slow, pytest.mark.timeout(3600)]

--- a/tests/inference/test_inference_slow.py
+++ b/tests/inference/test_inference_slow.py
@@ -31,8 +31,12 @@ import pandas as pd
 import pytest
 from helpers import PROTEUS_ROOT
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 from proteus.inference.inference import infer_from_config
 

--- a/tests/inference/test_objective.py
+++ b/tests/inference/test_objective.py
@@ -14,8 +14,12 @@ import pandas as pd
 import pytest
 import toml
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.objective as objective_mod  # noqa: E402
 

--- a/tests/inference/test_objective.py
+++ b/tests/inference/test_objective.py
@@ -13,9 +13,11 @@ import subprocess
 import pandas as pd
 import pytest
 import toml
-import torch
 
-import proteus.inference.objective as objective_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
+
+import proteus.inference.objective as objective_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_plot.py
+++ b/tests/inference/test_plot.py
@@ -31,8 +31,11 @@ import pandas as pd
 import pytest
 import toml
 
-import proteus.inference.plot as plot_mod
-import proteus.inference.transforms as transforms_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+pytest.importorskip('torch')
+
+import proteus.inference.plot as plot_mod  # noqa: E402
+import proteus.inference.transforms as transforms_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_plot.py
+++ b/tests/inference/test_plot.py
@@ -31,8 +31,12 @@ import pandas as pd
 import pytest
 import toml
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.plot as plot_mod  # noqa: E402
 import proteus.inference.transforms as transforms_mod  # noqa: E402

--- a/tests/inference/test_transforms.py
+++ b/tests/inference/test_transforms.py
@@ -22,8 +22,12 @@ from __future__ import annotations
 
 import pytest
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.transforms as tr_mod  # noqa: E402
 

--- a/tests/inference/test_transforms.py
+++ b/tests/inference/test_transforms.py
@@ -21,9 +21,11 @@ References:
 from __future__ import annotations
 
 import pytest
-import torch
 
-import proteus.inference.transforms as tr_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
+
+import proteus.inference.transforms as tr_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_utils.py
+++ b/tests/inference/test_utils.py
@@ -13,8 +13,12 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 import proteus.inference.utils as utils_mod  # noqa: E402
 

--- a/tests/inference/test_utils.py
+++ b/tests/inference/test_utils.py
@@ -12,9 +12,11 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-import torch
 
-import proteus.inference.utils as utils_mod
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
+torch = pytest.importorskip('torch')
+
+import proteus.inference.utils as utils_mod  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_utils_branches.py
+++ b/tests/inference/test_utils_branches.py
@@ -18,8 +18,12 @@ import logging
 import numpy as np
 import pytest
 
-# The Bayesian-optimisation stack ships as the optional `inference` extra.
+# The Bayesian-optimisation stack ships as the optional `inference` extra,
+# which installs all three together. Guarding the whole stack keeps a
+# partial environment skipping rather than failing collection.
 torch = pytest.importorskip('torch')
+pytest.importorskip('botorch')
+pytest.importorskip('gpytorch')
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tests/inference/test_utils_branches.py
+++ b/tests/inference/test_utils_branches.py
@@ -18,6 +18,7 @@ import logging
 import numpy as np
 import pytest
 
+# The Bayesian-optimisation stack ships as the optional `inference` extra.
 torch = pytest.importorskip('torch')
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1320,26 +1320,33 @@ def test_infer_propagates_broken_submodule_of_installed_distribution(monkeypatch
 
 
 @pytest.mark.unit
-def test_absent_inference_distribution_names_only_a_truly_missing_package(monkeypatch):
+@pytest.mark.parametrize('distribution', ['torch', 'botorch', 'gpytorch'])
+def test_absent_inference_distribution_names_only_a_truly_missing_package(
+    monkeypatch, distribution
+):
     """The classifier behind the CLI message answers with a distribution name
     only when that distribution is genuinely absent. Each rejection path is
     exercised separately, because each one alone is enough to turn a real
-    failure into misleading install advice.
+    failure into misleading install advice. Every package in the extra is
+    covered: a check written against one name only would leave the other two
+    without the install hint.
     """
-    absent = ModuleNotFoundError("No module named 'torch'", name='torch')
+    absent = ModuleNotFoundError(f"No module named '{distribution}'", name=distribution)
 
     # Reported only once the import system agrees the package is gone.
-    _pretend_absent(monkeypatch, 'torch')
-    assert cli._absent_inference_distribution(absent) == 'torch'
+    _pretend_absent(monkeypatch, distribution)
+    assert cli._absent_inference_distribution(absent) == distribution
 
     # A submodule of a missing distribution resolves to the distribution, so
     # the message names something a user can actually install.
-    submodule = ModuleNotFoundError("No module named 'torch.nn'", name='torch.nn')
-    assert cli._absent_inference_distribution(submodule) == 'torch'
+    submodule = ModuleNotFoundError(
+        f"No module named '{distribution}.sub'", name=f'{distribution}.sub'
+    )
+    assert cli._absent_inference_distribution(submodule) == distribution
 
     # A plain ImportError means the package was found and something inside it
     # failed, so it is never translated, even for a name in the extra.
-    inside = ImportError("dlopen failed while loading 'torch'", name='torch')
+    inside = ImportError(f"dlopen failed while loading '{distribution}'", name=distribution)
     assert cli._absent_inference_distribution(inside) is None
 
     # A missing package outside the extra is not this command's business, and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 # Test PROTEUS terminal CLI and commands
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
 
 import pytest
@@ -1165,6 +1166,9 @@ def test_grid_dry_run_passes_test_run_flag(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_infer_calls_infer_from_config(monkeypatch, tmp_path):
     """``proteus infer -c cfg`` dispatches to infer_from_config with the config path."""
+    # The optimisation stack is the optional `inference` extra.
+    pytest.importorskip('torch')
+
     cfg = tmp_path / 'cfg.toml'
     cfg.write_text('# stub\n')
 
@@ -1181,6 +1185,69 @@ def test_infer_calls_infer_from_config(monkeypatch, tmp_path):
     assert res.exit_code == 0
     assert len(received) == 1
     assert received[0].name == 'cfg.toml'
+
+
+def _patch_infer_import(monkeypatch, error: ImportError):
+    """Make importing the inference entry point raise ``error``.
+
+    The CLI imports ``proteus.inference.inference`` lazily inside the
+    command, so the failure has to be injected at the import call itself
+    rather than by removing an installed package.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'proteus.inference.inference':
+            raise error
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+
+
+@pytest.mark.unit
+def test_infer_reports_missing_inference_extra(monkeypatch, tmp_path):
+    """With the optimisation stack absent, ``proteus infer`` names the missing
+    package and the extra that provides it instead of surfacing a bare
+    ImportError traceback. The optimisation stack is optional, so this is the
+    first thing a user without it sees.
+    """
+    cfg = tmp_path / 'cfg.toml'
+    cfg.write_text('# stub\n')
+
+    _patch_infer_import(monkeypatch, ImportError("No module named 'torch'", name='torch'))
+
+    res = runner.invoke(cli.infer, ['-c', str(cfg)])
+
+    assert res.exit_code == 1
+    # Both halves of the message matter: which package is missing, and the
+    # command that installs it.
+    assert 'torch' in res.output
+    assert 'fwl-proteus[inference]' in res.output
+    # A ClickException is reported, not raised through as a traceback.
+    assert res.exception is None or isinstance(res.exception, SystemExit)
+
+
+@pytest.mark.unit
+def test_infer_propagates_unrelated_import_error(monkeypatch, tmp_path):
+    """An ImportError from inside the inference package that is not one of the
+    optional distributions propagates unchanged. Discrimination: a blanket
+    except would answer a broken PROTEUS import with an install-the-extra
+    message and send the user chasing a dependency that is already present.
+    """
+    cfg = tmp_path / 'cfg.toml'
+    cfg.write_text('# stub\n')
+
+    broken = ImportError(
+        "cannot import name 'missing_helper' from 'proteus.inference.utils'",
+        name='proteus.inference.utils',
+    )
+    _patch_infer_import(monkeypatch, broken)
+
+    res = runner.invoke(cli.infer, ['-c', str(cfg)])
+
+    assert res.exit_code == 1
+    assert res.exception is broken
+    assert 'fwl-proteus[inference]' not in res.output
 
 
 # ---------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import builtins
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -1204,6 +1205,23 @@ def _patch_infer_import(monkeypatch, error: ImportError):
     monkeypatch.setattr(builtins, '__import__', fake_import)
 
 
+def _pretend_absent(monkeypatch, *names: str):
+    """Make ``importlib.util.find_spec`` report *names* as not installed.
+
+    The CLI confirms absence before advising an install, so a test that
+    injects a missing-package error for a package the test environment
+    actually has must remove it from the import system's view too.
+    """
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name in names:
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, 'find_spec', fake_find_spec)
+
+
 @pytest.mark.unit
 def test_infer_reports_missing_inference_extra(monkeypatch, tmp_path):
     """With the optimisation stack absent, ``proteus infer`` names the missing
@@ -1214,7 +1232,11 @@ def test_infer_reports_missing_inference_extra(monkeypatch, tmp_path):
     cfg = tmp_path / 'cfg.toml'
     cfg.write_text('# stub\n')
 
-    _patch_infer_import(monkeypatch, ImportError("No module named 'torch'", name='torch'))
+    # The shape the import system produces for a genuinely absent package.
+    _patch_infer_import(
+        monkeypatch, ModuleNotFoundError("No module named 'torch'", name='torch')
+    )
+    _pretend_absent(monkeypatch, 'torch')
 
     res = runner.invoke(cli.infer, ['-c', str(cfg)])
 
@@ -1229,7 +1251,7 @@ def test_infer_reports_missing_inference_extra(monkeypatch, tmp_path):
 
 @pytest.mark.unit
 def test_infer_propagates_unrelated_import_error(monkeypatch, tmp_path):
-    """An ImportError from inside the inference package that is not one of the
+    """An import failure inside the inference package that is not one of the
     optional distributions propagates unchanged. Discrimination: a blanket
     except would answer a broken PROTEUS import with an install-the-extra
     message and send the user chasing a dependency that is already present.
@@ -1237,9 +1259,9 @@ def test_infer_propagates_unrelated_import_error(monkeypatch, tmp_path):
     cfg = tmp_path / 'cfg.toml'
     cfg.write_text('# stub\n')
 
-    broken = ImportError(
-        "cannot import name 'missing_helper' from 'proteus.inference.utils'",
-        name='proteus.inference.utils',
+    broken = ModuleNotFoundError(
+        "No module named 'proteus.inference.missing_helper'",
+        name='proteus.inference.missing_helper',
     )
     _patch_infer_import(monkeypatch, broken)
 
@@ -1248,6 +1270,106 @@ def test_infer_propagates_unrelated_import_error(monkeypatch, tmp_path):
     assert res.exit_code == 1
     assert res.exception is broken
     assert 'fwl-proteus[inference]' not in res.output
+
+
+@pytest.mark.unit
+def test_infer_propagates_import_error_from_present_distribution(monkeypatch, tmp_path):
+    """A symbol that cannot be imported from an installed distribution raises a
+    plain ImportError, not ModuleNotFoundError. That is the signature of a
+    version mismatch inside the optimisation stack, and it must reach the user
+    as itself: telling them to install a package they already have hides the
+    real cause and the reinstall changes nothing.
+    """
+    cfg = tmp_path / 'cfg.toml'
+    cfg.write_text('# stub\n')
+
+    skewed = ImportError(
+        "cannot import name 'LogExpectedImprovement' from 'botorch.acquisition.analytic'",
+        name='botorch.acquisition.analytic',
+    )
+    _patch_infer_import(monkeypatch, skewed)
+
+    res = runner.invoke(cli.infer, ['-c', str(cfg)])
+
+    assert res.exit_code == 1
+    assert res.exception is skewed
+    assert 'fwl-proteus[inference]' not in res.output
+
+
+@pytest.mark.unit
+def test_infer_propagates_broken_submodule_of_installed_distribution(monkeypatch, tmp_path):
+    """An installed distribution whose own submodule fails to import raises
+    ModuleNotFoundError naming that submodule, whose root is one of the three
+    optional packages. Discrimination: without the installed check the root
+    alone would be taken as proof of absence, and a corrupted install would be
+    reported as a missing extra.
+    """
+    pytest.importorskip('botorch')
+
+    cfg = tmp_path / 'cfg.toml'
+    cfg.write_text('# stub\n')
+
+    broken = ModuleNotFoundError("No module named 'botorch.models'", name='botorch.models')
+    _patch_infer_import(monkeypatch, broken)
+
+    res = runner.invoke(cli.infer, ['-c', str(cfg)])
+
+    assert res.exit_code == 1
+    assert res.exception is broken
+    assert 'fwl-proteus[inference]' not in res.output
+
+
+@pytest.mark.unit
+def test_absent_inference_distribution_names_only_a_truly_missing_package(monkeypatch):
+    """The classifier behind the CLI message answers with a distribution name
+    only when that distribution is genuinely absent. Each rejection path is
+    exercised separately, because each one alone is enough to turn a real
+    failure into misleading install advice.
+    """
+    absent = ModuleNotFoundError("No module named 'torch'", name='torch')
+
+    # Reported only once the import system agrees the package is gone.
+    _pretend_absent(monkeypatch, 'torch')
+    assert cli._absent_inference_distribution(absent) == 'torch'
+
+    # A submodule of a missing distribution resolves to the distribution, so
+    # the message names something a user can actually install.
+    submodule = ModuleNotFoundError("No module named 'torch.nn'", name='torch.nn')
+    assert cli._absent_inference_distribution(submodule) == 'torch'
+
+    # A plain ImportError means the package was found and something inside it
+    # failed, so it is never translated, even for a name in the extra.
+    inside = ImportError("dlopen failed while loading 'torch'", name='torch')
+    assert cli._absent_inference_distribution(inside) is None
+
+    # A missing package outside the extra is not this command's business, and
+    # its absence must not be answered with the inference install command.
+    unrelated = ModuleNotFoundError(
+        "No module named 'unrelated_absent_package_xyz'",
+        name='unrelated_absent_package_xyz',
+    )
+    assert cli._absent_inference_distribution(unrelated) is None
+
+    # An error carrying no module name cannot identify anything.
+    nameless = ModuleNotFoundError('import failed')
+    assert cli._absent_inference_distribution(nameless) is None
+
+
+@pytest.mark.unit
+def test_absent_inference_distribution_rejects_an_installed_package():
+    """A submodule failure inside an installed distribution names that
+    distribution as the root, and the classifier must still refuse it.
+    Discrimination: this is the one case the exception type alone cannot tell
+    apart from a real absence, so it pins the installed check specifically.
+    """
+    pytest.importorskip('botorch')
+
+    broken = ModuleNotFoundError("No module named 'botorch.models'", name='botorch.models')
+
+    assert cli._absent_inference_distribution(broken) is None
+    # The same error shape, with the import system reporting absence, is the
+    # case that does get reported: the two differ only in installed state.
+    assert broken.name.split('.')[0] in cli.INFERENCE_DISTRIBUTIONS
 
 
 # ---------------------------

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -87,6 +87,26 @@ def test_no_core_module_imports_the_inference_stack():
     # Discrimination: an empty scan would satisfy the assertion above without
     # checking anything. The package is far larger than this floor.
     assert scanned > 50
+    # The stack also arrives transitively: a core module importing anything
+    # from proteus.inference at module scope pulls torch with it, so that is
+    # the same defect wearing a different name.
+    reexporters = {
+        str(path.relative_to(REPO_ROOT))
+        for path in sorted(SRC_ROOT.rglob('*.py'))
+        if INFERENCE_ROOT not in path.parents
+        and any(
+            (
+                isinstance(node, ast.ImportFrom)
+                and (node.module or '').startswith('proteus.inference')
+            )
+            or (
+                isinstance(node, ast.Import)
+                and any(a.name.startswith('proteus.inference') for a in node.names)
+            )
+            for node in ast.parse(path.read_text()).body
+        )
+    }
+    assert reexporters == set(), f'core modules importing proteus.inference: {reexporters}'
     # The scan reaches modules that do import the stack, so a path filter that
     # silently excluded everything would fail here.
     inference_hits = {

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,163 @@
+"""Guards on the optional `inference` extra.
+
+The Bayesian-optimisation stack (torch, botorch, gpytorch) is installed only
+by ``pip install "fwl-proteus[inference]"``. Three properties keep an install
+without it working, and each is checked here:
+
+* no module outside ``src/proteus/inference/`` imports one of the three at
+  module scope, so ``import proteus`` and every command other than
+  ``proteus infer`` load without them,
+* the distribution list the CLI reports on matches the extra declared in
+  ``pyproject.toml``,
+* the test-quality linter requires an ``importorskip`` guard for all three,
+  so a new test that imports them cannot silently break collection on an
+  install without the extra.
+
+The checks read source, so they run whether or not the extra is installed.
+
+References:
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from proteus import cli
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / 'src' / 'proteus'
+INFERENCE_ROOT = SRC_ROOT / 'inference'
+
+
+def _module_level_imports(path: Path) -> set[str]:
+    """Return the root names imported at module scope in ``path``.
+
+    Imports nested inside functions, classes or ``try`` blocks are excluded:
+    they run on call, not at import, so they cannot break ``import proteus``.
+    """
+    roots: set[str] = set()
+    for node in ast.parse(path.read_text()).body:
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split('.', 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            roots.add(node.module.split('.', 1)[0])
+    return roots
+
+
+def _read_inference_extra() -> set[str]:
+    """Return the distribution names declared in the `inference` extra."""
+    cfg = tomllib.loads((REPO_ROOT / 'pyproject.toml').read_text())
+    extras = cfg['project']['optional-dependencies']
+    requirements = extras['inference']
+    return {
+        req.split('>')[0].split('=')[0].split('[')[0].split(';')[0].strip()
+        for req in requirements
+    }
+
+
+@pytest.mark.unit
+def test_no_core_module_imports_the_inference_stack():
+    """Only ``src/proteus/inference/`` may import the optimisation stack at
+    module scope. A core module that imports torch breaks ``import proteus``
+    for every user who installed without the extra, and CI would not notice
+    because CI installs it.
+    """
+    stack = set(cli.INFERENCE_DISTRIBUTIONS)
+    offenders = {}
+    scanned = 0
+    for path in sorted(SRC_ROOT.rglob('*.py')):
+        if INFERENCE_ROOT in path.parents:
+            continue
+        scanned += 1
+        hits = _module_level_imports(path) & stack
+        if hits:
+            offenders[str(path.relative_to(REPO_ROOT))] = sorted(hits)
+
+    assert offenders == {}, f'core modules importing the inference stack: {offenders}'
+    # Discrimination: an empty scan would satisfy the assertion above without
+    # checking anything. The package is far larger than this floor.
+    assert scanned > 50
+    # The scan reaches modules that do import the stack, so a path filter that
+    # silently excluded everything would fail here.
+    inference_hits = {
+        path.name: sorted(_module_level_imports(path) & stack)
+        for path in sorted(INFERENCE_ROOT.glob('*.py'))
+    }
+    assert 'torch' in inference_hits['BO.py']
+    assert 'botorch' in inference_hits['BO.py']
+
+
+@pytest.mark.unit
+def test_cli_distribution_list_matches_the_declared_extra():
+    """The names the CLI can report as missing are exactly the ones the extra
+    installs. Drift in either direction is a silent regression: a package
+    added to the extra but not here gets a raw traceback instead of the
+    install hint, and a name dropped from the extra leaves dead advice.
+    """
+    declared = _read_inference_extra()
+
+    assert declared == set(cli.INFERENCE_DISTRIBUTIONS)
+    # Pin the membership as well as the equality, so a rename on both sides at
+    # once still has to be deliberate.
+    assert declared == {'torch', 'botorch', 'gpytorch'}
+    # The extra must not leak into the core dependency list.
+    cfg = tomllib.loads((REPO_ROOT / 'pyproject.toml').read_text())
+    core = {
+        req.split('>')[0].split('=')[0].split('[')[0].split(';')[0].strip()
+        for req in cfg['project']['dependencies']
+    }
+    assert core & declared == set()
+
+
+@pytest.mark.unit
+def test_linter_requires_importorskip_for_the_inference_stack():
+    """``tools/check_test_quality.py`` treats all three distributions as
+    optional. Without that, a new test importing them at module scope passes
+    the linter and then fails collection on an install without the extra,
+    which is the recurring trap the rule exists to prevent.
+    """
+    spec = importlib.util.spec_from_file_location(
+        'check_test_quality', REPO_ROOT / 'tools' / 'check_test_quality.py'
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['check_test_quality'] = module
+    try:
+        spec.loader.exec_module(module)
+
+        assert set(cli.INFERENCE_DISTRIBUTIONS) <= module.OPTIONAL_DEPS
+        # The rule is enforced, not just declared: a module-top import with no
+        # guard is reported, and the same import behind a guard is not.
+        unguarded = ast.parse('import torch\n')
+        guarded = ast.parse("import pytest\npytest.importorskip('torch')\nimport torch\n")
+        assert 'torch' in module._missing_importorskip(unguarded)
+        assert 'torch' not in module._missing_importorskip(guarded)
+    finally:
+        del sys.modules['check_test_quality']
+
+
+@pytest.mark.unit
+def test_missing_module_error_names_the_root_distribution():
+    """The CLI reads ``ModuleNotFoundError.name`` and takes its first dotted
+    component as the distribution. This pins that contract against the real
+    import system rather than assuming it: a failed top-level import names the
+    package itself, and a failed submodule import names the dotted path whose
+    root is that package.
+    """
+    with pytest.raises(ModuleNotFoundError) as absent:
+        importlib.import_module('proteus_inference_stack_absent_xyz')
+    assert absent.value.name == 'proteus_inference_stack_absent_xyz'
+
+    with pytest.raises(ModuleNotFoundError) as submodule:
+        importlib.import_module('proteus.no_such_submodule_xyz')
+    assert submodule.value.name == 'proteus.no_such_submodule_xyz'
+    assert submodule.value.name.split('.')[0] == 'proteus'

--- a/tools/check_test_quality.py
+++ b/tools/check_test_quality.py
@@ -73,6 +73,10 @@ OPTIONAL_DEPS = {
     'mors',
     'vulcan',
     'zalmoxis',  # only optional when not installed as editable submodule
+    # The Bayesian-optimisation stack, shipped as the `inference` extra.
+    'torch',
+    'botorch',
+    'gpytorch',
 }
 
 # Test directories that contain at least one physics-required source file.


### PR DESCRIPTION
## Description

Every PROTEUS install currently pulls `torch`, `botorch` and `gpytorch`. Nothing outside `src/proteus/inference/` imports any of them, and that package is reached only through `proteus infer`, so a forward model, a grid sweep and the plotting path all pay for several hundred megabytes of dependencies they never touch. On Linux `torch` additionally pulls in the CUDA runtime packages.

They now ship as an `inference` extra:

```console
pip install "fwl-proteus[inference]"
```

**This is a breaking change for anyone who was getting torch transitively from `pip install fwl-proteus`.** It is worth calling out in the release notes for whichever version ships it.

Without the extra, `proteus infer` stops with a message naming the missing package and the install command. The classifier behind that message insists on all three of: the failure is a module-not-found, its name resolves to one of the three distributions, and the import system agrees the package is absent. Anything else propagates untouched, so a version mismatch inside the stack or a corrupted install is never disguised as "you forgot to install it".

## Changes

- `pyproject.toml`: `torch`, `botorch` and `gpytorch` move from `[project.dependencies]` to an `inference` extra.
- `src/proteus/cli.py`: `proteus infer` reports a missing extra with the package name and the install command; every other import failure propagates unchanged.
- `tests/inference/*`: each module guards the whole stack with `pytest.importorskip`, so an install without the extra skips instead of failing collection.
- `tests/test_optional_dependencies.py` (new): no module outside `src/proteus/inference/` may import the stack, directly or through `proteus.inference`; the CLI's distribution list and the test-quality linter's optional-dependency set are pinned to the extra declared in `pyproject.toml`.
- `.github/actions/setup-proteus`: CI installs `.[develop,vulcan,atmodeller,inference]`, alongside the existing optional backends, so the inference tests keep running there and coverage is unchanged.
- `tools/check_test_quality.py`: the three distributions join the optional-dependency set.
- Docs: a section in the optional-modules page (including PyTorch's CPU index for anyone who does not want the CUDA runtime), a requirement note at the top of the inference guide, and the extras needed to match CI's test selection in the testing guide, the manual install guide and the quick reference.

## Validation of changes

macOS 15 (Apple Silicon), Python 3.12, conda.

With the three packages blocked at import, simulating an install without the extra:

- unit tier: 2609 passed, 25 skipped, no collection errors
- `import proteus` and the CLI load
- `proteus infer` exits 1 with the missing-package message

With the extra installed:

- unit tier: 2708 passed, 11 skipped, unchanged from before the change
- inference tier: 105 passed, 3 skipped, unchanged

Packaging and partial installs:

- the built wheel lists all three only under `extra == "inference"`; no core `Requires-Dist` mentions them
- with only `gpytorch` removed, the inference directory produced 9 collection errors before this change and 11 skips after it

Each decision in the classifier and each structural guard was checked by mutation: dropping the module-not-found narrowing, the installed check, the membership check, the dotted-name resolution, the core-import guard, the `proteus.inference` guard, the pyproject-to-CLI link, or the linter entry each fails a specific test.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
