### PR TITLE
Option for time-dependent scaling of stellar fluxes

### DIFF
--- a/docs/Reference/config/star_orbit.md
+++ b/docs/Reference/config/star_orbit.md
@@ -17,6 +17,10 @@ See also [Model description](../../Explanations/model.md#stellar-evolution-mors)
 | `mass` | float | `1.0` | Stellar mass \[M$_\odot$] |
 | `age_ini` | float | `0.1` | Model start age \[Gyr] |
 | `bol_scale` | float | `1.0` | Bolometric luminosity scaling factor |
+| `bol_scale_start` | float or none | `none` | Stellar age from which `bol_scale` is applied \[Gyr]; `none` disables scaling entirely |
+| `bol_scale_duration` | float | `0.0` | Duration for which `bol_scale` is applied \[Gyr], starting at `bol_scale_start` |
+
+`bol_scale` only takes effect while the model's stellar age lies within the start-plus-duration interval. So, all three options should be set together. The scaling factor is applied uniformly to all stellar flux terms.
 
 ### MORS stellar tracks `[star.mors]`
 

--- a/docs/Reference/config/star_orbit.md
+++ b/docs/Reference/config/star_orbit.md
@@ -17,7 +17,7 @@ See also [Model description](../../Explanations/model.md#stellar-evolution-mors)
 | `mass` | float | `1.0` | Stellar mass \[M$_\odot$] |
 | `age_ini` | float | `0.1` | Model start age \[Gyr] |
 | `bol_scale` | float | `1.0` | Bolometric luminosity scaling factor |
-| `bol_scale_start` | float or none | `none` | Stellar age from which `bol_scale` is applied \[Gyr]; `none` disables scaling entirely |
+| `bol_scale_start` | float or none | `none` | Stellar age from which `bol_scale` is applied \[Gyr]; `none` to disable, in which case `bol_scale` should be set to unity |
 | `bol_scale_duration` | float | `0.0` | Duration for which `bol_scale` is applied \[Gyr], starting at `bol_scale_start` |
 
 `bol_scale` only takes effect while the model's stellar age lies within the start-plus-duration interval. So, all three options should be set together. The scaling factor is applied uniformly to all stellar flux terms.

--- a/input/all_options.toml
+++ b/input/all_options.toml
@@ -173,6 +173,8 @@ config_version = "3.0"
     age_ini                   = 0.100        # model start age [Gyr]
     module                    = "mors"       # mors | dummy
     bol_scale                 = 1.0          # bolometric luminosity scaling factor
+    bol_scale_start           = "none"       # stellar age from which bol_scale is applied [Gyr]; None to disable
+    bol_scale_duration        = 0.0          # duration for which bol_scale is applied [Gyr]
 
     [star.mors]
         # Rotation and evolution

--- a/input/dummy.toml
+++ b/input/dummy.toml
@@ -10,13 +10,15 @@ config_version = "3.0"
 
     [params.dt]
         initial  = 1e2           # initial step [yr]
-        minimum  = 1e2           # min step [yr]
-        maximum  = 3e7           # max step [yr]
+        minimum  = 1e3           # min step [yr]
+        maximum  = 2e8           # max step [yr]
+        method = 'maximum'
 
         [params.stop.time]
+            enabled = true
             maximum = 1e9        # stop time [yr]
         [params.stop.solid]
-            enabled = true
+            enabled = false
         [params.stop.escape]
             enabled = false
         [params.stop.radeqm]
@@ -25,6 +27,11 @@ config_version = "3.0"
 # Star: fixed solar luminosity (no evolution)
 [star]
     module = "dummy"
+
+    bol_scale                 = 0.0          # bolometric luminosity scaling factor
+    bol_scale_start           = 0.2          # stellar age from which bol_scale is applied [Gyr]
+    bol_scale_duration        = 0.05          # duration for which bol_scale is applied [Gyr]
+
     [star.dummy]
         radius = 1.0                 # [R_sun]
 

--- a/input/dummy.toml
+++ b/input/dummy.toml
@@ -10,15 +10,13 @@ config_version = "3.0"
 
     [params.dt]
         initial  = 1e2           # initial step [yr]
-        minimum  = 1e3           # min step [yr]
-        maximum  = 2e8           # max step [yr]
-        method = 'maximum'
+        minimum  = 1e2           # min step [yr]
+        maximum  = 3e7           # max step [yr]
 
         [params.stop.time]
-            enabled = true
             maximum = 1e9        # stop time [yr]
         [params.stop.solid]
-            enabled = false
+            enabled = true
         [params.stop.escape]
             enabled = false
         [params.stop.radeqm]
@@ -27,11 +25,6 @@ config_version = "3.0"
 # Star: fixed solar luminosity (no evolution)
 [star]
     module = "dummy"
-
-    bol_scale                 = 0.0          # bolometric luminosity scaling factor
-    bol_scale_start           = 0.2          # stellar age from which bol_scale is applied [Gyr]
-    bol_scale_duration        = 0.05          # duration for which bol_scale is applied [Gyr]
-
     [star.dummy]
         radius = 1.0                 # [R_sun]
 

--- a/src/proteus/atmos_clim/dummy.py
+++ b/src/proteus/atmos_clim/dummy.py
@@ -132,6 +132,12 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
     atm_H = const_R * T_surf_atm / (hf_row['atm_kg_per_mol'] * hf_row['gravity'])
     R_obs = hf_row['R_int'] + atm_H * config.atmos_clim.dummy.height_factor
 
+    # Bond albedo - handle zero instellation case to avoid divide by zero
+    if fluxes['fl_D_SW'] <= 0.0:
+        bond_albedo = 0.0
+    else:
+        bond_albedo = fluxes['fl_U_SW'] / fluxes['fl_D_SW']
+
     # Return result
     log.info('    T_surf     =  %.3e  K' % T_surf_atm)
     log.info('    F_atm      =  %.3e  W m-2' % F_atm_lim)
@@ -145,7 +151,7 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
     output['F_olr'] = fluxes['fl_U_LW']  # OLR
     output['F_sct'] = fluxes['fl_U_SW']  # Scattered SW flux
     output['R_obs'] = R_obs
-    output['albedo'] = fluxes['fl_U_SW'] / fluxes['fl_D_SW']
+    output['albedo'] = bond_albedo
     output['p_xuv'] = hf_row['P_surf']
     output['R_xuv'] = R_obs
     output['p_obs'] = hf_row['P_surf']

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -287,9 +287,13 @@ def update_bolometry(hf_row: dict):
 
     # Eclipse depth
     #    Accounting for fact that F_ins is scaled to TOA, not to stellar surface.
-    hf_row['eclipse_depth'] = ((hf_row['F_olr'] + hf_row['F_sct']) / hf_row['F_ins']) * (
-        hf_row['R_obs'] / hf_row['separation']
-    ) ** 2.0
+    #    Also, F_ins can be zero when bol_scale is being appled.
+    if hf_row['F_ins'] == 0.0:
+        hf_row['eclipse_depth'] = 0.0
+    else:
+        hf_row['eclipse_depth'] = ((hf_row['F_olr'] + hf_row['F_sct']) / hf_row['F_ins']) * (
+            hf_row['R_obs'] / hf_row['separation']
+        ) ** 2.0
 
 
 def ShallowMixedOceanLayer(hf_cur: dict, hf_pre: dict):

--- a/src/proteus/config/_star.py
+++ b/src/proteus/config/_star.py
@@ -153,13 +153,17 @@ class Star:
     Attributes
     ----------
     bol_scale: float
-        Scale factor to increase the luminosity.
+        Scale factor applied to bolometrically modulate the stellar fluxes.
+    bol_scale_start: float | None
+        Stellar age from which bol_scale is applied [Gyr]. 'None' to disable.
+    bol_scale_duration: float
+        Duration for which bol_scale is applied [Gyr].
     mass: float
         Stellar mass [M_sun]. Note that for Mors,
         it should be between 0.1 and 1.25 solar masses.
         Values outside of the valid range will be clipped.
     age_ini: float
-        Age of system at model initialisation [Gyr].
+        Stellar age at model initialisation, relative to stellar birthline [Gyr].
     module: str | None
         Select star module to use.
     mors: Mors
@@ -181,3 +185,5 @@ class Star:
     dummy: StarDummy = field(factory=StarDummy, validator=valid_stardummy)
 
     bol_scale: float = field(default=1.0, validator=ge(0.0))
+    bol_scale_start = field(default=None, converter=none_if_none)
+    bol_scale_duration: float = field(default=0.0, validator=ge(0.0))

--- a/src/proteus/config/_star.py
+++ b/src/proteus/config/_star.py
@@ -110,8 +110,12 @@ class Mors:
 
 
 def valid_bol_scale_start(instance, attribute, value):
-    if instance.bol_scale != 1.0 and value is None:
+    if instance.bol_scale == 1.0:
+        return
+    if value is None:
         raise ValueError('star.bol_scale_start must be set when star.bol_scale != 1.0')
+    if instance.bol_scale_duration <= 0.0:
+        raise ValueError('star.bol_scale_duration must be > 0 when star.bol_scale != 1.0')
 
 
 def valid_stardummy(instance, attribute, value):
@@ -190,9 +194,12 @@ class Star:
     dummy: StarDummy = field(factory=StarDummy, validator=valid_stardummy)
 
     bol_scale: float = field(default=1.0, validator=ge(0.0))
+    # Must be defined before bol_scale_start: attrs sets attributes in
+    # field-definition order, and valid_bol_scale_start (below) reads
+    # instance.bol_scale_duration, which must already exist on the instance.
+    bol_scale_duration: float = field(default=0.0, validator=ge(0.0))
     bol_scale_start: float | str | None = field(
         default=None,
         converter=none_if_none,
         validator=[optional(ge(0.0)), valid_bol_scale_start],
     )
-    bol_scale_duration: float = field(default=0.0, validator=ge(0.0))

--- a/src/proteus/config/_star.py
+++ b/src/proteus/config/_star.py
@@ -185,7 +185,5 @@ class Star:
     dummy: StarDummy = field(factory=StarDummy, validator=valid_stardummy)
 
     bol_scale: float = field(default=1.0, validator=ge(0.0))
-    bol_scale_start: float | None = field(
-        default=None, converter=none_if_none, validator=optional(ge(0.0))
-    )
+    bol_scale_start = field(default=None, converter=none_if_none, validator=optional(ge(0.0)))
     bol_scale_duration: float = field(default=0.0, validator=ge(0.0))

--- a/src/proteus/config/_star.py
+++ b/src/proteus/config/_star.py
@@ -185,5 +185,7 @@ class Star:
     dummy: StarDummy = field(factory=StarDummy, validator=valid_stardummy)
 
     bol_scale: float = field(default=1.0, validator=ge(0.0))
-    bol_scale_start = field(default=None, converter=none_if_none)
+    bol_scale_start: float | None = field(
+        default=None, converter=none_if_none, validator=optional(ge(0.0))
+    )
     bol_scale_duration: float = field(default=0.0, validator=ge(0.0))

--- a/src/proteus/config/_star.py
+++ b/src/proteus/config/_star.py
@@ -109,6 +109,11 @@ class Mors:
     )
 
 
+def valid_bol_scale_start(instance, attribute, value):
+    if instance.bol_scale != 1.0 and value is None:
+        raise ValueError('star.bol_scale_start must be set when star.bol_scale != 1.0')
+
+
 def valid_stardummy(instance, attribute, value):
     if instance.module != 'dummy':
         return
@@ -185,5 +190,9 @@ class Star:
     dummy: StarDummy = field(factory=StarDummy, validator=valid_stardummy)
 
     bol_scale: float = field(default=1.0, validator=ge(0.0))
-    bol_scale_start = field(default=None, converter=none_if_none, validator=optional(ge(0.0)))
+    bol_scale_start: float | str | None = field(
+        default=None,
+        converter=none_if_none,
+        validator=[optional(ge(0.0)), valid_bol_scale_start],
+    )
     bol_scale_duration: float = field(default=0.0, validator=ge(0.0))

--- a/src/proteus/interior_energetics/common.py
+++ b/src/proteus/interior_energetics/common.py
@@ -593,6 +593,10 @@ class Interior_t:
         # escaped from.
         self.dt_hysteresis_remaining = 0
 
+        # True when the most recent call to next_step() had its step size
+        # clamped. For example, by `_estimate_bolscale()`.
+        self.timestep_clamped = False
+
         # Lookup data for SPIDER (P-S tables, used by E_th and
         # melt-volume bookkeeping). Each is a (nS, nP, 3) array, the
         # third channel being the SI value of the quantity.

--- a/src/proteus/interior_energetics/timestep.py
+++ b/src/proteus/interior_energetics/timestep.py
@@ -329,7 +329,13 @@ def next_step(
 
     # Do not allow step size to skip bolometric scaling start/stop
     if hf_all is not None:
-        dtswitch = min(dtswitch, _estimate_bolscale(hf_all, config))
+        # Clamp dtswitch
+        dt_bolscale = _estimate_bolscale(hf_all, config)
+        dtswitch = min(dtswitch, dt_bolscale)
+
+        # Record the timestep as having been clamped
+        if interior_o is not None:
+            interior_o.timestep_clamped = bool(dt_bolscale <= dtswitch)
 
     # Apply the SPIDER-retry step scale factor uniformly to all branches.
     # In the "static" (Time < 2 yr) and "initial" branches, step_sf is

--- a/src/proteus/interior_energetics/timestep.py
+++ b/src/proteus/interior_energetics/timestep.py
@@ -129,6 +129,51 @@ def _estimate_escape(hf_all: pd.DataFrame, i1: int, i2: int) -> float:
     return dt_escape
 
 
+def _estimate_bolscale(hf_all: pd.DataFrame, config: Config) -> float:
+    """
+    Estimate the time remaining until the bolometric scaling begins or ends.
+
+    This ensures that the timestep does not skip over the bolometric scaling
+    period, if the period is small and the timestep is large.
+
+    Arguments
+    ----------
+    hf_all : pd.DataFrame
+        Dataframe containing simulation variables
+    config : Config
+        Configuration object
+
+    Returns
+    ----------
+    dt_bolscale : float
+        Time remaining until bolometric scaling begins or ends [years].
+    """
+
+    dt_bolscale = np.inf
+
+    # Trivial case: bolometric scaling is not enabled
+    if config.star.bol_scale == 1.0 or config.star.bol_scale_start is None:
+        log.debug('Bolometric scaling is disabled')
+        return dt_bolscale
+
+    # Stellar age now, and the start/end of bolometric scaling
+    age_now = hf_all.iloc[-1].get('age_star', 0.0)
+    age_ini = config.star.bol_scale_start * 1e9
+    age_end = age_ini + config.star.bol_scale_duration * 1e9
+
+    # Before bolometric scaling begins
+    if age_now < age_ini:
+        dt_bolscale = abs(age_ini - age_now)
+        log.debug('Bolometric scaling starts in %.3e yrs' % dt_bolscale)
+
+    # During bolometric scaling
+    elif age_now < age_end:
+        dt_bolscale = abs(age_end - age_now)
+        log.debug('Bolometric scaling ends in %.3e yrs' % dt_bolscale)
+
+    return dt_bolscale
+
+
 def next_step(
     config: Config,
     dirs: dict,
@@ -281,6 +326,10 @@ def next_step(
         dtminimum = config.params.dt.minimum  # absolute
         dtminimum += config.params.dt.minimum_rel * hf_row['Time']  # allow small steps
         dtswitch = max(dtswitch, dtminimum)
+
+    # Do not allow step size to skip bolometric scaling start/stop
+    if hf_all is not None:
+        dtswitch = min(dtswitch, _estimate_bolscale(hf_all, config))
 
     # Apply the SPIDER-retry step scale factor uniformly to all branches.
     # In the "static" (Time < 2 yr) and "initial" branches, step_sf is

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -961,6 +961,10 @@ class Proteus:
             _t0_stellar = time.perf_counter() if _IT_TIMING_ENABLED else 0.0
             update_stellar_spectrum = False
 
+            # Ensure stellar quantities are updated when time-step is clamped.
+            if getattr(self.interior_o, 'timestep_clamped', False):
+                self.sinst_prev = -np.inf
+
             # Calculate new instellation and radius
             if (
                 abs(self.hf_row['Time'] - self.sinst_prev) > self.config.params.dt.starinst

--- a/src/proteus/star/wrapper.py
+++ b/src/proteus/star/wrapper.py
@@ -593,7 +593,7 @@ def update_instellation(hf_row: dict, config: Config, stellar_track=None):
 
     # Determine if bolometric scaling is enabled
     bol_scale_apply = 1.0
-    if config.star.bol_scale != 1.0 or config.star.bol_scale_start is not None:
+    if config.star.bol_scale != 1.0 and config.star.bol_scale_start is not None:
         # Determine when bolometric is currently active
         bol_scale_ini = config.star.bol_scale_start * 1e9
         bol_scale_end = bol_scale_ini + config.star.bol_scale_duration * 1e9

--- a/src/proteus/star/wrapper.py
+++ b/src/proteus/star/wrapper.py
@@ -483,6 +483,12 @@ def update_stellar_quantities(hf_row: dict, config: Config, stellar_track=None):
     log.info('    F_xuv      = %.3e   W m-2' % hf_row['F_xuv'])
     log.info('    T_star     = %.3f    K' % hf_row['T_star'])
 
+    # Inform if applying bolometric scaling
+    if hf_row['bol_scale'] != 1.0:
+        log.info(
+            f'    Scaling factor is currently active on stellar fluxes: {hf_row["bol_scale"]}'
+        )
+
     # Calculate new eqm temperature
     log.debug('Update equilibrium temperature')
     update_equilibrium_temperature(hf_row, config)
@@ -585,9 +591,21 @@ def update_instellation(hf_row: dict, config: Config, stellar_track=None):
                 # XUV flux not provided by Baraffe tracks
                 Fxuv_SI = 0.0
 
+    # Determine if bolometric scaling is enabled
+    bol_scale_apply = 1.0
+    if config.star.bol_scale != 1.0 or config.star.bol_scale_start is not None:
+        # Determine when bolometric is currently active
+        bol_scale_ini = config.star.bol_scale_start * 1e9
+        bol_scale_end = bol_scale_ini + config.star.bol_scale_duration * 1e9
+
+        # Apply it if age is within the range
+        if bol_scale_ini <= hf_row['age_star'] <= bol_scale_end:
+            bol_scale_apply = config.star.bol_scale
+
     # Update hf_row dictionary
-    hf_row['F_ins'] = S_0 * config.star.bol_scale
-    hf_row['F_xuv'] = Fxuv_SI * config.star.bol_scale
+    hf_row['F_ins'] = S_0 * bol_scale_apply
+    hf_row['F_xuv'] = Fxuv_SI * bol_scale_apply
+    hf_row['bol_scale'] = bol_scale_apply
 
 
 def update_equilibrium_temperature(hf_row: dict, config: Config):

--- a/src/proteus/star/wrapper.py
+++ b/src/proteus/star/wrapper.py
@@ -599,7 +599,7 @@ def update_instellation(hf_row: dict, config: Config, stellar_track=None):
         bol_scale_end = bol_scale_ini + config.star.bol_scale_duration * 1e9
 
         # Apply it if age is within the range
-        if bol_scale_ini <= hf_row['age_star'] <= bol_scale_end:
+        if bol_scale_ini <= hf_row['age_star'] < bol_scale_end:
             bol_scale_apply = config.star.bol_scale
 
     # Update hf_row dictionary

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -810,6 +810,7 @@ def GetHelpfileKeys():
         'F_sct',            # outgoing shortwave radiation [W m-2]
         'F_ins',            # incoming instellation flux [W m-2]
         'F_xuv',            # incoming XUV radiation flux [W m-2]
+        'bol_scale',        # bolometric scaling factor [1]
         'tau_atm_TOA',      # optical depth at TOA, at ref wavelength [1]
         'tau_atm_surface',  # optical depth at surface, at ref wavelength [1]
         'atm_Ra_max',      # maximum Rayleigh number across levels [1]

--- a/tests/atmos_clim/test_atmos_clim.py
+++ b/tests/atmos_clim/test_atmos_clim.py
@@ -571,6 +571,82 @@ def test_rundummyatm_albedo_calculation():
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
+def test_rundummyatm_albedo_zero_when_no_downwelling_flux():
+    """Regression: zero instellation (F_ins=0, e.g. night side / a star
+    that has switched off) drives the downwelling shortwave flux to zero.
+    """
+    from proteus.atmos_clim.dummy import RunDummyAtm
+
+    config = MagicMock()
+    config.atmos_clim.dummy.gamma = 0.3
+    config.atmos_clim.dummy.height_factor = 1.0
+    config.orbit.zenith_angle = 0.0
+    config.orbit.s0_factor = 1.0
+    config.atmos_clim.surf_greyalbedo = 0.5
+    config.atmos_clim.surf_state = 'fixed'
+    config.planet.prevent_warming = False
+
+    hf_row = {
+        'T_magma': 1400.0,
+        'albedo_pl': 0.2,
+        'F_ins': 0.0,  # no instellation -> fl_D_SW == 0.0
+        'atm_kg_per_mol': 0.029,
+        'gravity': 9.8,
+        'R_int': 6.371e6,
+        'P_surf': 1e5,
+    }
+
+    # Zero instellation gives zero albedo
+    output = RunDummyAtm({}, config, hf_row)
+    assert output['albedo'] == pytest.approx(0.0, abs=1e-15)
+
+    # Discrimination: the rest of the flux chain (surface emission) is
+    # unaffected by the F_ins=0 change, so F_olr must stay positive
+    assert output['F_olr'] > 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_rundummyatm_albedo_formula_flux_positive():
+    """The zero-flux guard must only fire on the degenerate F_ins=0 case;
+    with positive instellation, albedo is still the closed-form
+    ``surf_greyalbedo / (1 - surf_greyalbedo)`` (the F_ins-dependent
+    prefactor cancels between numerator and denominator).
+
+    surf_greyalbedo=0.25 -> expected = 0.25 / 0.75 = 1/3.
+    """
+    from proteus.atmos_clim.dummy import RunDummyAtm
+
+    config = MagicMock()
+    config.atmos_clim.dummy.gamma = 0.3
+    config.atmos_clim.dummy.height_factor = 1.0
+    config.orbit.zenith_angle = 0.0
+    config.orbit.s0_factor = 1.0
+    config.atmos_clim.surf_greyalbedo = 0.25
+    config.atmos_clim.surf_state = 'fixed'
+    config.planet.prevent_warming = False
+
+    hf_row = {
+        'T_magma': 1400.0,
+        'albedo_pl': 0.2,
+        'F_ins': 1361.0,
+        'atm_kg_per_mol': 0.029,
+        'gravity': 9.8,
+        'R_int': 6.371e6,
+        'P_surf': 1e5,
+    }
+
+    # albedo derived correctly from F_ins and surf_greyalbedo
+    output = RunDummyAtm({}, config, hf_row)
+    assert output['albedo'] == pytest.approx(1.0 / 3.0, rel=1e-12)
+
+    # Discrimination: the zero-flux guard's hardcoded 0.0 must NOT have
+    # leaked into this positive-flux case
+    assert output['albedo'] != pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_rundummyatm_output_keys():
     """Test that all expected output keys are present in returned dictionary.
 

--- a/tests/config/test_star_validators.py
+++ b/tests/config/test_star_validators.py
@@ -72,6 +72,24 @@ def test_star_bol_scale_nonunity_requires_start():
     star_default = Star(bol_scale_start=None)
     assert star_default.bol_scale == pytest.approx(1.0)
 
-    # Providing a start with a non-unity scale is accepted.
-    star_windowed = Star(bol_scale=2.0, bol_scale_start=0.5)
+    # Providing a start and a positive duration with a non-unity scale is
+    # accepted.
+    star_windowed = Star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.1)
     assert star_windowed.bol_scale_start == pytest.approx(0.5)
+
+
+@pytest.mark.unit
+def test_star_bol_scale_nonunity_requires_positive_duration():
+    """A non-unity ``bol_scale`` with ``bol_scale_start`` set but
+    ``bol_scale_duration`` left at its zero default would define a window
+    that never opens (start == end), silently scaling nothing anywhere.
+    That combination must be rejected, not just the missing-start case."""
+    with pytest.raises(Exception, match='bol_scale_duration'):
+        Star(bol_scale=2.0, bol_scale_start=0.5)
+
+    with pytest.raises(Exception, match='bol_scale_duration'):
+        Star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.0)
+
+    # The default bol_scale=1.0 is exempt: a zero duration is a real no-op.
+    star_default = Star(bol_scale_duration=0.0)
+    assert star_default.bol_scale == pytest.approx(1.0)

--- a/tests/config/test_star_validators.py
+++ b/tests/config/test_star_validators.py
@@ -1,0 +1,60 @@
+"""Unit tests for star config fields (config/_star.py).
+
+Testing standards:
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
+"""
+
+from __future__ import annotations
+
+import cattrs
+import pytest
+
+from proteus.config._star import Star
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+
+@pytest.mark.unit
+def test_star_bol_scale_window_defaults_disabled():
+    """By default the bolometric-scaling window is disabled: no start age
+    and zero duration, matching the pre-existing (unwindowed) behaviour
+    when a config only sets ``bol_scale``."""
+    star = Star()
+    assert star.bol_scale_start is None
+    assert star.bol_scale_duration == pytest.approx(0.0)
+    assert star.bol_scale == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_star_bol_scale_start_accepts_numeric_gyr_value():
+    """A numeric ``bol_scale_start`` (Gyr) round-trips through both the
+    direct attrs constructor and cattrs structuring (the TOML path)
+    without being coerced or clamped."""
+    star_direct = Star(bol_scale_start=0.5)
+    assert star_direct.bol_scale_start == pytest.approx(0.5)
+
+    star_cattrs = cattrs.structure({'bol_scale_start': 0.5, 'bol_scale_duration': 0.2}, Star)
+    assert star_cattrs.bol_scale_start == pytest.approx(0.5)
+    assert star_cattrs.bol_scale_duration == pytest.approx(0.2)
+    assert star_direct.bol_scale_start == pytest.approx(star_cattrs.bol_scale_start)
+
+
+@pytest.mark.unit
+def test_star_bol_scale_duration_rejects_negative():
+    """``bol_scale_duration`` uses the ``ge(0.0)`` validator: a negative
+    window length is physically meaningless (time does not run backwards)
+    and must raise rather than silently clamp."""
+    with pytest.raises(Exception, match='bol_scale_duration'):
+        Star(bol_scale_duration=-1.0)
+    star = Star(bol_scale_duration=1.0)
+    assert star.bol_scale_duration == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_star_bol_scale_duration_accepts_zero_boundary():
+    """Exactly zero is the inclusive lower boundary of ``ge(0.0)`` and is
+    also the default; it must be accepted, not rejected as a degenerate
+    (zero-width) window."""
+    star = Star(bol_scale_duration=0.0)
+    assert star.bol_scale_duration == pytest.approx(0.0, abs=1e-15)

--- a/tests/config/test_star_validators.py
+++ b/tests/config/test_star_validators.py
@@ -58,3 +58,20 @@ def test_star_bol_scale_duration_accepts_zero_boundary():
     (zero-width) window."""
     star = Star(bol_scale_duration=0.0)
     assert star.bol_scale_duration == pytest.approx(0.0, abs=1e-15)
+
+
+@pytest.mark.unit
+def test_star_bol_scale_nonunity_requires_start():
+    """A non-unity ``bol_scale`` with no ``bol_scale_start`` would silently
+    apply nowhere (the window is undefined), so the combination is rejected
+    outright rather than left as a config that quietly does nothing."""
+    with pytest.raises(Exception, match='bol_scale_start'):
+        Star(bol_scale=2.0, bol_scale_start=None)
+
+    # The default bol_scale=1.0 is exempt: no window is needed for a no-op.
+    star_default = Star(bol_scale_start=None)
+    assert star_default.bol_scale == pytest.approx(1.0)
+
+    # Providing a start with a non-unity scale is accepted.
+    star_windowed = Star(bol_scale=2.0, bol_scale_start=0.5)
+    assert star_windowed.bol_scale_start == pytest.approx(0.5)

--- a/tests/integration/test_integration_agni_mors.py
+++ b/tests/integration/test_integration_agni_mors.py
@@ -166,7 +166,7 @@ def test_star_bol_scale_allows_zero_rejects_negative():
     from proteus.config._star import Star
 
     # Zero is allowed (bol_scale != 1.0 requires bol_scale_start to be set).
-    s_zero = Star(bol_scale=0.0, bol_scale_start=0.0)
+    s_zero = Star(bol_scale=0.0, bol_scale_start=0.0, bol_scale_duration=1.0)
     assert s_zero.bol_scale == pytest.approx(0.0, abs=1e-12)
     # Positive round-trips.
     s_one = Star(bol_scale=1.0)

--- a/tests/integration/test_integration_agni_mors.py
+++ b/tests/integration/test_integration_agni_mors.py
@@ -165,8 +165,8 @@ def test_star_bol_scale_allows_zero_rejects_negative():
     """
     from proteus.config._star import Star
 
-    # Zero is allowed.
-    s_zero = Star(bol_scale=0.0)
+    # Zero is allowed (bol_scale != 1.0 requires bol_scale_start to be set).
+    s_zero = Star(bol_scale=0.0, bol_scale_start=0.0)
     assert s_zero.bol_scale == pytest.approx(0.0, abs=1e-12)
     # Positive round-trips.
     s_one = Star(bol_scale=1.0)

--- a/tests/interior_energetics/test_timestep.py
+++ b/tests/interior_energetics/test_timestep.py
@@ -74,7 +74,8 @@ def _make_config(
         time=stop_time,
     )
     params = SimpleNamespace(dt=dt, stop=stop)
-    return SimpleNamespace(params=params)
+    star = SimpleNamespace(bol_scale=1.0, bol_scale_start=None, bol_scale_duration=0.0)
+    return SimpleNamespace(params=params, star=star)
 
 
 def _make_hf_all(n_rows: int = 10, dt_prev: float = 1.0e3, phi: float = 1.0):
@@ -437,7 +438,8 @@ def _make_overshoot_config(*, dt_maximum, stop_time_enabled, stop_time_maximum):
         escape=SimpleNamespace(enabled=False),
         time=SimpleNamespace(enabled=stop_time_enabled, maximum=stop_time_maximum),
     )
-    return SimpleNamespace(params=SimpleNamespace(dt=dt, stop=stop))
+    star = SimpleNamespace(bol_scale=1.0, bol_scale_start=None, bol_scale_duration=0.0)
+    return SimpleNamespace(params=SimpleNamespace(dt=dt, stop=stop), star=star)
 
 
 def _make_overshoot_hf_all():

--- a/tests/interior_energetics/test_timestep_bolscale_event.py
+++ b/tests/interior_energetics/test_timestep_bolscale_event.py
@@ -1,0 +1,234 @@
+"""Unit tests for the bolometric-scaling timestep guard.
+
+Covers ``proteus.interior_energetics.timestep._estimate_bolscale`` event
+which checks the current stellar age against the configured bolometric-scaling
+and window fields, and the ``proteus.interior_energetics.timestep.next_step``.
+
+
+Testing standards:
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from proteus.interior_energetics.timestep import _estimate_bolscale, next_step
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+
+def _config_with_star(bol_scale=1.0, bol_scale_start=None, bol_scale_duration=0.0):
+    star = SimpleNamespace(
+        bol_scale=bol_scale,
+        bol_scale_start=bol_scale_start,
+        bol_scale_duration=bol_scale_duration,
+    )
+    return SimpleNamespace(star=star)
+
+
+def _hf_all_with_age(age_star, n_rows=3):
+    return pd.DataFrame(
+        {
+            'Time': np.arange(n_rows, dtype=float),
+            'age_star': np.full(n_rows, float(age_star)),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# _estimate_bolscale: trivial-disable routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.physics_invariant
+def test_estimate_bolscale_disabled_when_bol_scale_is_one():
+    """bol_scale == 1.0 is a no-op scaling factor regardless of the window,
+    so the estimator must not constrain the timestep even with a window
+    defined."""
+    config = _config_with_star(bol_scale=1.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    hf_all = _hf_all_with_age(age_star=0.7e9)  # inside the window, if it mattered
+    assert _estimate_bolscale(hf_all, config) == np.inf
+
+
+@pytest.mark.physics_invariant
+def test_estimate_bolscale_disabled_when_bol_scale_start_is_none():
+    """bol_scale_start=None means no window was ever configured, so a
+    non-unity bol_scale alone must not constrain the timestep."""
+    config = _config_with_star(bol_scale=2.0, bol_scale_start=None, bol_scale_duration=0.0)
+    hf_all = _hf_all_with_age(age_star=0.7e9)
+    assert _estimate_bolscale(hf_all, config) == np.inf
+
+
+# ---------------------------------------------------------------------------
+# _estimate_bolscale: active window, before / during / after
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.physics_invariant
+def test_estimate_bolscale_before_window_returns_time_until_start():
+    """Before the window opens, dt_bolscale = age_ini - age_now (converted
+    from Gyr to yr via the *1e9 factor in the source).
+
+    Window: start=0.5 Gyr -> age_ini=5.0e8 yr. age_now=4.0e8 yr, so the
+    expected remaining time is 1.0e8 yr.
+    """
+    config = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    hf_all = _hf_all_with_age(age_star=4.0e8)
+    dt_bolscale = _estimate_bolscale(hf_all, config)
+    assert dt_bolscale == pytest.approx(1.0e8, rel=1e-9)
+    assert abs(dt_bolscale - 4.0e8) > 1.0e7
+
+
+@pytest.mark.physics_invariant
+def test_estimate_bolscale_inside_window_returns_time_until_end():
+    """Inside the window, dt_bolscale = age_end - age_now.
+
+    Window: [5.0e8, 1.0e9] yr. age_now=7.0e8 yr -> 3.0e8 yr remaining.
+    """
+    config = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    hf_all = _hf_all_with_age(age_star=7.0e8)
+    dt_bolscale = _estimate_bolscale(hf_all, config)
+    assert dt_bolscale == pytest.approx(3.0e8, rel=1e-9)
+
+
+@pytest.mark.physics_invariant
+def test_estimate_bolscale_after_window_returns_inf():
+    """After the window has closed, the estimator no longer constrains
+    the timestep (falls through both branches to the +inf sentinel)."""
+    config = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    hf_all = _hf_all_with_age(age_star=1.1e9)
+    assert _estimate_bolscale(hf_all, config) == np.inf
+
+
+def test_estimate_bolscale_boundary_at_exact_start_uses_during_branch():
+    """age_now exactly equal to age_ini fails the strict `age_now <
+    age_ini` "before" check and falls into the `elif age_now < age_end`
+    "during" branch, so the returned value is age_end - age_now, NOT the
+    "before" formula's age_ini - age_now (which would be 0 here).
+    """
+    config = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    hf_all = _hf_all_with_age(age_star=5.0e8)  # == age_ini exactly
+    dt_bolscale = _estimate_bolscale(hf_all, config)
+    assert dt_bolscale == pytest.approx(5.0e8, rel=1e-9)  # age_end - age_now = 1e9 - 5e8
+
+
+def test_estimate_bolscale_defaults_missing_age_star_column_to_zero():
+    """hf_all without an 'age_star' column must not raise: the source
+    reads it via ``.get('age_star', 0.0)``. This is the error-contract
+    path for malformed/partial helpfile frames (no validation exists
+    upstream, so the limit-input behaviour is the contract to pin).
+    """
+    config = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    hf_all = pd.DataFrame({'Time': [0.0, 1.0, 2.0]})  # no age_star column
+    dt_bolscale = _estimate_bolscale(hf_all, config)
+    assert dt_bolscale == pytest.approx(5.0e8, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# next_step integration: the bolscale clip actually binds the returned dt
+# ---------------------------------------------------------------------------
+
+
+def _next_step_config(dt_maximum, bol_scale, bol_scale_start, bol_scale_duration):
+    dt = SimpleNamespace(
+        method='maximum',
+        propconst=52.0,
+        atol=0.02,
+        rtol=0.10,
+        scale_incr=1.6,
+        scale_decr=0.8,
+        window=3,
+        minimum=0.1,
+        minimum_rel=0.0,
+        maximum=dt_maximum,
+        maximum_rel=0.0,
+        initial=1.0,
+        mushy_maximum=0.0,
+        mushy_upper=0.99,
+        hysteresis_iters=0,
+        hysteresis_sfinc=1.1,
+        max_growth_factor=0.0,
+    )
+    stop = SimpleNamespace(
+        solid=SimpleNamespace(enabled=False, phi_crit=0.05),
+        radeqm=SimpleNamespace(enabled=False),
+        escape=SimpleNamespace(enabled=False),
+        time=SimpleNamespace(enabled=False, maximum=1.0e18),
+    )
+    star = SimpleNamespace(
+        bol_scale=bol_scale,
+        bol_scale_start=bol_scale_start,
+        bol_scale_duration=bol_scale_duration,
+    )
+    return SimpleNamespace(params=SimpleNamespace(dt=dt, stop=stop), star=star)
+
+
+def _next_step_hf_all(age_star, n_rows=12):
+    """Long enough (>dt.window+3) that next_step reaches the 'maximum'
+    dt-method branch instead of the 'initial' branch."""
+    return pd.DataFrame(
+        {
+            'Time': np.arange(n_rows, dtype=float) * 10.0,
+            'age_star': np.full(n_rows, float(age_star)),
+        }
+    )
+
+
+@pytest.mark.physics_invariant
+def test_next_step_clips_dt_when_bolscale_window_is_imminent():
+    """The dt.method='maximum' branch would normally return dt.maximum
+    (1e5 yr) unmodified; with the bolometric-scaling window opening in
+    5e4 yr, next_step must clip to that smaller remaining time instead of
+    silently stepping past the window.
+    """
+    # Window: start=0.5 Gyr -> age_ini=5.0e8 yr. age_now is 5e4 yr short
+    # of that, so the window opens in exactly 5e4 yr.
+    config = _next_step_config(
+        dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row = {'Time': 100.0}
+    hf_all = _next_step_hf_all(age_star=5.0e8 - 5.0e4)
+
+    dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0)
+    assert dt == pytest.approx(5.0e4, rel=1e-9)
+
+    # Monotonicity/positivity guard
+    assert dt < 1.0e5
+    assert dt > 0.0
+
+
+@pytest.mark.physics_invariant
+def test_next_step_does_not_clip_when_window_is_far_away():
+    """When the bolometric-scaling window is far in the future (remaining
+    time well above dt.maximum), the clip does not bind and next_step
+    returns the un-modified controller value."""
+    config = _next_step_config(
+        dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=50.0, bol_scale_duration=0.5
+    )
+    hf_row = {'Time': 100.0}
+    hf_all = _next_step_hf_all(age_star=1.0e8)  # window opens at 5e10 yr, far away
+
+    dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0)
+    assert dt == pytest.approx(1.0e5, rel=1e-9)
+
+
+def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
+    """On the very first call (no history yet), hf_all is None; the
+    ``if hf_all is not None`` gate must skip `_estimate_bolscale` entirely
+    rather than crashing on ``None.iloc[-1]``. Force the static branch
+    (Time < 2 yr) so no other part of next_step needs hf_all either.
+    """
+    config = _next_step_config(
+        dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row = {'Time': 1.0}  # static branch: Time < 2.0
+
+    # Static time-step branch returns exactly 1.0 yr
+    dt = next_step(config, {}, hf_row, None, step_sf=1.0)
+    assert dt == pytest.approx(1.0)

--- a/tests/interior_energetics/test_timestep_bolscale_event.py
+++ b/tests/interior_energetics/test_timestep_bolscale_event.py
@@ -232,3 +232,45 @@ def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
     # Static time-step branch returns exactly 1.0 yr
     dt = next_step(config, {}, hf_row, None, step_sf=1.0)
     assert dt == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# interior_o.bolscale_clamped: flag consumed by the main loop to force a
+# stellar update at the window edge (proteus.py STELLAR FLUX MANAGEMENT).
+# ---------------------------------------------------------------------------
+
+
+def test_next_step_flags_interior_o_when_bolscale_clamps_the_step():
+    """When the bolometric-scaling window opens before the controller's own
+    dt would, next_step must mark ``interior_o.bolscale_clamped = True`` so
+    the main loop can force a stellar update even if the resulting step is
+    shorter than ``params.dt.starinst``."""
+    config = _next_step_config(
+        dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row = {'Time': 100.0}
+    hf_all = _next_step_hf_all(age_star=5.0e8 - 5.0e4)
+    interior_o = SimpleNamespace(bolscale_clamped=False)
+
+    dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0, interior_o=interior_o)
+
+    assert dt == pytest.approx(5.0e4, rel=1e-9)
+    assert interior_o.bolscale_clamped is True
+
+
+def test_next_step_does_not_flag_interior_o_when_window_is_far_away():
+    """Discrimination case: when the controller's own dt is already smaller
+    than the remaining time to the window, the bolscale estimate did not
+    bind, so the flag must stay False (else every step would force a
+    stellar update, defeating the dt.starinst cadence entirely)."""
+    config = _next_step_config(
+        dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=50.0, bol_scale_duration=0.5
+    )
+    hf_row = {'Time': 100.0}
+    hf_all = _next_step_hf_all(age_star=1.0e8)  # window opens at 5e10 yr, far away
+    interior_o = SimpleNamespace(bolscale_clamped=True)  # start True to prove it flips
+
+    dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0, interior_o=interior_o)
+
+    assert dt == pytest.approx(1.0e5, rel=1e-9)
+    assert interior_o.bolscale_clamped is False

--- a/tests/interior_energetics/test_timestep_bolscale_event.py
+++ b/tests/interior_energetics/test_timestep_bolscale_event.py
@@ -235,14 +235,14 @@ def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
 
 
 # ---------------------------------------------------------------------------
-# interior_o.bolscale_clamped: flag consumed by the main loop to force a
+# interior_o.timestep_clamped: flag consumed by the main loop to force a
 # stellar update at the window edge (proteus.py STELLAR FLUX MANAGEMENT).
 # ---------------------------------------------------------------------------
 
 
 def test_next_step_flags_interior_o_when_bolscale_clamps_the_step():
     """When the bolometric-scaling window opens before the controller's own
-    dt would, next_step must mark ``interior_o.bolscale_clamped = True`` so
+    dt would, next_step must mark ``interior_o.timestep_clamped = True`` so
     the main loop can force a stellar update even if the resulting step is
     shorter than ``params.dt.starinst``."""
     config = _next_step_config(
@@ -250,12 +250,12 @@ def test_next_step_flags_interior_o_when_bolscale_clamps_the_step():
     )
     hf_row = {'Time': 100.0}
     hf_all = _next_step_hf_all(age_star=5.0e8 - 5.0e4)
-    interior_o = SimpleNamespace(bolscale_clamped=False)
+    interior_o = SimpleNamespace(timestep_clamped=False)
 
     dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0, interior_o=interior_o)
 
     assert dt == pytest.approx(5.0e4, rel=1e-9)
-    assert interior_o.bolscale_clamped is True
+    assert interior_o.timestep_clamped is True
 
 
 def test_next_step_does_not_flag_interior_o_when_window_is_far_away():
@@ -268,9 +268,9 @@ def test_next_step_does_not_flag_interior_o_when_window_is_far_away():
     )
     hf_row = {'Time': 100.0}
     hf_all = _next_step_hf_all(age_star=1.0e8)  # window opens at 5e10 yr, far away
-    interior_o = SimpleNamespace(bolscale_clamped=True)  # start True to prove it flips
+    interior_o = SimpleNamespace(timestep_clamped=True)  # start True to prove it flips
 
     dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0, interior_o=interior_o)
 
     assert dt == pytest.approx(1.0e5, rel=1e-9)
-    assert interior_o.bolscale_clamped is False
+    assert interior_o.timestep_clamped is False

--- a/tests/interior_energetics/test_timestep_branches.py
+++ b/tests/interior_energetics/test_timestep_branches.py
@@ -67,7 +67,8 @@ def _build_config(method='adaptive', dt_initial=10.0, dt_max=1.0e7, propconst=50
         hysteresis_sfinc=1.1,
         max_growth_factor=0.0,
     )
-    return SimpleNamespace(params=SimpleNamespace(dt=dt, stop=_stop_namespace()))
+    star = SimpleNamespace(bol_scale=1.0, bol_scale_start=None, bol_scale_duration=0.0)
+    return SimpleNamespace(params=SimpleNamespace(dt=dt, stop=_stop_namespace()), star=star)
 
 
 def _two_row_hf():

--- a/tests/star/test_star.py
+++ b/tests/star/test_star.py
@@ -230,9 +230,8 @@ def test_calc_instellation_earth_like():
     assert 1e3 < s < 2e3
 
 
-@pytest.mark.smoke
 @pytest.mark.physics_invariant
-def test_smoke_bol_scale_window_applies_across_dummy_run():
+def test_bol_scale_window_applies_across_dummy_run():
     """A bol_scale window spanning the whole run must stay active for
     every post-init row, and the scaled F_ins must match an independently
     recomputed unscaled instellation times the configured factor.
@@ -242,7 +241,7 @@ def test_smoke_bol_scale_window_applies_across_dummy_run():
         config_path = PROTEUS_ROOT / 'input' / 'dummy.toml'
         runner = Proteus(config_path=config_path)
 
-        runner.config.params.out.path = str(Path(tmpdir) / f'smoke_bolscale_{unique_id}')
+        runner.config.params.out.path = str(Path(tmpdir) / f'bolscale_{unique_id}')
         runner.init_directories()
 
         runner.config.planet.tsurf_init = 2000.0

--- a/tests/star/test_star.py
+++ b/tests/star/test_star.py
@@ -257,8 +257,11 @@ def test_bol_scale_window_applies_across_dummy_run():
         # open for far longer (2 Gyr) than the run can possibly advance
         # (stop.time.maximum=1e5 yr), so the window covers every row.
         runner.config.star.bol_scale = 2.0
-        runner.config.star.bol_scale_start = runner.config.star.age_ini
+
+        # Set duration before start: valid_bol_scale_start performs its checks
+        # when bol_scale_start is assigned.
         runner.config.star.bol_scale_duration = 2.0
+        runner.config.star.bol_scale_start = runner.config.star.age_ini
 
         runner.config.params.out.plot_mod = 0
         runner.config.params.out.write_mod = 0

--- a/tests/star/test_star.py
+++ b/tests/star/test_star.py
@@ -7,13 +7,18 @@ Follows PROTEUS testing standards (see docs/How-to/testing.md).
 
 from __future__ import annotations
 
+import tempfile
+import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pytest
+from helpers import PROTEUS_ROOT
 
 import proteus.star.dummy as star
+from proteus import Proteus
 from proteus.utils.constants import AU, R_sun, Teff_sun
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
@@ -223,3 +228,67 @@ def test_calc_instellation_earth_like():
     # slip would land at ~1e3x the correct value. The bracket
     # discriminates either slip.
     assert 1e3 < s < 2e3
+
+
+@pytest.mark.smoke
+@pytest.mark.physics_invariant
+def test_smoke_bol_scale_window_applies_across_dummy_run():
+    """A bol_scale window spanning the whole run must stay active for
+    every post-init row, and the scaled F_ins must match an independently
+    recomputed unscaled instellation times the configured factor.
+    """
+    unique_id = str(uuid.uuid4())[:8]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = PROTEUS_ROOT / 'input' / 'dummy.toml'
+        runner = Proteus(config_path=config_path)
+
+        runner.config.params.out.path = str(Path(tmpdir) / f'smoke_bolscale_{unique_id}')
+        runner.init_directories()
+
+        runner.config.planet.tsurf_init = 2000.0
+
+        # Short run: a couple of small timesteps.
+        runner.config.params.stop.time.minimum = 1e2
+        runner.config.params.stop.time.maximum = 1e5
+        runner.config.params.dt.initial = 1e3
+        runner.config.params.dt.minimum = 1e2
+        runner.config.params.dt.maximum = 1e4
+
+        # Bolometric-scaling window: opens exactly at age_ini and stays
+        # open for far longer (2 Gyr) than the run can possibly advance
+        # (stop.time.maximum=1e5 yr), so the window covers every row.
+        runner.config.star.bol_scale = 2.0
+        runner.config.star.bol_scale_start = runner.config.star.age_ini
+        runner.config.star.bol_scale_duration = 2.0
+
+        runner.config.params.out.plot_mod = 0
+        runner.config.params.out.write_mod = 0
+        runner.config.params.out.archive_mod = 'none'
+
+        runner.start(resume=False, offline=True)
+
+        assert runner.hf_all is not None, 'Helpfile should be created'
+        times = runner.hf_all['Time'].values
+        post_init = runner.hf_all[times > 0]
+        assert len(post_init) >= 2, (
+            f'Need at least 2 post-init rows with Time > 0, got {len(post_init)}'
+        )
+
+        # The window covers the whole run: bol_scale must read the
+        # configured 2.0 in every post-init row, not just the first.
+        bol_scale_vals = post_init['bol_scale'].values
+        np.testing.assert_allclose(bol_scale_vals, 2.0, rtol=1e-12)
+
+        # Independent reference check: recompute the UNSCALED instellation
+        for _, row in post_init.iterrows():
+            s0_unscaled = star.calc_instellation(
+                runner.config.star.dummy.Teff, row['R_star'], row['separation']
+            )
+            assert row['F_ins'] == pytest.approx(row['bol_scale'] * s0_unscaled, rel=1e-9)
+
+        # Discrimination: the scaled flux must actually differ from unscaled
+        last_row = post_init.iloc[-1]
+        s0_last_unscaled = star.calc_instellation(
+            runner.config.star.dummy.Teff, last_row['R_star'], last_row['separation']
+        )
+        assert last_row['F_ins'] > s0_last_unscaled

--- a/tests/star/test_wrapper.py
+++ b/tests/star/test_wrapper.py
@@ -226,6 +226,99 @@ def test_update_instellation_dummy_branch_zeroes_fxuv_and_computes_finstellation
     assert hf_row['F_xuv'] == pytest.approx(0.0, abs=1e-12)
 
 
+# ---------------------------------------------------------------------------
+# update_instellation: bolometric-scaling time window (bol_scale_start /
+# bol_scale_duration). These gate the pre-existing `bol_scale` factor to a
+# stellar-age window [start, start + duration] instead of applying it for
+# the whole run.
+# ---------------------------------------------------------------------------
+
+
+def _dummy_config_for_bolscale(bol_scale, bol_scale_start, bol_scale_duration):
+    """Dummy-star config with the three bolometric-scaling fields set."""
+    from unittest.mock import MagicMock
+
+    config = MagicMock()
+    config.star.module = 'dummy'
+    config.star.dummy.Teff = 5778.0
+    config.star.bol_scale = bol_scale
+    config.star.bol_scale_start = bol_scale_start
+    config.star.bol_scale_duration = bol_scale_duration
+    return config
+
+
+def _run_update_instellation_dummy(config, age_star, s0_return=1361.0):
+    from unittest.mock import patch
+
+    from proteus.star.wrapper import update_instellation
+
+    hf_row = {'R_star': 6.957e8, 'separation': 1.496e11, 'age_star': age_star}
+    with patch('proteus.star.dummy.calc_instellation', return_value=s0_return):
+        update_instellation(hf_row, config)
+    return hf_row
+
+
+@pytest.mark.physics_invariant
+def test_update_instellation_applies_scaling_inside_window():
+    """Inside [bol_scale_start, bol_scale_start + bol_scale_duration], F_ins
+    and F_xuv are multiplied by bol_scale and hf_row['bol_scale'] records
+    the applied factor.
+
+    Window: start=0.5 Gyr, duration=0.5 Gyr -> [0.5e9, 1.0e9] yr.
+    age_star=0.7e9 yr sits inside it.
+    """
+    config = _dummy_config_for_bolscale(
+        bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row = _run_update_instellation_dummy(config, age_star=0.7e9)
+    assert hf_row['F_ins'] == pytest.approx(1361.0 * 2.0, rel=1e-12)
+    assert hf_row['bol_scale'] == pytest.approx(2.0)
+
+
+@pytest.mark.physics_invariant
+def test_update_instellation_no_scaling_before_window():
+    """age_star before bol_scale_start: scaling not yet active."""
+    config = _dummy_config_for_bolscale(
+        bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row = _run_update_instellation_dummy(config, age_star=0.4e9)
+    assert hf_row['F_ins'] == pytest.approx(1361.0, rel=1e-12)
+    assert hf_row['bol_scale'] == pytest.approx(1.0)
+
+
+@pytest.mark.physics_invariant
+def test_update_instellation_no_scaling_after_window():
+    """age_star after bol_scale_start + bol_scale_duration: scaling has
+    already ended."""
+    config = _dummy_config_for_bolscale(
+        bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row = _run_update_instellation_dummy(config, age_star=1.1e9)
+    assert hf_row['F_ins'] == pytest.approx(1361.0, rel=1e-12)
+    assert hf_row['bol_scale'] == pytest.approx(1.0)
+
+
+@pytest.mark.physics_invariant
+def test_update_instellation_window_boundaries_are_inclusive():
+    """Both edges of the window are inclusive (`<=` on both sides in the
+    source): age_star exactly equal to the start age, and exactly equal to
+    the end age, must both apply scaling. Boundary edge case for a window
+    defined by two closed inequalities.
+    """
+    config = _dummy_config_for_bolscale(
+        bol_scale=3.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    hf_row_start = _run_update_instellation_dummy(config, age_star=0.5e9)
+    assert hf_row_start['bol_scale'] == pytest.approx(3.0)
+
+    hf_row_end = _run_update_instellation_dummy(config, age_star=1.0e9)
+    assert hf_row_end['bol_scale'] == pytest.approx(3.0)
+    # Discrimination: nudging just past the end boundary must fall back to
+    # unscaled, so the inclusivity is specific to the exact boundary value.
+    hf_row_after = _run_update_instellation_dummy(config, age_star=1.0e9 + 1.0)
+    assert hf_row_after['bol_scale'] == pytest.approx(1.0)
+
+
 @pytest.mark.physics_invariant
 @pytest.mark.reference_pinned
 def test_update_equilibrium_temperature_pins_stefan_boltzmann_closed_form():

--- a/tests/star/test_wrapper.py
+++ b/tests/star/test_wrapper.py
@@ -320,6 +320,20 @@ def test_update_instellation_window_boundaries_are_inclusive():
 
 
 @pytest.mark.physics_invariant
+def test_update_instellation_disabled_when_bol_scale_start_is_none():
+    """bol_scale_start=None disables scaling regardless of bol_scale.
+
+    Enabling condition (not None) requires bol_scale_start to be set.
+    """
+    config = _dummy_config_for_bolscale(
+        bol_scale=2.0, bol_scale_start=None, bol_scale_duration=0.0
+    )
+    hf_row = _run_update_instellation_dummy(config, age_star=0.7e9)
+    assert hf_row['F_ins'] == pytest.approx(1361.0, rel=1e-12)
+    assert hf_row['bol_scale'] == pytest.approx(1.0)
+
+
+@pytest.mark.physics_invariant
 @pytest.mark.reference_pinned
 def test_update_equilibrium_temperature_pins_stefan_boltzmann_closed_form():
     """T_eqm = ((1 - albedo) * S * s0_factor / sigma) ** 0.25.

--- a/tests/star/test_wrapper.py
+++ b/tests/star/test_wrapper.py
@@ -299,11 +299,10 @@ def test_update_instellation_no_scaling_after_window():
 
 
 @pytest.mark.physics_invariant
-def test_update_instellation_window_boundaries_are_inclusive():
-    """Both edges of the window are inclusive (`<=` on both sides in the
-    source): age_star exactly equal to the start age, and exactly equal to
-    the end age, must both apply scaling. Boundary edge case for a window
-    defined by two closed inequalities.
+def test_update_instellation_window_is_half_open():
+    """The window is half-open, [start, start + duration): age_star exactly
+    equal to the start age applies scaling, but age_star exactly equal to the
+    end age must not apply it.
     """
     config = _dummy_config_for_bolscale(
         bol_scale=3.0, bol_scale_start=0.5, bol_scale_duration=0.5
@@ -311,12 +310,27 @@ def test_update_instellation_window_boundaries_are_inclusive():
     hf_row_start = _run_update_instellation_dummy(config, age_star=0.5e9)
     assert hf_row_start['bol_scale'] == pytest.approx(3.0)
 
+    # Discrimination: exactly at the end boundary must already be unscaled,
+    # not merely "just past" it
     hf_row_end = _run_update_instellation_dummy(config, age_star=1.0e9)
-    assert hf_row_end['bol_scale'] == pytest.approx(3.0)
-    # Discrimination: nudging just past the end boundary must fall back to
-    # unscaled, so the inclusivity is specific to the exact boundary value.
-    hf_row_after = _run_update_instellation_dummy(config, age_star=1.0e9 + 1.0)
-    assert hf_row_after['bol_scale'] == pytest.approx(1.0)
+    assert hf_row_end['bol_scale'] == pytest.approx(1.0)
+
+    hf_row_before_end = _run_update_instellation_dummy(config, age_star=1.0e9 - 1.0)
+    assert hf_row_before_end['bol_scale'] == pytest.approx(3.0)
+
+
+@pytest.mark.physics_invariant
+def test_update_instellation_zero_duration_is_no_op():
+    """bol_scale_duration=0.0 collapses the window to a single instant, so
+    the half-open upper edge makes even age_star exactly equal to
+    bol_scale_start fall outside [start, start) and scaling never applies.
+    """
+    config = _dummy_config_for_bolscale(
+        bol_scale=5.0, bol_scale_start=0.5, bol_scale_duration=0.0
+    )
+    hf_row = _run_update_instellation_dummy(config, age_star=0.5e9)
+    assert hf_row['F_ins'] == pytest.approx(1361.0, rel=1e-12)
+    assert hf_row['bol_scale'] == pytest.approx(1.0)
 
 
 @pytest.mark.physics_invariant

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -341,6 +341,28 @@ def test_kappah_floor_and_maximum_rel_overrides():
     assert mig.OVERRIDES['params.dt.maximum_rel'] == 0.0
 
 
+def test_bol_scale_window_override_reproduces_unwindowed_2_0_scaling():
+    """2.0 had no time-gating on bol_scale: a non-unity factor applied for
+    the whole run. The live 3.0 default (bol_scale_start=None) disables
+    scaling outright regardless of bol_scale, so a naive migration would
+    silently turn off any bol_scale a 2.0 config had set. The override
+    must pin an always-open window: start at t=0 and a duration far
+    longer than any plausible run.
+    """
+    assert mig.OVERRIDES['star.bol_scale_start'] == pytest.approx(0.0)
+    # Discrimination: the duration must be large enough that no
+    # realistic stellar age (even the ~13.8 Gyr age of the universe)
+    # falls outside the window; a duration comparable to a typical run
+    # length (e.g. 1-10 Gyr) would silently reintroduce a cutoff 2.0
+    # never had.
+    assert mig.OVERRIDES['star.bol_scale_duration'] > 20.0
+
+    v3_defaults, _ = _v3()
+    # The pin is doing the work: the live 3.0 schema default disables
+    # scaling entirely, so letting the field default (rather than pinning
+    # it) would silently change a migrated run's stellar flux.
+    assert v3_defaults['star.bol_scale_start'] is None
+
 def _translate(v2_dict):
     nested, report = mig.translate(v2_dict)
     return mig._flatten(nested), report

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -363,6 +363,7 @@ def test_bol_scale_window_override_reproduces_unwindowed_2_0_scaling():
     # it) would silently change a migrated run's stellar flux.
     assert v3_defaults['star.bol_scale_start'] is None
 
+
 def _translate(v2_dict):
     nested, report = mig.translate(v2_dict)
     return mig._flatten(nested), report

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -102,6 +102,11 @@ def test_get_helpfile_keys_contains_required_keys():
     assert 'F_atm' in keys
     assert 'F_net' in keys
 
+    # Stellar fluxes
+    assert 'bol_scale' in keys
+    assert 'F_ins' in keys
+    assert 'F_xuv' in keys
+
 
 @pytest.mark.unit
 def test_get_helpfile_keys_includes_gas_species():

--- a/tools/migrate_config_v2_to_v3.py
+++ b/tools/migrate_config_v2_to_v3.py
@@ -254,6 +254,10 @@ OVERRIDES = {
     # 3.0 adds dt.maximum + maximum_rel * Time with a default maximum_rel of 1.0,
     # a time-growing cap 2.0 lacked. Pin 0.0 to recover the strict 2.0 cap.
     'params.dt.maximum_rel': 0.0,
+    
+    # 2.0 had no time-gating on bol_scale
+    'star.bol_scale_start': 0.0,
+    'star.bol_scale_duration': 100.0,
 }
 
 # Element-budget fields consumed by the element handler (not mapped directly).

--- a/tools/migrate_config_v2_to_v3.py
+++ b/tools/migrate_config_v2_to_v3.py
@@ -254,7 +254,6 @@ OVERRIDES = {
     # 3.0 adds dt.maximum + maximum_rel * Time with a default maximum_rel of 1.0,
     # a time-growing cap 2.0 lacked. Pin 0.0 to recover the strict 2.0 cap.
     'params.dt.maximum_rel': 0.0,
-    
     # 2.0 had no time-gating on bol_scale
     'star.bol_scale_start': 0.0,
     'star.bol_scale_duration': 100.0,


### PR DESCRIPTION
## Description

Support for time-dependent bolometric stellar luminosity scaling, allowing users to specify when and for how long a scaling factor is applied. This is part of a project with Tuhin Gosh and @shorttle. Closes #741 

Items below describe the changes that were necessary to implement this.

* Added new configuration options `bol_scale_start` and `bol_scale_duration` to control the timing and duration of bolometric luminosity scaling. Added default values into `all_options.toml`.
* Updated the stellar flux calculation in `update_instellation` to apply `bol_scale` only within the specified age range, and to record the active scaling factor in the output.
* Updated helpfile key to include the current `bol_scale` value.
* Implemented `_estimate_bolscale` to prevent the timestep from skipping over the start or end of the scaling period
* Avoid divide-by-zero in the calculation of Bond albedo and eclipse depths

## Validation of changes

* Ran `all_options.toml` with new keys at their default values. Works as before.
* Tested with `dummy.toml` with various start/duration times for dimming. See screenshots below.
* Added new tests for this new behaviour.
* Tests pass on my laptop (Fedora 44, Python 3.12) and on the GitHub CI.
* Performed self-review with Claude

**Demo with modified dummy config**

[example.zip](https://github.com/user-attachments/files/30585979/example.zip)

Using 
```
    bol_scale                 = 0.0          # bolometric luminosity scaling factor
    bol_scale_start           = 0.2          # stellar age from which bol_scale is applied [Gyr]
    bol_scale_duration        = 0.05          # duration for which bol_scale is applied [Gyr]
```


Note that the absorbed stellar flux (ASF) drops to zero and then recovers after the dimming period. This corresponds to a decrease in the surface temperature, which then also recovers to its previous value. The helpfile CSV contains rows in which `age_star` exactly equals 2e8 and 2.5e8, which confirms that the event trigger in `timestep.py` is operational.

<img width="90%" alt="image" src="https://github.com/user-attachments/assets/13c349a7-5d2d-4d37-b515-8f5656f41c91" />


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
