### PR TITLE
Check the fwl-io version in proteus doctor

### DIFF
--- a/src/proteus/doctor.py
+++ b/src/proteus/doctor.py
@@ -581,6 +581,7 @@ ENVIRONMENT_VARS = [
 # missing when a user has not installed them.
 PYTHON_PACKAGES = [
     'fwl-proteus',
+    'fwl-io',
     'fwl-aragog',
     'fwl-calliope',
     'fwl-janus',

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -28,6 +28,7 @@ from proteus.doctor import (
     CheckResult,
     _collect_environment_info,
     _conda_build_lines,
+    _dependency_specs,
     _editable_checkout_path,
     _get_script_for_package,
     _git_dirty,
@@ -76,6 +77,57 @@ def test_python_packages_excludes_optional_backends():
     mandatory = {'fwl-proteus', 'fwl-aragog', 'fwl-calliope', 'fwl-zalmoxis'}
     assert mandatory <= set(PYTHON_PACKAGES), (
         f'doctor lost mandatory package checks: {mandatory - set(PYTHON_PACKAGES)}'
+    )
+
+
+@pytest.mark.unit
+def test_python_packages_covers_every_pinned_fwl_dependency():
+    """Every FWL package pinned in pyproject must be one doctor checks.
+
+    A package carrying a version floor but absent from the list is a silent
+    hole: doctor reports the whole stack green while the installed version sits
+    below the bound the framework relies on. fwl-io is the costliest case to
+    miss, because its floor exists to keep out releases with neither a timeout
+    nor a retry on the data fetch, where an unreachable archive hangs a run
+    rather than failing it.
+
+    Both directions matter, and they fail differently. A pinned package missing
+    from the list is never checked at all. A listed package whose bound the
+    reader does not see is checked but always passes, since the version
+    comparison is skipped when no specifier is found; that is the same silent
+    green, reached from the other side. The spec reader matches dependency
+    names containing ``fwl-``, so a pin written with an underscore, or a
+    dependency dropped from pyproject, produces exactly that.
+
+    Verifies:
+    - Every dependency the spec reader discovers is checked.
+    - Every checked package carries a version bound the reader actually reads,
+      the project's own distribution aside.
+    - The spec reader found something, so neither comparison is vacuously
+      satisfied by an empty set.
+    """
+    specs = _dependency_specs()
+    pinned = set(specs)
+    assert pinned, 'no FWL dependencies were discovered; the comparisons below are vacuous'
+    assert 'fwl-io' in pinned, (
+        'fwl-io is no longer a pinned dependency, so this test is guarding nothing'
+    )
+
+    # `_dependency_specs` reads [project] dependencies only, so the optional
+    # extras are out of scope here by construction rather than by exclusion.
+    checked = set(PYTHON_PACKAGES)
+    missing = pinned - checked
+    assert not missing, (
+        f'pyproject pins these FWL packages but doctor does not check them: {sorted(missing)}'
+    )
+
+    # fwl-proteus is the distribution being diagnosed, not one of its own
+    # dependencies, so it carries no bound to read.
+    enforced = {name for name, spec in specs.items() if spec and spec.specifier}
+    unbounded = checked - enforced - {'fwl-proteus'}
+    assert not unbounded, (
+        f'doctor checks these but reads no version bound for them, so they pass at any '
+        f'installed version: {sorted(unbounded)}'
     )
 
 


### PR DESCRIPTION
## Description

`proteus doctor` reported the whole stack green while the installed fwl-io sat below the floor pyproject pins, because fwl-io was never in the list of packages it checks. That floor is not cosmetic: it keeps out releases with neither a timeout nor a retry on the data fetch, where an unreachable archive hangs a run instead of failing it. Doctor is the tool that should have said so, and it said nothing.

The version spec was already being discovered, since the reader matches dependency names containing `fwl-`. Only the check list was missing the entry.

## Changes

- `src/proteus/doctor.py`: add `fwl-io` to `PYTHON_PACKAGES`.
- `tests/test_doctor.py`: tie the check list and the pinned dependencies together in both directions.

The second direction is the one worth explaining. A pinned package absent from the list is never checked at all. A listed package whose bound the reader does not see is checked but passes at any installed version, because the version comparison is skipped when no specifier is found. That is the same silent green arrived at from the other side, and it is reachable in practice: a pin written with an underscore (`fwl_aragog>=...`, legal PEP 508 and pip-identical) or a dependency dropped from pyproject both produce it.

## Validation of changes

macOS 15 on Apple silicon, Python 3.12.

- Unit tier: 2734 passed, 11 skipped.
- `proteus doctor` now reports `[ok] fwl-io: 26.7.26.dev1+g09bb7c329` alongside the other framework packages.
- Both failure directions verified by mutating pyproject and confirming the test fails, naming the right package each time: dropping `fwl-zephyrus` from dependencies, and rewriting the aragog pin as `fwl_aragog`. Restored afterwards.
- Test-quality lint unchanged against baseline.

Not changed: `proteus update` picks fwl-io up automatically through the same list, installing it when absent and upgrading it when below the floor. No `tools/get_io.sh` exists, which puts fwl-io in the same class as janus, mors, calliope and zephyrus, all PyPI-only.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
