### PR TITLE
Close the fwl logger handlers after each test (#791)

### DIFF
--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -28,6 +28,29 @@ from proteus.utils.logs import (
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
 
+@pytest.fixture
+def tmpdir_that_closes_logger_files():
+    """Yield a temp dir, then close the 'fwl' file handlers before removing it.
+
+    setup_logger attaches a FileHandler to the shared 'fwl' logger. If the logfile
+    is still open when the directory is torn down, cleanup fails on an NFS TMPDIR:
+    the server keeps the open file as a .nfsXXXX entry, so rmdir raises OSError
+    [Errno 39]. Owning the TemporaryDirectory here and closing the handlers after
+    the test yields but before this with-block removes the directory releases the
+    descriptors first, so cleanup succeeds on NFS as well as local disk. A plain
+    post-test teardown fixture would be too late: an inline with-block
+    TemporaryDirectory inside a test removes the directory when the method returns,
+    before any fixture teardown runs. Shared by the setup_logger and
+    bootstrap_logger tests that write a logfile. See issue #791.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+        logger = logging.getLogger('fwl')
+        for handler in list(logger.handlers):
+            handler.close()
+            logger.removeHandler(handler)
+
+
 class TestStreamToLogger:
     """Test suite for StreamToLogger stream-to-logger redirection.
 
@@ -300,212 +323,202 @@ class TestSetupLogger:
     """
 
     @pytest.mark.unit
-    def test_setup_logger_creates_file(self):
+    def test_setup_logger_creates_file(self, tmpdir_that_closes_logger_files):
         """Verify setup_logger creates FormingWorlds logger with file handler.
 
         Each PROTEUS run writes to separate log file for parallel ensemble tracking.
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, logterm=False)
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, logterm=False)
 
-            # Verify logger instance and canonical name
-            assert isinstance(logger, logging.Logger)
-            assert logger.name == 'fwl'  # FormingWorlds standard logger
+        # Verify logger instance and canonical name
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == 'fwl'  # FormingWorlds standard logger
 
     @pytest.mark.unit
-    def test_setup_logger_removes_existing_file(self):
+    def test_setup_logger_removes_existing_file(self, tmpdir_that_closes_logger_files):
         """setup_logger removes pre-existing logfile."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            # Create existing file
-            pathlib.Path(logpath).touch()
-            assert os.path.exists(logpath)
-            logger = setup_logger(logpath=logpath, logterm=False)
-            assert logger is not None
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        # Create existing file
+        pathlib.Path(logpath).touch()
+        assert os.path.exists(logpath)
+        logger = setup_logger(logpath=logpath, logterm=False)
+        assert logger is not None
 
     @pytest.mark.unit
-    def test_setup_logger_default_level_info(self):
+    def test_setup_logger_default_level_info(self, tmpdir_that_closes_logger_files):
         """setup_logger uses INFO as default log level."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, level='INFO', logterm=False)
-            assert logger.level == logging.INFO
-            # Discrimination: confirm a FileHandler was registered against the
-            # requested logpath. A regression that silently dropped the file
-            # handler would still pass the level check but break the contract
-            # (route fwl output to logpath).
-            file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
-            assert any(h.baseFilename == os.path.abspath(logpath) for h in file_handlers)
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, level='INFO', logterm=False)
+        assert logger.level == logging.INFO
+        # Discrimination: confirm a FileHandler was registered against the
+        # requested logpath. A regression that silently dropped the file
+        # handler would still pass the level check but break the contract
+        # (route fwl output to logpath).
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        assert any(h.baseFilename == os.path.abspath(logpath) for h in file_handlers)
 
     @pytest.mark.unit
