### PR TITLE
Write the JANUS snapshot from the column it solved

### DIFF
--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -22,6 +22,16 @@ class Atmos_t:
         # Atmosphere object internal to JANUS or AGNI
         self._atm = None
 
+        # The most recently solved atmosphere, for the modules whose solver
+        # returns a column that is not the one it was given. JANUS copies
+        # `_atm` before it integrates and resamples the copy onto the radiative
+        # grid, so only the copy carries a profile at all: `_atm` keeps the
+        # surface boundary condition between iterations and nothing else, its
+        # profile arrays sitting at their allocated length with only the
+        # boundary cell written. Read this one, never `_atm`, for anything that
+        # wants the atmosphere itself. AGNI solves in place and leaves it None.
+        self._atm_solved = None
+
         # Whether the most recent atmosphere call converged. For AGNI this
         # is True iff the Newton/LM solver converged on at least one attempt;
         # JANUS, dummy, and transparent solvers always set it True. The main

--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -22,15 +22,15 @@ class Atmos_t:
         # Atmosphere object internal to JANUS or AGNI
         self._atm = None
 
-        # The most recently solved atmosphere, for the modules whose solver
-        # returns a column that is not the one it was given. JANUS copies
-        # `_atm` before it integrates and resamples the copy onto the radiative
-        # grid, so only the copy carries a profile at all: `_atm` keeps the
-        # surface boundary condition between iterations and nothing else, its
-        # profile arrays sitting at their allocated length with only the
-        # boundary cell written. Read this one, never `_atm`, for anything that
-        # wants the atmosphere itself. AGNI solves in place and leaves it None.
-        self._atm_solved = None
+        # The column JANUS last solved, and JANUS only: None under every other
+        # atmosphere module. JANUS copies `_atm` before it integrates and
+        # resamples the copy onto the radiative grid, so only the copy carries
+        # a profile at all. `_atm` keeps the surface boundary condition between
+        # iterations and nothing else, its profile arrays sitting at their
+        # allocated length with only the boundary cell written, so anything
+        # that wants the atmosphere itself has to read this instead. AGNI
+        # solves its column in place and needs no second reference.
+        self._atm_janus_last = None
 
         # Whether the most recent atmosphere call converged. For AGNI this
         # is True iff the Newton/LM solver converged on at least one attempt;

