### PR TITLE
Fail the resume parity check when a column drops out of it

### DIFF
--- a/tests/integration/test_integration_resume.py
+++ b/tests/integration/test_integration_resume.py
@@ -63,8 +63,9 @@ from helpers import PROTEUS_ROOT
 from proteus import Proteus
 
 # Integration tier. Each test runs two or three real dummy-module
-# simulations, so the file costs about 39 s locally and the slowest single
-# test about 14 s. The 300 s tier ceiling leaves room for slower CI runners.
+# simulations, so the file costs roughly 80 to 105 s locally and its slowest
+# single test 26 to 36 s, depending on machine load. The 300 s tier ceiling is
+# per test and leaves room for slower CI runners.
 pytestmark = [pytest.mark.integration, pytest.mark.timeout(300)]
 
 CONFIG = PROTEUS_ROOT / 'input' / 'dummy.toml'
@@ -135,6 +136,12 @@ PARITY_RTOL = 1.0e-6
 # Columns excluded from that comparison because they are not part of the
 # simulated state.
 PARITY_SKIP = ('runtime',)
+
+# Backstop on the comparison's coverage, for a helpfile that collapsed
+# outright. The screens below are asserted to drop nothing, so this fires only
+# if the schema itself lost most of its columns, which both sides would lose
+# together while still agreeing over the few that remained.
+MIN_COLUMNS_COMPARED = 400
 
 
 # Scratch directories created by Proteus construction, cleared after each
@@ -707,6 +714,8 @@ def test_resume_reproduces_uninterrupted_run(tmp_path):
     )
 
     compared = 0
+    non_numeric: list[str] = []
+    non_finite: list[str] = []
     for column in reference.columns:
         if column in PARITY_SKIP:
             continue
@@ -715,12 +724,14 @@ def test_resume_reproduces_uninterrupted_run(tmp_path):
         if not (
             np.issubdtype(expected.dtype, np.number) and np.issubdtype(actual.dtype, np.number)
         ):
+            non_numeric.append(column)
             continue
         # Only the reference side is screened. Screening the restarted side
         # too would skip precisely the columns a resume corrupted into NaN,
         # which is the signature this comparison exists to catch; leaving them
         # in makes the comparison below fail on them instead.
         if not np.all(np.isfinite(expected)):
+            non_finite.append(column)
             continue
         np.testing.assert_allclose(
             actual,
@@ -731,12 +742,19 @@ def test_resume_reproduces_uninterrupted_run(tmp_path):
         )
         compared += 1
 
-    # Guard against the comparison silently covering nothing, for instance if
-    # the helpfile schema changed to non-numeric columns. The dummy helpfile
-    # carries about 460 finite numeric columns, so the floor is set well above
-    # a token handful: a filter that started rejecting most columns shows up
-    # as a failure rather than as a comparison that quietly covers little.
-    assert compared > 400, (
-        f'only {compared} numeric columns were compared; the parity check is not '
-        'covering the helpfile'
+    # The screens above drop columns without comparing them, and most of what
+    # this configuration writes holds still for the whole run, so a count of
+    # compared columns cannot tell a covered helpfile from a sparse one.
+    # Nothing here is non-numeric or non-finite, so anything dropped is a
+    # change to look at rather than an expected loss.
+    dropped = non_numeric + non_finite
+    assert not dropped, (
+        f'{len(non_numeric)} non-numeric and {len(non_finite)} non-finite columns were '
+        f'dropped before comparison ({", ".join(dropped[:8])}); the parity check no '
+        'longer covers them'
+    )
+
+    assert compared >= MIN_COLUMNS_COMPARED, (
+        f'only {compared} of the {len(reference.columns)} columns written were '
+        'compared; the parity check is not covering the helpfile'
     )


### PR DESCRIPTION
## Description

The resume parity check walks the helpfile column by column and compares the uninterrupted run against the restarted one. It skips any column that is not numeric on both sides, or not finite on the reference side, and it skips them without saying so. The only thing standing behind those two screens was a count of how many columns did get compared, with a floor of 400.

That count cannot do the job, because most of what this configuration writes holds still for the whole run. Of the 761 columns compared, 675 are constant across every row and 633 are identically zero; only 86 actually vary. A constant column agrees between any two runs, so it lifts the count whatever happens to the physics. An entire block could stop writing finite values in both legs, the escape rates (24 columns), the energy-conservation columns (about 20) or the per-gas ocean columns (37), and the count would stay far above 400 while the test reported full parity.

The comparison now records what each screen dropped and fails if either dropped anything, naming the columns. Nothing in this configuration is non-numeric or non-finite, so the expected set is empty and any future column that starts being screened out has to be looked at rather than absorbed. The count floor stays as a backstop for the one case the screens cannot see: a helpfile that collapsed outright, where both sides lose the same columns and still agree over what is left.

Changes:

- `tests/integration/test_integration_resume.py`: the two screens collect what they reject and the test asserts the collection is empty, reporting the count in each category and naming the first columns. The old inline floor becomes a named `MIN_COLUMNS_COMPARED = 400` carrying what it is now for.
- Same file: the header quoted 39 s for the file and 14 s for its slowest test, and said the tier ceiling applies to the file rather than to each test. Both now match what the file does.

No issue is tracked for this; it came out of the work on #790 and is small enough to fix directly.

## Validation of changes

Measured rather than assumed:

- The dummy run writes 762 columns over 115 rows and the check compares 761, with `runtime` the only skip. Of those 761, 675 have zero variance across the run and 633 are identically zero, leaving 86 that carry any signal. That is the measurement the change rests on.
- Blanking five varying physics columns (`T_magma`, `F_atm`, `Phi_global`, `M_atm`, `P_surf`) on the reference side now fails with `0 non-numeric and 5 non-finite columns were dropped before comparison`, naming all five. The old floor of 400 passed that case, and so would any count floor: 756 columns were still compared.
- The whole file passes. Wall time varies with machine load across repeated runs, 76 s to 106 s for the file and 26 s to 36 s for its slowest test, which is where the header range comes from.

Note that the integration tier does not run on pull requests, so the checks below do not exercise this test. I dispatched the nightly workflow on this branch to run it in CI.

Test configuration: macOS 15 (arm64), Python 3.12, rebased onto `main` at e60f5799.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