-    def test_setup_logger_level_debug(self):
+    def test_setup_logger_level_debug(self, tmpdir_that_closes_logger_files):
         """setup_logger accepts DEBUG log level."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, level='DEBUG', logterm=False)
-            assert logger.level == logging.DEBUG
-            # Discrimination: pin the canonical logger name ('fwl'). A
-            # regression that returned the root logger or a per-call named
-            # instance would still expose the correct .level and pass the
-            # primary check but break downstream getLogger('fwl') lookups.
-            assert logger.name == 'fwl'
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, level='DEBUG', logterm=False)
+        assert logger.level == logging.DEBUG
+        # Discrimination: pin the canonical logger name ('fwl'). A
+        # regression that returned the root logger or a per-call named
+        # instance would still expose the correct .level and pass the
+        # primary check but break downstream getLogger('fwl') lookups.
+        assert logger.name == 'fwl'
 
     @pytest.mark.unit
-    def test_setup_logger_level_error(self):
+    def test_setup_logger_level_error(self, tmpdir_that_closes_logger_files):
         """setup_logger accepts ERROR log level."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, level='ERROR', logterm=False)
-            assert logger.level == logging.ERROR
-            # Discrimination: ERROR (40) must sit strictly above WARNING (30).
-            # A regression that mapped 'ERROR' to a lower numeric level would
-            # pass the equality check only if both literal constants moved,
-            # but would fail the strict-ordering pin against WARNING.
-            assert logger.level > logging.WARNING
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, level='ERROR', logterm=False)
+        assert logger.level == logging.ERROR
+        # Discrimination: ERROR (40) must sit strictly above WARNING (30).
+        # A regression that mapped 'ERROR' to a lower numeric level would
+        # pass the equality check only if both literal constants moved,
+        # but would fail the strict-ordering pin against WARNING.
+        assert logger.level > logging.WARNING
 
     @pytest.mark.unit
-    def test_setup_logger_level_warning(self):
+    def test_setup_logger_level_warning(self, tmpdir_that_closes_logger_files):
         """setup_logger accepts WARNING log level."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, level='WARNING', logterm=False)
-            assert logger.level == logging.WARNING
-            # Discrimination: WARNING (30) sits strictly between INFO (20) and
-            # ERROR (40). Pin both inequalities to catch a regression that
-            # silently mapped 'WARNING' to INFO or ERROR.
-            assert logging.INFO < logger.level < logging.ERROR
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, level='WARNING', logterm=False)
+        assert logger.level == logging.WARNING
+        # Discrimination: WARNING (30) sits strictly between INFO (20) and
+        # ERROR (40). Pin both inequalities to catch a regression that
+        # silently mapped 'WARNING' to INFO or ERROR.
+        assert logging.INFO < logger.level < logging.ERROR
 
     @pytest.mark.unit
-    def test_setup_logger_invalid_level_raises(self):
+    def test_setup_logger_invalid_level_raises(self, tmpdir_that_closes_logger_files):
         """Verify setup_logger raises ValueError for invalid log levels.
 
         Prevents silent failures when config specifies typo in log level
         (e.g., 'INFOO' instead of 'INFO').
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
 
-            # Invalid level should raise immediately, not silently default
-            with pytest.raises(ValueError, match='Invalid log level'):
-                setup_logger(logpath=logpath, level='INVALID', logterm=False)
-            # Discrimination: failure must happen BEFORE any side effect on
-            # disk. A regression that opened the FileHandler before validating
-            # the level would have left the logfile behind even though the
-            # exception fired.
-            assert not os.path.exists(logpath)
+        # Invalid level should raise immediately, not silently default
+        with pytest.raises(ValueError, match='Invalid log level'):
+            setup_logger(logpath=logpath, level='INVALID', logterm=False)
+        # Discrimination: failure must happen BEFORE any side effect on
+        # disk. A regression that opened the FileHandler before validating
+        # the level would have left the logfile behind even though the
+        # exception fired.
+        assert not os.path.exists(logpath)
 
     @pytest.mark.unit
