### PR TITLE
Stop re-downloading cached FWL_DATA and AGNI data on every CI run

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -527,11 +527,20 @@ runs:
     # ------------------------------------------------------------------
     # 9. FWL_DATA cache + smoke / full data download
     # ------------------------------------------------------------------
+    # The key hashes BOTH dataset descriptors: .github/data-manifest.yaml (the
+    # older download() datasets: spectral files, stellar spectra, tracks) and
+    # src/proteus/data/proteus_manifest.toml (the fwl-io pins for the exoplanet
+    # + mass-radius reference data). Keying on the fwl-io manifest as well means
+    # a Zenodo re-pin busts the cache and forces a fresh save. Without it, files
+    # pinned after the cache was first frozen re-download on every run: the key
+    # stays constant, actions/cache exact-hits and never re-saves, so the stale
+    # tree can never pick them up. The restore-keys prefix still lets a fresh
+    # save build on the previous tree instead of re-downloading everything.
     - name: Cache FWL_DATA
       uses: actions/cache@v5
       with:
         path: ~/fwl_data
-        key: fwl-data-${{ runner.os }}-${{ hashFiles('.github/data-manifest.yaml') }}
+        key: fwl-data-${{ runner.os }}-${{ hashFiles('.github/data-manifest.yaml', 'src/proteus/data/proteus_manifest.toml') }}
         restore-keys: |
           fwl-data-${{ runner.os }}-
 

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -387,6 +387,18 @@ runs:
           fi
           return $rc
         }
+        # Skip the fetch when a warm cache already holds a complete res/ tree.
+        # res_complete asserts every required artifact is present AND non-empty
+        # (a zero-byte file from a green-but-empty fetch fails the -s test), so a
+        # tree that passes needs no repair and re-pulling it is pure download
+        # cost (~200 s, dominated by the thermodynamics archive). An incomplete
+        # or partially-written tree fails the check and falls through to the
+        # retry loop below, which overwrites and repairs it, so the repair path
+        # the unconditional fetch was added for is preserved.
+        if res_complete 2>/dev/null; then
+          echo "AGNI basic data already complete in res/ (warm cache); skipping fetch."
+          exit 0
+        fi
         fetch="$GITHUB_WORKSPACE/AGNI/src/get_data.sh"
         delays=(10 30 60)
         attempts=$(( ${#delays[@]} + 1 ))

--- a/.github/data-manifest.yaml
+++ b/.github/data-manifest.yaml
@@ -1,9 +1,10 @@
 # PROTEUS data manifest -- explicit version pins for the datasets CI caches.
 #
 # The CI composite action (.github/actions/setup-proteus/action.yml) hashes
-# this file to key the FWL_DATA cache. The cache invalidates only when this
-# manifest changes; CI runs that don't change the manifest reuse the
-# previously cached FWL_DATA tree.
+# this file together with src/proteus/data/proteus_manifest.toml (the fwl-io
+# dataset pins) to key the FWL_DATA cache. The cache invalidates when either
+# descriptor changes; CI runs that change neither reuse the previously cached
+# FWL_DATA tree.
 #
 # Bump a version string in this file when:
 #   * a new dataset becomes a hard requirement of a tier the CI runs;


### PR DESCRIPTION
## Description

Two cheap caching fixes for the fast PR checks, addressing part of #793. Both target the "Set up PROTEUS environment" step, which is where nearly all of the recent slowdown lives (Linux setup grew from ~4.5 min in May to ~14 min now; the unit tests themselves are still ~90 s). Both the Linux and macOS legs were affected.

**FWL_DATA cache (solution 1 in #793).** The cache key hashed only `.github/data-manifest.yaml`, which has not changed since the exoplanet and mass-radius reference data were moved to fwl-io (#782). With a constant key, `actions/cache` exact-hits and never re-saves, so the 58 fwl-io reference files (~190 s of serial per-file downloads) were absent from the frozen tree, re-downloaded on every run, and thrown away at job end. This PR hashes `src/proteus/data/proteus_manifest.toml` (the real fwl-io pins) into the key as well, so:

- a Zenodo re-pin now busts the cache and forces a fresh save, instead of silently re-downloading forever against a frozen exact-hit cache;
- the key changes once with this PR, which seeds a fresh, complete cache; the `restore-keys` prefix lets that save build on the previous tree rather than re-downloading everything.

**AGNI spectral-data fetch (solution 2 in #793).** The fetch ran unconditionally, re-pulling ~200 s of data (dominated by the thermodynamics archive) even when the warm AGNI cache already held a complete `res/` tree. It is now guarded by the step's existing `res_complete` check: skip when every required artifact is present and non-empty, and fall through to the existing retry/repair loop otherwise. The repair path the unconditional fetch was added for (a partial or zero-byte `res/` from a green-but-incomplete download) is preserved, because such a tree fails `res_complete` and still triggers the fetch.

Solutions 3 (skip the real-binary toolchain for the mocked unit job) and 4 (decouple downloads from the OS matrix) from #793 are deliberately out of scope here; they need verification and design first.

## Validation of changes

Confirmed on CI (both runners): a warm re-run downloads 0 reference files and skips the AGNI fetch, cutting the job from 16m30s to 6m39s on Linux and 11m50s to 5m19s on macOS. Full evidence and the two-run explanation are in [this comment](https://github.com/FormingWorlds/PROTEUS/pull/794#issuecomment-5105593962).

Test configuration: CI-config only (no Python touched); the two guarding unit tests (`test_ci_setup_installs_every_declared_extra`, `test_ci_config_never_pins_user`) pass locally.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