--- a/src/proteus/atmos_clim/janus.py
+++ b/src/proteus/atmos_clim/janus.py
@@ -199,7 +199,12 @@ def RunJANUS(
     Returns
     ----------
         atm : atmos
-            Updated atmos object
+            The solved atmosphere. This is not the object passed in: the
+            adiabat solve copies that one before integrating and returns a
+            copy resampled onto the radiative grid, and only the copy carries
+            a profile and fluxes on one common grid. The object passed in is
+            left holding the surface boundary condition alone and remains the
+            seed for the next call.
         output : dict
             Output variables, as a dict
 
@@ -366,4 +371,4 @@ def RunJANUS(
             x_xuv = 0.0
         hf_row[f'{g}_vmr_xuv'] = x_xuv
 
-    return output
+    return atm, output

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -130,7 +130,7 @@ def run_atmosphere(
             InitStellarSpectrum(dirs, wl_un, fl_un, spectral_file_nostar)
             atmos_o._atm = InitAtm(dirs, config)
 
-        atmos_o._atm_solved, atm_output = RunJANUS(
+        atmos_o._atm_janus_last, atm_output = RunJANUS(
             atmos_o._atm, dirs, config, hf_row, hf_all, write_data=write_data
         )
 
@@ -254,11 +254,11 @@ def write_atmosphere_snapshot(atmos_o: Atmos_t, config: Config, dirs: dict, hf_r
         # back onto it. Its arrays are sized for the integration grid while
         # those fluxes are on the radiative one, so it cannot be written as a
         # single consistent snapshot.
-        if atmos_o._atm_solved is None:
+        if atmos_o._atm_janus_last is None:
             log.warning('Cannot write atmosphere; JANUS has not solved a column yet')
             return
 
-        write_atmos_ncdf(atmos_o._atm_solved, dirs, time)
+        write_atmos_ncdf(atmos_o._atm_janus_last, dirs, time)
 
     # Otherwise, write no atmosphere NetCDF
 

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -130,7 +130,9 @@ def run_atmosphere(
             InitStellarSpectrum(dirs, wl_un, fl_un, spectral_file_nostar)
             atmos_o._atm = InitAtm(dirs, config)
 
-        atm_output = RunJANUS(atmos_o._atm, dirs, config, hf_row, hf_all, write_data=write_data)
+        atmos_o._atm_solved, atm_output = RunJANUS(
+            atmos_o._atm, dirs, config, hf_row, hf_all, write_data=write_data
+        )
 
     elif config.atmos_clim.module == 'agni':
         # Import
@@ -246,11 +248,17 @@ def write_atmosphere_snapshot(atmos_o: Atmos_t, config: Config, dirs: dict, hf_r
     elif config.atmos_clim.module == 'janus':
         from proteus.atmos_clim.janus import write_atmos_ncdf
 
-        if atmos_o._atm is None:
-            log.warning('Cannot write atmosphere; JANUS object unallocated')
+        # The solved column, not `_atm`: JANUS copies `_atm` before it
+        # integrates and resamples the copy, so `_atm` carries no profile of
+        # its own, only the surface boundary condition and the fluxes written
+        # back onto it. Its arrays are sized for the integration grid while
+        # those fluxes are on the radiative one, so it cannot be written as a
+        # single consistent snapshot.
+        if atmos_o._atm_solved is None:
+            log.warning('Cannot write atmosphere; JANUS has not solved a column yet')
             return
 
-        write_atmos_ncdf(atmos_o._atm, dirs, time)
+        write_atmos_ncdf(atmos_o._atm_solved, dirs, time)
 
     # Otherwise, write no atmosphere NetCDF
 

--- a/tests/atmos_clim/test_janus.py
+++ b/tests/atmos_clim/test_janus.py
@@ -386,10 +386,15 @@ def test_run_janus_gobs_inverse_square_of_robs(monkeypatch, tmp_path):
     R_int = 6.371e6
     z_obs_height = 8.0e4  # m; observed level sits this far above the surface
 
-    atm = _build_run_atm(g_surf=g_surf, z_obs_height=z_obs_height, stale_grav=g_surf)
+    solved_atm = _build_run_atm(g_surf=g_surf, z_obs_height=z_obs_height, stale_grav=g_surf)
+    # The seed the caller holds between iterations. JANUS deep-copies it before
+    # integrating and resamples the copy, so the solved column is always a
+    # different object; keeping them distinct here is what lets the return
+    # value below tell the two apart.
+    seed_atm = SimpleNamespace()
 
-    # Solver is mocked to return the fake atmosphere unchanged.
-    monkeypatch.setattr('janus.modules.MCPA', lambda *a, **kw: atm)
+    # Solver is mocked to return the solved column, not the seed it was given.
+    monkeypatch.setattr('janus.modules.MCPA', lambda *a, **kw: solved_atm)
     # State push and hydrostatic solve are covered by their own unit tests.
     monkeypatch.setattr(janus_mod, 'UpdateStateAtm', lambda *a, **kw: None)
     # Deterministic "observed level" = last array entry, independent of p_obs.
@@ -407,8 +412,15 @@ def test_run_janus_gobs_inverse_square_of_robs(monkeypatch, tmp_path):
     }
     dirs = {'output': str(tmp_path)}
 
-    # Run JANUS
-    output = RunJANUS(atm, dirs, config, hf_row, None, write_in_tmp_dir=False)
+    # Run JANUS. The solved column comes back alongside the outputs; it is what
+    # a snapshot must be written from, so the caller can reach it.
+    solved, output = RunJANUS(seed_atm, dirs, config, hf_row, None, write_in_tmp_dir=False)
+
+    # Discrimination: the seed and the solved column are different objects, so
+    # handing back the seed, which is what the caller used to be left holding,
+    # fails here rather than passing an is-not-None check.
+    assert solved is solved_atm
+    assert solved is not seed_atm
 
     # Check additive radii
     R_obs_expected = R_int + z_obs_height

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -255,9 +255,14 @@ def test_shallow_mixed_ocean_layer_zero_flux_keeps_temperature_constant():
 # ---------------------------------------------------------------------------
 
 
-def _fake_atmos_o(atm):
-    """Minimal Atmos_t stand-in exposing only the `_atm` attribute."""
-    return SimpleNamespace(_atm=atm)
+def _fake_atmos_o(atm, solved=None):
+    """Minimal Atmos_t stand-in exposing the two atmosphere attributes.
+
+    `_atm` is the module's own struct; `_atm_solved` is the column JANUS
+    returns from a solve, which is a different object from the one it was
+    given and is the only one whose profiles and fluxes share a grid.
+    """
+    return SimpleNamespace(_atm=atm, _atm_solved=solved)
 
 
 def _fake_config(module):
@@ -322,10 +327,20 @@ def test_write_atmosphere_snapshot_agni_writes_when_allocated():
 
 
 def test_write_atmosphere_snapshot_janus_writes():
-    """For JANUS with a present struct, the dispatch calls the JANUS writer
-    once with the current time, and NOT the AGNI writer."""
-    atm = object()
-    atmos_o = _fake_atmos_o(atm)
+    """For JANUS the dispatch writes the solved column, not the seed.
+
+    JANUS integrates its adiabat on a high-resolution grid and resamples onto
+    the radiative grid when it solves, so the object it was handed keeps the
+    integration profiles while the fluxes written back onto it sit on the
+    radiative grid. Writing that object mixes two grids and the NetCDF write
+    fails on the shape mismatch, so the snapshot has to come from the solved
+    column the solver returned.
+
+    Edge case: a run that has not solved a column yet has nothing coherent to
+    write, and the dispatch must return rather than fall back to the seed.
+    """
+    seed, solved = object(), object()
+    atmos_o = _fake_atmos_o(seed, solved=solved)
     config = _fake_config('janus')
     dirs = {'output': '/tmp/x'}
     with (
@@ -333,5 +348,18 @@ def test_write_atmosphere_snapshot_janus_writes():
         patch('proteus.atmos_clim.janus.write_atmos_ncdf') as janus_w,
     ):
         atmos_wrapper.write_atmosphere_snapshot(atmos_o, config, dirs, {'Time': 4675466.0})
-    janus_w.assert_called_once_with(atm, dirs, 4675466.0)
+    janus_w.assert_called_once_with(solved, dirs, 4675466.0)
+    # Discrimination: the seed is a different object, so a dispatch that still
+    # reached for `_atm` would have been called with it instead.
+    assert janus_w.call_args.args[0] is not seed
     agni_w.assert_not_called()
+
+    # Seed present but never solved: nothing is written.
+    unsolved = _fake_atmos_o(seed, solved=None)
+    with (
+        patch('proteus.atmos_clim.agni.write_atmos_ncdf') as agni_w2,
+        patch('proteus.atmos_clim.janus.write_atmos_ncdf') as janus_w2,
+    ):
+        atmos_wrapper.write_atmosphere_snapshot(unsolved, config, dirs, {'Time': 4675466.0})
+    janus_w2.assert_not_called()
+    agni_w2.assert_not_called()

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -258,11 +258,11 @@ def test_shallow_mixed_ocean_layer_zero_flux_keeps_temperature_constant():
 def _fake_atmos_o(atm, solved=None):
     """Minimal Atmos_t stand-in exposing the two atmosphere attributes.
 
-    `_atm` is the module's own struct; `_atm_solved` is the column JANUS
+    `_atm` is the module's own struct; `_atm_janus_last` is the column JANUS
     returns from a solve, which is a different object from the one it was
     given and is the only one whose profiles and fluxes share a grid.
     """
-    return SimpleNamespace(_atm=atm, _atm_solved=solved)
+    return SimpleNamespace(_atm=atm, _atm_janus_last=solved)
 
 
 def _fake_config(module):
@@ -363,3 +363,77 @@ def test_write_atmosphere_snapshot_janus_writes():
         atmos_wrapper.write_atmosphere_snapshot(unsolved, config, dirs, {'Time': 4675466.0})
     janus_w2.assert_not_called()
     agni_w2.assert_not_called()
+
+
+def test_run_atmosphere_keeps_the_column_janus_solved():
+    """The JANUS dispatch stores the solved column where the writer reads it.
+
+    JANUS returns a column that is not the object it was given, and the
+    end-of-run snapshot is written from the returned one. That wiring is the
+    single point where a regression would silently put the run back to writing
+    the seed, which cannot be written at all: its profile arrays are sized for
+    the integration grid while the fluxes on it are on the radiative grid.
+
+    Verifies:
+    - What the solver returned is what the struct carries afterwards.
+    - The seed is left in place, so the next iteration still integrates from
+      the object JANUS expects rather than from a resampled column.
+    - The struct starts out carrying nothing, so the attribute is genuinely
+      written by the call rather than pre-set by the fixture.
+    """
+    from proteus.atmos_clim.common import Atmos_t
+
+    seed, solved = object(), object()
+    atmos_o = Atmos_t()
+    atmos_o._atm = seed
+    assert atmos_o._atm_janus_last is None
+
+    config = SimpleNamespace(
+        atmos_clim=SimpleNamespace(
+            module='janus',
+            albedo_pl=0.0,
+            rayleigh=False,
+            cloud_enabled=False,
+            surf_state='fixed',
+        ),
+        interior_energetics=SimpleNamespace(module='aragog'),
+    )
+    hf_row = {
+        'T_magma': 1800.0,
+        'M_planet': 6.0e24,
+        'R_obs': 6.4e6,
+        'F_int': 120.0,
+        'F_atm': 100.0,
+        'axial_period': 86400.0,
+        'atm_kg_per_mol': 0.029,
+        'T_surf': 0.0,
+        'R_int': 6.371e6,
+        'R_star': 6.96e8,
+        'F_olr': 200.0,
+        'F_sct': 100.0,
+        'F_ins': 1361.0,
+        'separation': 1.5e11,
+    }
+    atm_output = {'albedo': 0.2, 'F_atm': 100.0}
+
+    with patch(
+        'proteus.atmos_clim.janus.RunJANUS', return_value=(solved, atm_output)
+    ) as run_janus:
+        atmos_wrapper.run_atmosphere(
+            atmos_o,
+            config,
+            {'output': '/tmp/x'},
+            {'total': 5},
+            [1.0],
+            [1.0],
+            False,
+            None,
+            hf_row,
+        )
+
+    run_janus.assert_called_once()
+    # The seed is what JANUS was handed, and it is what the struct keeps as
+    # its seed; the solved column is stored separately.
+    assert run_janus.call_args.args[0] is seed
+    assert atmos_o._atm is seed
+    assert atmos_o._atm_janus_last is solved

--- a/tests/integration/test_integration_zalmoxis_atmodeller.py
+++ b/tests/integration/test_integration_zalmoxis_atmodeller.py
@@ -278,20 +278,32 @@ def test_atmodeller_whole_element_totals_in_hf_row_schema_under_zalmoxis():
     GetHelpfileKeys is caught regardless of which outgas backend is
     in play.
 
-    Discrimination: per-element check so a regression that dropped
-    one element's total fails the specific assertion. The volatile
-    species (H, O, C, N, S) and the rock-forming species (Si, Mg,
-    Fe, Na) are pinned together because the dry-mass subtraction
-    treats them uniformly.
+    Discrimination: the elements that must carry a column are named
+    literally, so dropping any one of them from its source list fails
+    here. Comparing against the source lists instead would not: both
+    sides of that comparison are built from the same lists and move
+    together, so a dropped element would pass. The volatile species
+    (H, O, C, N, S) and the rock-forming species are pinned together
+    because the dry-mass subtraction treats them uniformly.
     """
-    from proteus.utils.constants import element_list, noble_gases
+    from proteus.utils.constants import (
+        element_list,
+        noble_gases,
+        vap_element_list,
+        vol_element_list,
+    )
     from proteus.utils.coupler import GetHelpfileKeys, ZeroHelpfileRow
 
-    # The reactive and rock-forming elements plus the opt-in noble gases, which
-    # are tracked as elements in the whole-planet mass balance.
-    assert set(element_list) == {'H', 'O', 'C', 'N', 'S', 'Si', 'Mg', 'Fe', 'Na'} | set(
-        noble_gases
-    )
+    # The volatile and rock-forming elements plus the opt-in noble gases, which
+    # are tracked as elements in the whole-planet mass balance. A floor, not an
+    # equality, so a new element is an addition rather than a failure.
+    required = {'H', 'O', 'C', 'N', 'S', 'Si', 'Mg', 'Fe', 'Na'} | set(noble_gases)
+    missing = required - set(element_list)
+    assert not missing, f'{sorted(missing)} dropped from element_list; mass balance breaks'
+
+    # Every element the sources declare reaches the list, exactly once.
+    assert set(element_list) == set(vol_element_list) | set(vap_element_list) | set(noble_gases)
+    assert len(element_list) == len(set(element_list))
     keys = GetHelpfileKeys()
     for e in element_list:
         col = f'{e}_kg_total'

--- a/tests/integration/test_integration_zalmoxis_calliope.py
+++ b/tests/integration/test_integration_zalmoxis_calliope.py
@@ -397,26 +397,38 @@ def test_element_list_includes_oxygen_under_calliope_pair():
     that removed O from the list would let M_atm exceed M_planet at
     high H budgets.
 
-    The list also includes the rock-forming elements (Si, Mg, Fe,
-    Na) so the same dry-mass subtraction works for sub-Neptune and
-    super-Earth compositions where the dissolved rocky inventory is
-    non-negligible. Pin the full documented set.
+    The list also includes the rock-forming elements so the same
+    dry-mass subtraction works for sub-Neptune and super-Earth
+    compositions where the dissolved rocky inventory is
+    non-negligible.
 
-    Discrimination: set equality fails on both addition and removal
-    of any element.
+    Discrimination: the elements that must be present are named
+    literally, so dropping any one of them from its source list fails
+    here. Comparing against the source lists instead would not: both
+    sides of that comparison are built from the same lists and move
+    together, so it would hold however many elements were removed.
+    The membership pin is a floor rather than an equality, so adding
+    an element is not itself a failure, and a separate check requires
+    the construction to reach every element its sources declare.
     """
-    from proteus.utils.constants import element_list, noble_gases
-
-    # The reactive and rock-forming elements plus the opt-in noble gases, which
-    # are tracked as elements in the whole-planet mass balance.
-    assert set(element_list) == {'H', 'O', 'C', 'N', 'S', 'Si', 'Mg', 'Fe', 'Na'} | set(
-        noble_gases
+    from proteus.utils.constants import (
+        element_list,
+        noble_gases,
+        vap_element_list,
+        vol_element_list,
     )
-    # The volatile species CALLIOPE partitions must all be present.
-    for vol in ('H', 'O', 'C', 'N', 'S'):
-        assert vol in element_list, (
-            f'{vol} missing from element_list; whole-planet bookkeeping breaks'
-        )
+
+    # The volatile and rock-forming elements plus the opt-in noble gases, which
+    # are tracked as elements in the whole-planet mass balance. Losing any of
+    # these silently drops its mass from M_ele and from the dry-mass target.
+    required = {'H', 'O', 'C', 'N', 'S', 'Si', 'Mg', 'Fe', 'Na'} | set(noble_gases)
+    missing = required - set(element_list)
+    assert not missing, f'{sorted(missing)} dropped from element_list; mass balance breaks'
+
+    # Every element the sources declare reaches the list, and none appears
+    # twice, so a sum over element_list counts each element exactly once.
+    assert set(element_list) == set(vol_element_list) | set(vap_element_list) | set(noble_gases)
+    assert len(element_list) == len(set(element_list))
 
 
 def test_whole_element_helpfile_keys_register_per_element_total_columns():


### PR DESCRIPTION
## Description

Three integration-tier tests are failing on `main` right now. The last nightly ran on `eadad47e`, before both #775 and #634 merged, so nothing has reported them yet; tonight's run would.

The JANUS one is a real bug, not a stale test. `write_atmosphere_snapshot` wrote the atmosphere object the caller holds between iterations, but JANUS copies that object before it integrates and resamples the copy onto the radiative grid. The object the caller keeps therefore has no profile of its own: its arrays stay at the integration length with only the surface cell written, while the fluxes written back onto it are on the radiative grid. `write_ncdf` takes its level count from the profile and then assigns a flux array of the other length into it, so the write raised `shape mismatch ... (10001,) and (50,)` and no JANUS run could produce a final snapshot at all.

The solve already builds the column whose profiles and fluxes share a grid, and already writes its own per-iteration file from it, but never returned it. It now comes back alongside the outputs and the snapshot is written from it. The seed is left alone deliberately: the resample does not resize the integration index arrays, so reusing the solved column as the next seed would write past the end of them.

The other two are the whole-planet element checks, which compared the element list against a literal of the nine elements it used to hold. #634 added Al, Ti, Ca and K, so both failed although nothing they protect had changed. They now require the elements the mass balance depends on to be present, which is the property at stake, and separately require the list to reach every element its sources declare and hold each once. Growing the list is no longer a failure; dropping an element from it still is.

## Validation of changes

macOS 15 (Darwin 25.3.0), Python 3.12, conda env with the current module pins.

All three previously-failing tests pass, and the full local tiers are green on the branch tip: unit 2823 passed / 11 skipped, integration 197 passed / 11 skipped, smoke 24 passed / 1 skipped. `ruff check` and `ruff format --check` clean, `tools/validate_test_structure.sh` complete, and the test-quality baseline moves from 11 to 10.

Each fix was checked against the bug it is supposed to catch rather than only against the current tree. Reverting `RunJANUS` to hand back the seed fails the JANUS unit test; pointing the snapshot dispatch back at the old attribute fails the wrapper test; removing `Fe` from `vap_element_list` fails both element checks, which the previous wording of those checks did not.

The written snapshot was also inspected directly rather than only checked for the absence of a crash: a JANUS run through `Proteus.start()` produces `2_atm.nc` with `nlev_c=50`, `nlev_l=51`, `ngases=11`, no NaN or Inf, and `net_flux[0]` matching the coupled loop's `F_atm` to float32 precision, so the file holds the converged state the interior was given.

One thing this does not fix, worth a separate issue: the `gravity` array in the JANUS snapshot is not consistent with the `z` array beside it. `write_ncdf` reintegrates the heights just before writing but leaves `grav_z` at whatever the adiabat solve last set, so the two disagree by tens of percent at altitude. The per-iteration snapshots already carried this, so it is not introduced here, but `observe/petitRADTRANS.py` reads that column and it should be looked at on the JANUS side.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