-    def test_setup_logger_level_case_insensitive(self):
+    def test_setup_logger_level_case_insensitive(self, tmpdir_that_closes_logger_files):
         """setup_logger accepts log level in any case."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, level='info', logterm=False)
-            assert logger.level == logging.INFO
-            # Discrimination: lowercase 'info' must resolve to the SAME numeric
-            # level as uppercase 'INFO'. A regression that dropped the .upper()
-            # call and returned a different default for unrecognized strings
-            # would diverge here. Pin parity with the canonical form.
-            logger2 = setup_logger(logpath=logpath + '.up', level='INFO', logterm=False)
-            assert logger2.level == logger.level
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, level='info', logterm=False)
+        assert logger.level == logging.INFO
+        # Discrimination: lowercase 'info' must resolve to the SAME numeric
+        # level as uppercase 'INFO'. A regression that dropped the .upper()
+        # call and returned a different default for unrecognized strings
+        # would diverge here. Pin parity with the canonical form.
+        logger2 = setup_logger(logpath=logpath + '.up', level='INFO', logterm=False)
+        assert logger2.level == logger.level
 
     @pytest.mark.unit
-    def test_setup_logger_level_with_whitespace(self):
+    def test_setup_logger_level_with_whitespace(self, tmpdir_that_closes_logger_files):
         """setup_logger strips whitespace from log level."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, level='  DEBUG  ', logterm=False)
-            assert logger.level == logging.DEBUG
-            # Discrimination: whitespace-padded input must resolve to the same
-            # level as the stripped form. A regression that dropped the
-            # `.strip()` call would raise ValueError before reaching this line.
-            # Pin parity with the canonical form to lock the contract.
-            logger2 = setup_logger(logpath=logpath + '.bare', level='DEBUG', logterm=False)
-            assert logger2.level == logger.level
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, level='  DEBUG  ', logterm=False)
+        assert logger.level == logging.DEBUG
+        # Discrimination: whitespace-padded input must resolve to the same
+        # level as the stripped form. A regression that dropped the
+        # `.strip()` call would raise ValueError before reaching this line.
+        # Pin parity with the canonical form to lock the contract.
+        logger2 = setup_logger(logpath=logpath + '.bare', level='DEBUG', logterm=False)
+        assert logger2.level == logger.level
 
     @pytest.mark.unit
-    def test_setup_logger_with_terminal_output(self):
+    def test_setup_logger_with_terminal_output(self, tmpdir_that_closes_logger_files):
         """setup_logger adds terminal handler when logterm=True."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, logterm=True)
-            # Check for StreamHandler (or similar terminal output handler)
-            handlers = [h for h in logger.handlers if not isinstance(h, logging.FileHandler)]
-            assert len(handlers) > 0
-            # Discriminating check: at least one of the non-file handlers is a
-            # StreamHandler (the contract that logterm=True must add). A
-            # regression that attached a NullHandler instead would still pass
-            # the bare ``len > 0`` check.
-            assert any(isinstance(h, logging.StreamHandler) for h in handlers)
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, logterm=True)
+        # Check for StreamHandler (or similar terminal output handler)
+        handlers = [h for h in logger.handlers if not isinstance(h, logging.FileHandler)]
+        assert len(handlers) > 0
+        # Discriminating check: at least one of the non-file handlers is a
+        # StreamHandler (the contract that logterm=True must add). A
+        # regression that attached a NullHandler instead would still pass
+        # the bare ``len > 0`` check.
+        assert any(isinstance(h, logging.StreamHandler) for h in handlers)
 
     @pytest.mark.unit
-    def test_setup_logger_without_terminal_output(self):
+    def test_setup_logger_without_terminal_output(self, tmpdir_that_closes_logger_files):
         """setup_logger with logterm=False does not add additional terminal handlers."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            # Count handlers before call
-            logger = setup_logger(logpath=logpath, logterm=False)
-            # Logger is a singleton so just verify that file logging works
-            logger.info('Test without terminal')
-            with open(logpath) as f:
-                content = f.read()
-            assert 'Test without terminal' in content
-            # Discrimination: with logterm=False no plain StreamHandler routed
-            # to sys.stdout should have been registered by this call. The
-            # FileHandler subclass is still allowed; check the non-file
-            # handlers do not include a stdout-routed StreamHandler.
-            stream_to_stdout = [
-                h
-                for h in logger.handlers
-                if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
-            ]
-            assert stream_to_stdout == []
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        # Count handlers before call
+        logger = setup_logger(logpath=logpath, logterm=False)
+        # Logger is a singleton so just verify that file logging works
+        logger.info('Test without terminal')
+        with open(logpath) as f:
+            content = f.read()
+        assert 'Test without terminal' in content
+        # Discrimination: with logterm=False no plain StreamHandler routed
+        # to sys.stdout should have been registered by this call. The
+        # FileHandler subclass is still allowed; check the non-file
+        # handlers do not include a stdout-routed StreamHandler.
+        stream_to_stdout = [
+            h
+            for h in logger.handlers
+            if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
+        ]
+        assert stream_to_stdout == []
 
     @pytest.mark.unit
-    def test_setup_logger_file_handler_has_custom_formatter(self):
+    def test_setup_logger_file_handler_has_custom_formatter(
+        self, tmpdir_that_closes_logger_files
+    ):
         """setup_logger file handler uses simple formatter (no colors)."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, logterm=False)
-            file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
-            # Logger is singleton, may have many handlers from other tests
-            # Just verify at least one file handler has a formatter
-            assert len(file_handlers) > 0
-            assert any(h.formatter is not None for h in file_handlers)
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, logterm=False)
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        # Logger is singleton, may have many handlers from other tests
+        # Just verify at least one file handler has a formatter
+        assert len(file_handlers) > 0
+        assert any(h.formatter is not None for h in file_handlers)
 
     @pytest.mark.unit
-    def test_setup_logger_logs_to_file(self):
+    def test_setup_logger_logs_to_file(self, tmpdir_that_closes_logger_files):
         """setup_logger actually writes logs to file."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            logger = setup_logger(logpath=logpath, logterm=False)
-            logger.info('Test message')
-            with open(logpath) as f:
-                content = f.read()
-            assert 'Test message' in content
-            # Discrimination: the file formatter emits a level prefix
-            # ('[ INFO  ] ...' per the source). A regression that wrote raw
-            # messages without the level tag would pass the substring check
-            # above but break log post-processing tools that key on the prefix.
-            assert 'INFO' in content
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        logger = setup_logger(logpath=logpath, logterm=False)
+        logger.info('Test message')
+        with open(logpath) as f:
+            content = f.read()
+        assert 'Test message' in content
+        # Discrimination: the file formatter emits a level prefix
+        # ('[ INFO  ] ...' per the source). A regression that wrote raw
+        # messages without the level tag would pass the substring check
+        # above but break log post-processing tools that key on the prefix.
+        assert 'INFO' in content
 
     @pytest.mark.unit
-    def test_setup_logger_exception_handler(self):
+    def test_setup_logger_exception_handler(self, tmpdir_that_closes_logger_files):
         """setup_logger installs custom exception hook."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            original_hook = sys.excepthook
-            setup_logger(logpath=logpath, logterm=False)
-            # Verify exception hook was set
-            assert sys.excepthook != original_hook
-            # Discrimination: the installed hook must be callable. A regression
-            # that stored a non-callable sentinel would pass the !=-original
-            # check but break on the first uncaught exception.
-            assert callable(sys.excepthook)
-            sys.excepthook = original_hook  # Restore original hook
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        original_hook = sys.excepthook
+        setup_logger(logpath=logpath, logterm=False)
+        # Verify exception hook was set
+        assert sys.excepthook != original_hook
+        # Discrimination: the installed hook must be callable. A regression
+        # that stored a non-callable sentinel would pass the !=-original
+        # check but break on the first uncaught exception.
+        assert callable(sys.excepthook)
+        sys.excepthook = original_hook  # Restore original hook
 
     @pytest.mark.unit
-    def test_plain_fmt_writes_uncoloured_timestamped_file(self):
+    def test_plain_fmt_writes_uncoloured_timestamped_file(
+        self, tmpdir_that_closes_logger_files
+    ):
         """An explicit fmt makes the file use that plain layout.
 
         The grid manager passes a timestamped, colourless format so its
@@ -514,20 +527,19 @@ class TestSetupLogger:
         """
         import re
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'plain.log')
-            setup_logger(
-                logpath=logpath,
-                level='INFO',
-                logterm=False,
-                fmt='[%(asctime)s] %(message)s',
-                datefmt='%Y-%m-%d %H:%M:%S',
-            )
-            logging.getLogger('fwl').info('PLAINMARK')
-            for h in logging.getLogger('fwl').handlers:
-                h.flush()
-            with open(logpath) as f:
-                contents = f.read().strip()
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'plain.log')
+        setup_logger(
+            logpath=logpath,
+            level='INFO',
+            logterm=False,
+            fmt='[%(asctime)s] %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+        )
+        logging.getLogger('fwl').info('PLAINMARK')
+        for h in logging.getLogger('fwl').handlers:
+            h.flush()
+        with open(logpath) as f:
+            contents = f.read().strip()
         assert 'PLAINMARK' in contents
         # The plain layout must NOT carry the default '[ LEVEL ]' tag; this
         # discriminates the fmt path from the default-formatter path.
@@ -537,20 +549,19 @@ class TestSetupLogger:
         assert re.match(r'^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] PLAINMARK$', contents)
 
     @pytest.mark.unit
-    def test_default_fmt_keeps_level_tag(self):
+    def test_default_fmt_keeps_level_tag(self, tmpdir_that_closes_logger_files):
         """Without fmt, the file keeps the default '[ LEVEL ] message' layout.
 
         This pins that the new fmt parameter is opt-in and does not change the
         layout of existing (non-grid) logs.
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'tagged.log')
-            setup_logger(logpath=logpath, level='INFO', logterm=False)
-            logging.getLogger('fwl').info('TAGMARK')
-            for h in logging.getLogger('fwl').handlers:
-                h.flush()
-            with open(logpath) as f:
-                contents = f.read().strip()
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'tagged.log')
+        setup_logger(logpath=logpath, level='INFO', logterm=False)
+        logging.getLogger('fwl').info('TAGMARK')
+        for h in logging.getLogger('fwl').handlers:
+            h.flush()
+        with open(logpath) as f:
+            contents = f.read().strip()
         assert 'TAGMARK' in contents
         # Default layout carries the level tag...
         assert '[ INFO' in contents
@@ -627,47 +638,45 @@ class TestBootstrapLogger:
         assert n_after_first == 1
 
     @pytest.mark.unit
-    def test_noop_when_handler_already_present(self):
+    def test_noop_when_handler_already_present(self, tmpdir_that_closes_logger_files):
         """bootstrap_logger must not clobber a configured file logger.
 
         If setup_logger has already installed a file handler, calling
         bootstrap_logger afterwards must leave that configuration untouched so a
         real run keeps logging to its proteus_XX.log file.
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            setup_logger(logpath=logpath, logterm=False)
-            handlers_before = list(logging.getLogger('fwl').handlers)
-            bootstrap_logger()
-            assert logging.getLogger('fwl').handlers == handlers_before
-            # Discrimination: the file handler must survive so file logging is
-            # unaffected. A regression that added a stdout handler anyway would
-            # change the handler list identity checked above.
-            file_handlers = [
-                h
-                for h in logging.getLogger('fwl').handlers
-                if isinstance(h, logging.FileHandler)
-            ]
-            assert len(file_handlers) == 1
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        setup_logger(logpath=logpath, logterm=False)
+        handlers_before = list(logging.getLogger('fwl').handlers)
+        bootstrap_logger()
+        assert logging.getLogger('fwl').handlers == handlers_before
+        # Discrimination: the file handler must survive so file logging is
+        # unaffected. A regression that added a stdout handler anyway would
+        # change the handler list identity checked above.
+        file_handlers = [
+            h for h in logging.getLogger('fwl').handlers if isinstance(h, logging.FileHandler)
+        ]
+        assert len(file_handlers) == 1
 
     @pytest.mark.unit
-    def test_setup_logger_after_bootstrap_has_no_duplicate_stdout(self):
+    def test_setup_logger_after_bootstrap_has_no_duplicate_stdout(
+        self, tmpdir_that_closes_logger_files
+    ):
         """setup_logger after bootstrap yields exactly one stdout handler.
 
         setup_logger clears handlers before adding its own, so the bootstrap
         console handler must not survive to double every terminal line.
         """
         bootstrap_logger()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            logpath = os.path.join(tmpdir, 'test.log')
-            setup_logger(logpath=logpath, logterm=True, level='INFO')
-            logger = logging.getLogger('fwl')
-            stdout_handlers = [
-                h
-                for h in logger.handlers
-                if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
-            ]
-            assert len(stdout_handlers) == 1
+        logpath = os.path.join(tmpdir_that_closes_logger_files, 'test.log')
+        setup_logger(logpath=logpath, logterm=True, level='INFO')
+        logger = logging.getLogger('fwl')
+        stdout_handlers = [
+            h
+            for h in logger.handlers
+            if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
+        ]
+        assert len(stdout_handlers) == 1
 
     @pytest.mark.unit
     def test_info_record_reaches_handler(self):


### PR DESCRIPTION
## Description
`TestSetupLogger` in `tests/utils/test_logs.py` errors on machines whose `TMPDIR` is an NFS mount. The tests call `setup_logger(logpath=..., logterm=False)` with a path inside an inline `with tempfile.TemporaryDirectory()`, but the `FileHandler` that `setup_logger` attaches to the shared `fwl` logger is never closed, so the logfile is still open when the directory is torn down.

On a local filesystem an unlinked-but-open file is invisible to `rmdir`. On NFS the server keeps the open file as a `.nfsXXXX` entry until the descriptor closes, so `rmdir` sees a non-empty directory and raises `OSError: [Errno 39] Directory not empty` during cleanup. Because the failure is in `TemporaryDirectory` teardown rather than an assertion, every affected test reports as failed even though its checks passed. CI does not catch this because the runners use local-disk temp space.

Fix: add a module-level `tmpdir_that_closes_logger_files` fixture that owns the `TemporaryDirectory`, yields it to the test, and after the test returns closes and detaches the `fwl` handlers before its own `with` block removes the directory. Every `setup_logger` / `bootstrap_logger` test that writes a logfile now takes this fixture instead of opening its own `TemporaryDirectory`. This covers the `TestSetupLogger` tests, the two `fmt` tests, and the two `TestBootstrapLogger` tests that write a logfile (the latter three were added by #708 / #776).

Note on the design:
- A plain post-test teardown fixture does not fix this: an inline `with tempfile.TemporaryDirectory()` inside a test removes the directory when the method returns, which is before any fixture teardown runs. The fixture therefore has to own the directory so the close happens between the test and the removal.
- `TestBootstrapLogger`'s existing `pristine_fwl` fixture is kept as-is. It provides a handler-free logger at setup for that class's preconditions; it cannot fix the cleanup itself (same too-late ordering), so its two file-writing tests use the shared fixture for the directory.

This branch is rebased onto `main` after #776 merged, so it applies the fix to the tests that PR added as well.

Closes #791

## Validation of changes
- `tests/utils/test_logs.py`: 49 tests pass locally; `ruff check` and `ruff format --check` clean.
- Reproduced and fixed on real NFS storage (a Kapteyn workstation with `$HOME` on NFS), with `TMPDIR` pointing at the NFS mount, running `TestSetupLogger` and `TestBootstrapLogger`:
  - Pre-fix (`main`, post-#776): `17 failed, 5 passed`, with `OSError: [Errno 39] Directory not empty` in `TemporaryDirectory` cleanup. The failures include the two `TestBootstrapLogger` file-tests added by #776. The 5 passes are the tests that never open a FileHandler (the invalid-level test and the console-only bootstrap tests).
  - With this fix: `22 passed` on the same NFS `TMPDIR`.

Test configuration: reproduction on a Linux NFS mount (the reported condition); local development checks on macOS with the PROTEUS conda environment (Python 3.12).

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
