### PR TITLE
Stop escape using radii from an atmosphere solve that did not converge

### DIFF
--- a/docs/Explanations/coupling_loop.md
+++ b/docs/Explanations/coupling_loop.md
@@ -217,6 +217,21 @@ converged, -1 rejected, 0 before the first atmosphere call), and
 `atm_levels_stale` records the number of consecutive iterations without a
 converged solve of the run, zero on every converged row.
 
+## The XUV level is limited to the Hill radius
+
+Independently of convergence, the XUV level itself is bounded: gas beyond the
+Hill radius is not bound to the planet, so an XUV radius outside it would size
+the escape cross-section with material the planet does not hold, and the
+energy-limited rate grows as the cube of the excess. With `escape.hill_clamp`
+enabled (the default), each atmosphere module limits $R_\mathrm{xuv}$ to
+`escape.hill_clamp_frac` of the Hill radius, floored at $R_\mathrm{int}$ since
+the solid body is always bound. The level moves as a whole: $p_\mathrm{xuv}$,
+$T_\mathrm{xuv}$, $g_\mathrm{xuv}$ and the XUV-level mixing ratios are read at
+the clipped radius, so escape never sees a radius from one level combined with
+a composition from another. Each engagement is logged as a warning. The
+observed level is not clipped; a transit radius beyond the Hill radius is
+reported as computed and flagged by the orbit module's existing warning.
+
 ## Energy conservation diagnostics
 
 When using the Aragog interior module, PROTEUS tracks cumulative energy

--- a/docs/Explanations/coupling_loop.md
+++ b/docs/Explanations/coupling_loop.md
@@ -181,17 +181,18 @@ planet. Escape reads $R_\mathrm{xuv}$ from the previous iteration, and the
 energy-limited rate goes as $R_\mathrm{xuv}^3$, so an unusable structure would
 otherwise become a large mass-loss rate that looks like a physical result.
 
-When the atmosphere solve does not converge, PROTEUS therefore substitutes
-$R_\mathrm{obs}$, $p_\mathrm{obs}$, $T_\mathrm{obs}$, $g_\mathrm{obs}$,
-$R_\mathrm{xuv}$, $p_\mathrm{xuv}$ and the volume mixing ratios at the XUV level
-with the values from the most recent converged solve, and logs the substituted
-value of each of the six scalars as a warning. They are carried as a group, so a
-held radius is never
-combined with the pressure, temperature, gravity or composition of a rejected
-structure; the quantities derived from the radius, such as $\rho_\mathrm{obs}$
-and the transit depth, are computed from the carried value. Fluxes and surface
-state are never carried: the coupling advances on them, and the deadlock
-detector above needs to see them stop moving.
+When the atmosphere solve does not converge, PROTEUS therefore substitutes the
+radius, pressure, temperature and gravity of both levels ($R_\mathrm{obs}$,
+$p_\mathrm{obs}$, $T_\mathrm{obs}$, $g_\mathrm{obs}$, $R_\mathrm{xuv}$,
+$p_\mathrm{xuv}$, $T_\mathrm{xuv}$, $g_\mathrm{xuv}$) together with the volume
+mixing ratios at the XUV level, using the values from the most recent converged
+solve. A warning reports each such iteration, and the substituted values are
+listed at debug level. The levels are carried as a group, so a held radius is
+never combined with the pressure, temperature, gravity or composition of a
+rejected structure; the quantities derived from the radius, such as
+$\rho_\mathrm{obs}$ and the transit depth, are computed from the carried value.
+Fluxes and surface state are never carried: the coupling advances on them, and
+the deadlock detector above needs to see them stop moving.
 
 The record of converged levels is not written to the output files, so a resumed
 run starts without one. If the first solve of such a run is rejected, it falls
@@ -210,8 +211,11 @@ row the run reports it at error level. A streak that long means the interior is
 evolving while the levels stand still, which the deadlock detector above cannot
 catch: it fires only when the interior has stopped moving too.
 
-The substitution appears in the log, not in the helpfile: no output column marks
-a row whose levels were carried.
+Two helpfile columns persist the outcome, so a carried row is identifiable from
+the output alone: `atm_converged` records the solve outcome of each row (+1
+converged, -1 rejected, 0 before the first atmosphere call), and
+`atm_levels_stale` records the number of consecutive iterations without a
+converged solve of the run, zero on every converged row.
 
 ## Energy conservation diagnostics
 

--- a/docs/Explanations/coupling_loop.md
+++ b/docs/Explanations/coupling_loop.md
@@ -173,6 +173,46 @@ by tracking consecutive iterations where:
 After three consecutive deadlocked iterations, PROTEUS aborts with a
 diagnostic message identifying the stuck state.
 
+## Levels from a rejected atmosphere solve
+
+A solver that rejects its solution still returns an atmospheric structure, and
+the photospheric and XUV levels read off that structure can sit far outside the
+planet. Escape reads $R_\mathrm{xuv}$ from the previous iteration, and the
+energy-limited rate goes as $R_\mathrm{xuv}^3$, so an unusable structure would
+otherwise become a large mass-loss rate that looks like a physical result.
+
+When the atmosphere solve does not converge, PROTEUS therefore substitutes
+$R_\mathrm{obs}$, $p_\mathrm{obs}$, $T_\mathrm{obs}$, $g_\mathrm{obs}$,
+$R_\mathrm{xuv}$, $p_\mathrm{xuv}$ and the volume mixing ratios at the XUV level
+with the values from the most recent converged solve, and logs the substituted
+value of each of the six scalars as a warning. They are carried as a group, so a
+held radius is never
+combined with the pressure, temperature, gravity or composition of a rejected
+structure; the quantities derived from the radius, such as $\rho_\mathrm{obs}$
+and the transit depth, are computed from the carried value. Fluxes and surface
+state are never carried: the coupling advances on them, and the deadlock
+detector above needs to see them stop moving.
+
+The record of converged levels is not written to the output files, so a resumed
+run starts without one. If the first solve of such a run is rejected, it falls
+back on the last committed row instead, which was written before the run began
+and is the state escape would have used in any case; the warning names which of
+the two sources it used. Later solves never reach back to the committed rows,
+because once a run has begun writing rows, an empty record means those rows carry
+rejected levels themselves. A run with nothing to fall back on keeps the levels of
+the rejected structure and warns that it is doing so. Modules without a nonlinear
+solve (JANUS, the dummy module, and AGNI's transparent and prescribed-temperature
+branches) always report convergence and are unaffected.
+
+Each warning counts the consecutive iterations whose levels the run did not
+resolve itself, the ones with nothing to fall back on included, and past ten in a
+row the run reports it at error level. A streak that long means the interior is
+evolving while the levels stand still, which the deadlock detector above cannot
+catch: it fires only when the interior has stopped moving too.
+
+The substitution appears in the log, not in the helpfile: no output column marks
+a row whose levels were carried.
+
 ## Energy conservation diagnostics
 
 When using the Aragog interior module, PROTEUS tracks cumulative energy

--- a/docs/Reference/config/escape_outgas.md
+++ b/docs/Reference/config/escape_outgas.md
@@ -16,6 +16,8 @@ See also [Model description](../../Explanations/model.md#atmospheric-escape-zeph
 |-----------|------|---------|-------------|
 | `module` | str or none | `"zephyrus"` | Escape module: `zephyrus` (energy-limited), `dummy` (fixed rate), `none` (disabled) |
 | `reservoir` | str | `"outgas"` | Composition reservoir for escaping gas: `outgas`, `bulk`, `pxuv` |
+| `hill_clamp` | bool | `true` | Limit the XUV level to the Hill radius; gas beyond it is not bound to the planet |
+| `hill_clamp_frac` | float | `1.0` | Fraction of the Hill radius used as that limit, in (0, 1] |
 
 ### ZEPHYRUS `[escape.zephyrus]`
 

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -47,6 +47,8 @@ _REQUIRED_ATMOS_FIELDS = (
     'p_oboa',
     'tmp_surf',
     'tmp_magma',
+    # Cell-centre gravity, read at the XUV level
+    'g',
     # Solver flags
     'is_converged',
     'transparent',
@@ -1212,6 +1214,17 @@ def run_agni(
         p_xuv = hf_row['p_xuv']  # bar
         r_xuv = get_oarr_from_parr(atmos.p, atmos.r, p_xuv * 1e5)[1]  # m
 
+    # Temperature and gravity at the XUV level, from the cell-centre profiles.
+    # The transparent solver updates only the surface scalars, so in that
+    # branch the profiles hold the pre-solve guess and the surface values are
+    # the solved ones, exactly as for the observed level above.
+    if bool(atmos.transparent):
+        t_xuv = float(atmos.tmp_surf)  # K
+        g_xuv = float(hf_row['gravity'])  # m s-2
+    else:
+        t_xuv = get_oarr_from_parr(atmos.p, atmos.tmp, p_xuv * 1e5)[1]  # K
+        g_xuv = get_oarr_from_parr(atmos.p, atmos.g, p_xuv * 1e5)[1]  # m s-2
+
     # Diagnostics surfaced into hf_row: median optical depth at TOA
     # and at the surface, plus the Ra_max and timescale ratios.
     tau_TOA, tau_surface = _summarise_tau_band(atmos)
@@ -1239,6 +1252,8 @@ def run_agni(
     output['agni_converged'] = bool(agni_converged)
     output['p_xuv'] = p_xuv  # Pressure at Rxuv   [bars]
     output['R_xuv'] = r_xuv  # Radius at Pxuv     [m]
+    output['T_xuv'] = float(t_xuv)  # Temperature at Pxuv [K]
+    output['g_xuv'] = float(g_xuv)  # Gravity at Pxuv    [m s-2]
     output['ocean_areacov'] = float(atmos.ocean_areacov)
     output['ocean_maxdepth'] = float(atmos.ocean_maxdepth)
     output['P_surf_clim'] = float(atmos.p_boa) / 1e5  # Calculated Psurf [bar]

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -11,7 +11,7 @@ from juliacall import Main as jl
 from juliacall import convert
 from scipy.interpolate import PchipInterpolator
 
-from proteus.atmos_clim.common import get_oarr_from_parr, get_spfile_path
+from proteus.atmos_clim.common import clip_radius_to_hill, get_oarr_from_parr, get_spfile_path
 from proteus.utils.constants import gas_list, noble_gases
 from proteus.utils.helper import (
     UpdateStatusfile,
@@ -1204,15 +1204,20 @@ def run_agni(
         log.warning('Change in F_atm [W m-2] limited in this step!')
         log.warning('    %g  ->  %g' % (F_atm_new, F_atm_lim))
 
-    # p_xuv from R_xuv
+    # p_xuv from R_xuv, clipping the radius before the pressure lookup
     if config.escape.xuv_defined_by_radius:
-        r_xuv = hf_row['R_xuv']  # m
+        r_xuv = clip_radius_to_hill(config, hf_row, float(hf_row['R_xuv']))  # m
         p_xuv = get_oarr_from_parr(atmos.r, atmos.p, r_xuv)[1] * 1e-5  # bar
 
-    # R_xuv from p_xuv
+    # R_xuv from p_xuv; a clipped radius moves the level, so the pressure is
+    # re-read at the clipped radius to keep the level self-consistent
     else:
         p_xuv = hf_row['p_xuv']  # bar
         r_xuv = get_oarr_from_parr(atmos.p, atmos.r, p_xuv * 1e5)[1]  # m
+        r_clip = clip_radius_to_hill(config, hf_row, r_xuv)
+        if r_clip != r_xuv:
+            r_xuv = r_clip
+            p_xuv = get_oarr_from_parr(atmos.r, atmos.p, r_xuv)[1] * 1e-5  # bar
 
     # Temperature and gravity at the XUV level, from the cell-centre profiles.
     # The transparent solver updates only the surface scalars, so in that

--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -39,6 +39,25 @@ class Atmos_t:
         # failures with no interior state change). Transient, not persisted.
         self.converged: bool = True
 
+        # Photospheric and XUV level properties from the most recent solve
+        # that converged, keyed as in the helpfile row. Empty until this run
+        # converges a solve of its own; a run that has to substitute before
+        # then falls back on the last committed row. Transient, not persisted.
+        self.levels_converged: dict[str, float] = {}
+
+        # Where the levels above came from, and how many consecutive iterations
+        # have run on levels this run did not resolve itself. The source is
+        # tracked here rather than re-derived per call, since a run that has
+        # only ever fallen back on the committed row must not report those
+        # levels as converged. Transient, not persisted.
+        self.levels_source: str = 'last converged solve'
+        self.levels_carried: int = 0
+
+        # Atmosphere solves this run has made. Only the first one may fall back
+        # on the rows committed before the run started; after that, an empty
+        # record means this run's own rows carry rejected levels too.
+        self.solves_seen: int = 0
+
 
 def ncdf_flag_to_bool(var) -> bool:
     """Convert NetCDF flag (y/n) to Python bool (true/false)"""

--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -342,6 +342,52 @@ def get_spfile_path(fwl_dir: str, config: Config):
     return os.path.join(fwl_dir, 'spectral_files', group, bands, group) + '.sf'
 
 
+def clip_radius_to_hill(config: Config, hf_row: dict, radius: float) -> float:
+    """Limit a level radius to the Hill radius, never below the solid body.
+
+    Gas beyond the Hill radius is not bound to the planet, so an XUV radius
+    outside it sizes the escape cross-section with material the planet does
+    not hold, and the energy-limited rate grows as the cube of the excess.
+    The limit is ``escape.hill_clamp_frac`` of the Hill radius, floored at
+    ``R_int`` since the solid body is always bound.
+
+    Parameters
+    ----------
+        config : Config
+            Configuration options for PROTEUS.
+        hf_row : dict
+            Current helpfile row; provides ``hill_radius`` and ``R_int``.
+        radius : float
+            Level radius to limit [m].
+
+    Returns
+    ----------
+        float
+            The radius, limited when the clip is enabled and applicable.
+    """
+    if not getattr(config.escape, 'hill_clamp', False):
+        return radius
+
+    # Zero before the first orbit update; nothing to clip against yet.
+    r_hill = float(hf_row.get('hill_radius', 0.0))
+    if not np.isfinite(r_hill) or r_hill <= 0.0:
+        return radius
+
+    frac = float(getattr(config.escape, 'hill_clamp_frac', 1.0))
+    r_limit = max(frac * r_hill, float(hf_row.get('R_int', 0.0)))
+    if radius <= r_limit:
+        return radius
+
+    log.warning(
+        'Level radius %.4e m exceeds %.3g of the Hill radius (%.4e m); clipping to %.4e m',
+        radius,
+        frac,
+        r_hill,
+        r_limit,
+    )
+    return r_limit
+
+
 def get_oarr_from_parr(p_arr: list, o_arr: list, p_tgt: float) -> tuple:
     """
     Get the value of o_array corresponding to the p_tgt level in p_arr.

--- a/src/proteus/atmos_clim/common.py
+++ b/src/proteus/atmos_clim/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import glob
 import logging
 import os
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -14,6 +15,19 @@ if TYPE_CHECKING:
     from proteus.config import Config
 
 log = logging.getLogger('fwl.' + __name__)
+
+
+class LevelsSource(Enum):
+    """Origin of the fallback level properties held on `Atmos_t`.
+
+    CONVERGED_SOLVE: levels recorded from a solve this run accepted.
+    COMMITTED_ROW: levels taken from the last helpfile row written before this
+    run began, which is what a resumed run has until it converges a solve of
+    its own.
+    """
+
+    CONVERGED_SOLVE = auto()
+    COMMITTED_ROW = auto()
 
 
 # Atmosphere structure class
@@ -45,13 +59,18 @@ class Atmos_t:
         # then falls back on the last committed row. Transient, not persisted.
         self.levels_converged: dict[str, float] = {}
 
-        # Where the levels above came from, and how many consecutive iterations
-        # have run on levels this run did not resolve itself. The source is
-        # tracked here rather than re-derived per call, since a run that has
-        # only ever fallen back on the committed row must not report those
-        # levels as converged. Transient, not persisted.
-        self.levels_source: str = 'last converged solve'
-        self.levels_carried: int = 0
+        # Where the levels above came from. Tracked here rather than re-derived
+        # per call, since a run that has only ever fallen back on the committed
+        # row must not report those levels as converged. Transient.
+        self.levels_source: LevelsSource = LevelsSource.CONVERGED_SOLVE
+
+        # Number of consecutive iterations whose level properties were not
+        # produced by a converged solve of this run, whether they were
+        # substituted from the record or kept from a rejected structure for
+        # want of anything better. Reset to zero by the next converged solve.
+        # Mirrored to the helpfile column `atm_levels_stale` on every
+        # iteration, so it is readable per row after the run.
+        self.levels_stale_iters: int = 0
 
         # Atmosphere solves this run has made. Only the first one may fall back
         # on the rows committed before the run started; after that, an empty

--- a/src/proteus/atmos_clim/dummy.py
+++ b/src/proteus/atmos_clim/dummy.py
@@ -44,6 +44,9 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
             'R_xuv': R_obs,
             'p_obs': hf_row['P_surf'],
             'T_obs': T_surf_atm,
+            # The dummy XUV level coincides with the observed one
+            'T_xuv': T_surf_atm,
+            'g_xuv': hf_row['gravity'] * (hf_row['R_int'] / R_obs) ** 2,
             'ocean_areacov': 0.0,
             'ocean_maxdepth': 0.0,
             'P_surf_clim': hf_row['P_surf'],
@@ -159,6 +162,9 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
     # Use the locally computed value to avoid requiring hf_row["T_surf"] in unit tests.
     output['T_obs'] = T_surf_atm
     output['g_obs'] = hf_row['gravity'] * (hf_row['R_int'] / R_obs) ** 2
+    # The dummy XUV level coincides with the observed one
+    output['T_xuv'] = T_surf_atm
+    output['g_xuv'] = output['g_obs']
     output['ocean_areacov'] = 0.0
     output['ocean_maxdepth'] = 0.0
     output['P_surf_clim'] = hf_row['P_surf']

--- a/src/proteus/atmos_clim/dummy.py
+++ b/src/proteus/atmos_clim/dummy.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from proteus.atmos_clim.common import clip_radius_to_hill
 from proteus.utils.constants import const_R, const_sigma, gas_list
 from proteus.utils.helper import UpdateStatusfile
 
@@ -33,6 +34,9 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
         T_surf_atm = float(hf_row['T_magma'])
         atm_H = const_R * T_surf_atm / (hf_row['atm_kg_per_mol'] * hf_row['gravity'])
         R_obs = hf_row['R_int'] + atm_H * config.atmos_clim.dummy.height_factor
+        # The dummy XUV level sits at the observed radius, limited to the Hill
+        # radius; there is no profile to re-read pressure or temperature from.
+        R_xuv = clip_radius_to_hill(config, hf_row, R_obs)
         output = {
             'T_surf': T_surf_atm,
             'F_atm': fixed_flux,
@@ -41,12 +45,11 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
             'R_obs': R_obs,
             'albedo': 0.0,
             'p_xuv': hf_row['P_surf'],
-            'R_xuv': R_obs,
+            'R_xuv': R_xuv,
             'p_obs': hf_row['P_surf'],
             'T_obs': T_surf_atm,
-            # The dummy XUV level coincides with the observed one
             'T_xuv': T_surf_atm,
-            'g_xuv': hf_row['gravity'] * (hf_row['R_int'] / R_obs) ** 2,
+            'g_xuv': hf_row['gravity'] * (hf_row['R_int'] / R_xuv) ** 2,
             'ocean_areacov': 0.0,
             'ocean_maxdepth': 0.0,
             'P_surf_clim': hf_row['P_surf'],
@@ -156,15 +159,16 @@ def RunDummyAtm(dirs: dict, config: Config, hf_row: dict):
     output['R_obs'] = R_obs
     output['albedo'] = bond_albedo
     output['p_xuv'] = hf_row['P_surf']
-    output['R_xuv'] = R_obs
+    # The XUV level sits at the observed radius, limited to the Hill radius
+    R_xuv = clip_radius_to_hill(config, hf_row, R_obs)
+    output['R_xuv'] = R_xuv
     output['p_obs'] = hf_row['P_surf']
     # For the dummy climate model, the observed temperature is the surface temperature.
     # Use the locally computed value to avoid requiring hf_row["T_surf"] in unit tests.
     output['T_obs'] = T_surf_atm
     output['g_obs'] = hf_row['gravity'] * (hf_row['R_int'] / R_obs) ** 2
-    # The dummy XUV level coincides with the observed one
     output['T_xuv'] = T_surf_atm
-    output['g_xuv'] = output['g_obs']
+    output['g_xuv'] = hf_row['gravity'] * (hf_row['R_int'] / R_xuv) ** 2
     output['ocean_areacov'] = 0.0
     output['ocean_maxdepth'] = 0.0
     output['P_surf_clim'] = hf_row['P_surf']

--- a/src/proteus/atmos_clim/janus.py
+++ b/src/proteus/atmos_clim/janus.py
@@ -346,6 +346,18 @@ def RunJANUS(
         p_xuv = hf_row['p_xuv']  # bar
         r_xuv = get_oarr_from_parr(atm.p, r_arr, p_xuv * 1e5)[1]  # m
 
+    # Temperature at the XUV level from the temperature profile; gravity by the
+    # inverse-square law from the surface value, for the same reason as g_obs
+    # above (atm.grav_z is stale after write_ncdf reintegrates the heights).
+    # When the hydrostatic integration failed the heights are unusable, so fall
+    # back to the surface values, matching the r_obs fallback above.
+    if atm.height_error or r_xuv <= 0.0:
+        t_xuv = float(hf_row['T_surf'])
+        g_xuv = float(hf_row['gravity'])
+    else:
+        _, t_xuv = get_oarr_from_parr(atm.p, t_arr, p_xuv * 1e5)  # K
+        g_xuv = float(hf_row['gravity']) * (float(hf_row['R_int']) / r_xuv) ** 2  # m s-2
+
     # final things to store
     output = {}
     output['T_surf'] = atm.ts  # Surface temperature [K]
@@ -359,6 +371,8 @@ def RunJANUS(
     output['g_obs'] = g_obs  # observed gravity [m/s^2]
     output['p_xuv'] = p_xuv  # Closest pressure to Pxuv [bar]
     output['R_xuv'] = r_xuv  # Radius at Pxuv [m]
+    output['T_xuv'] = float(t_xuv)  # Temperature at Pxuv [K]
+    output['g_xuv'] = g_xuv  # Gravity at Pxuv [m s-2]
     output['P_surf_clim'] = P_surf_clim  # calculated surface pressure [bar]
     output['ocean_areacov'] = 0.0
     output['ocean_maxdepth'] = 0.0

--- a/src/proteus/atmos_clim/janus.py
+++ b/src/proteus/atmos_clim/janus.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
-from proteus.atmos_clim.common import get_oarr_from_parr
+from proteus.atmos_clim.common import clip_radius_to_hill, get_oarr_from_parr
 from proteus.utils.constants import vap_list, vol_list, gas_list
 from proteus.utils.helper import UpdateStatusfile, create_tmp_folder
 
@@ -336,15 +336,20 @@ def RunJANUS(
     # This neglects self-gravity but is self-consistent with JANUS internals.
     g_obs = float(hf_row['gravity']) * (float(hf_row['R_int']) / r_obs) ** 2
 
-    # p_xuv from R_xuv
+    # p_xuv from R_xuv, clipping the radius before the pressure lookup
     if config.escape.xuv_defined_by_radius:
-        r_xuv = hf_row['R_xuv']  # m
+        r_xuv = clip_radius_to_hill(config, hf_row, float(hf_row['R_xuv']))  # m
         p_xuv = get_oarr_from_parr(r_arr, atm.p, r_xuv)[1] * 1e-5  # bar
 
-    # R_xuv from p_xuv
+    # R_xuv from p_xuv; a clipped radius moves the level, so the pressure is
+    # re-read at the clipped radius to keep the level self-consistent
     else:
         p_xuv = hf_row['p_xuv']  # bar
         r_xuv = get_oarr_from_parr(atm.p, r_arr, p_xuv * 1e5)[1]  # m
+        r_clip = clip_radius_to_hill(config, hf_row, r_xuv)
+        if r_clip != r_xuv:
+            r_xuv = r_clip
+            p_xuv = get_oarr_from_parr(r_arr, atm.p, r_xuv)[1] * 1e-5  # bar
 
     # Temperature at the XUV level from the temperature profile; gravity by the
     # inverse-square law from the surface value, for the same reason as g_obs

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -12,7 +12,12 @@ from numpy import pi, unique
 if TYPE_CHECKING:
     from proteus.config import Config
 
-from proteus.atmos_clim.common import Atmos_t, LevelsSource, get_spfile_path
+from proteus.atmos_clim.common import (
+    Atmos_t,
+    LevelsSource,
+    clip_radius_to_hill,
+    get_spfile_path,
+)
 from proteus.utils.constants import const_R, gas_list
 from proteus.utils.helper import UpdateStatusfile, safe_rm
 
@@ -359,6 +364,13 @@ def run_atmosphere(
     if hf_all is not None and len(hf_all) > 0:
         previous_row = hf_all.iloc[-1].to_dict()
     carry_converged_levels(atmos_o, hf_row, previous_row=previous_row)
+
+    # A carried radius can come from a row written before the clip existed, or
+    # under a different Hill radius, so bound it here as well. There is no
+    # profile on this path to re-read the rest of the level from, and the
+    # rate escape computes goes as the cube of this radius, so the bound wins.
+    if hasattr(config, 'escape') and 'R_xuv' in hf_row:
+        hf_row['R_xuv'] = clip_radius_to_hill(config, hf_row, float(hf_row['R_xuv']))
 
     # Persist the solve outcome, so a row whose levels were carried can be
     # identified from the output alone rather than from the log.

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -13,10 +13,153 @@ if TYPE_CHECKING:
     from proteus.config import Config
 
 from proteus.atmos_clim.common import Atmos_t, get_spfile_path
-from proteus.utils.constants import const_R
+from proteus.utils.constants import const_R, gas_list
 from proteus.utils.helper import UpdateStatusfile, safe_rm
 
 log = logging.getLogger('fwl.' + __name__)
+
+# Scalar properties of the photospheric and XUV levels, all read off the
+# atmospheric structure the solver returns. They are carried together so that
+# each level keeps a radius, pressure, temperature and gravity that describe the
+# same structure. Fluxes and surface state are deliberately absent: the coupling
+# and the deadlock detector both need to see those move when a solve fails.
+LEVEL_KEYS = ('R_obs', 'p_obs', 'T_obs', 'g_obs', 'R_xuv', 'p_xuv')
+
+# Composition at the XUV level, read off the same structure and used by BOREAS
+# to set the mean molecular weight of the outflow. Carried with the levels, so
+# a held radius is never combined with the composition of a rejected structure.
+XUV_VMR_KEYS = tuple(f'{gas}_vmr_xuv' for gas in gas_list)
+
+# Number of consecutive iterations on carried levels after which the run says so
+# at error level. Long enough that a solver which stumbles for an iteration or
+# two passes unremarked, short enough to appear while a run is still worth
+# steering.
+CARRIED_LEVELS_ALERT = 10
+
+
+def _finite_levels(source: dict, keys) -> dict:
+    """Read the level properties out of `source`, skipping the unusable ones.
+
+    A key is taken only when it is present and its value is finite. A solver
+    that returns NaN for a level has not measured it, so storing that value
+    would replace the fallback with something that cannot be fallen back on.
+    """
+    out = {}
+    for key in keys:
+        if key not in source:
+            continue
+        val = float(source[key])
+        if np.isfinite(val):
+            out[key] = val
+    return out
+
+
+def _alert_on_long_streak(atmos_o: Atmos_t):
+    """Report a long run of iterations whose levels the run did not resolve.
+
+    A streak this long is no longer a solver that stumbled once. The interior
+    keeps evolving while the levels stand still, so escape is computed on a
+    planet that has moved on, and the deadlock detector cannot see it: that
+    detector fires only when the interior has stopped moving as well.
+    """
+    if atmos_o.levels_carried >= CARRIED_LEVELS_ALERT:
+        log.error(
+            'Atmosphere levels have been unresolved for %d consecutive iterations; '
+            'escape is running on a structure this run has not converged',
+            atmos_o.levels_carried,
+        )
+
+
+def carry_converged_levels(atmos_o: Atmos_t, hf_row: dict, previous_row: dict | None = None):
+    """Carry the photospheric and XUV levels across a solve that was rejected.
+
+    A solver that rejects its solution still returns an atmospheric structure,
+    and the levels read off that structure can sit far outside the planet. The
+    energy-limited escape rate goes as the cube of the XUV radius, so a rejected
+    structure otherwise becomes a large mass-loss rate that looks like a
+    physical result. Each converged solve records its levels; a rejected one has
+    its levels replaced by that record, and the substitution is logged.
+
+    Modules without a nonlinear solve (JANUS, dummy, and AGNI's transparent and
+    prescribed-temperature branches) always report convergence, so this records
+    their levels and never substitutes.
+
+    A resumed run starts with an empty record, since the record is not written
+    to the output files. If its very first solve is rejected it falls back on the
+    last committed row, which was written before this run began and is the state
+    escape would have used in any case. That row is the last one written, not
+    necessarily one that converged, so the substitution says which of the two
+    sources it used.
+
+    Later solves never reach back to the committed rows. Once this run has begun
+    writing rows, an empty record means every solve so far was rejected, so those
+    rows carry rejected levels themselves and are worth no more than the levels
+    in hand.
+
+    Parameters
+    ----------
+        atmos_o : Atmos_t
+            Atmosphere struct. Carries the convergence flag of the solve that
+            has just run, and the record of converged levels, which this
+            function updates.
+        hf_row : dict
+            Simulation variables for this iteration, modified in place. Holds
+            the levels the atmosphere module has just written.
+        previous_row : dict, optional
+            The last committed row, used only when this run's first solve is
+            rejected.
+    """
+
+    keys = LEVEL_KEYS + XUV_VMR_KEYS
+    atmos_o.solves_seen += 1
+
+    # Solve was accepted: its levels become the ones to fall back on. Merged
+    # rather than replaced, so a module that reports one level intermittently
+    # does not empty the record of that level.
+    if atmos_o.converged:
+        atmos_o.levels_converged.update(_finite_levels(hf_row, keys))
+        atmos_o.levels_source = 'last converged solve'
+        atmos_o.levels_carried = 0
+        return
+
+    # First solve of this run, and it failed. The last committed row predates
+    # the run, which is the situation a resumed run is in, so fall back on that.
+    if atmos_o.solves_seen == 1 and previous_row:
+        atmos_o.levels_converged.update(_finite_levels(previous_row, keys))
+        atmos_o.levels_source = 'last committed row'
+
+    # Counts every iteration whose levels this run did not resolve itself, so a
+    # run with nothing to fall back on is counted too. That case is the worse
+    # of the two, since escape then runs on the rejected structure directly.
+    atmos_o.levels_carried += 1
+
+    if not atmos_o.levels_converged:
+        log.warning(
+            'Atmosphere solve did not converge and no earlier levels are '
+            'available; using the levels of the rejected structure '
+            '(%d consecutive iterations)',
+            atmos_o.levels_carried,
+        )
+        _alert_on_long_streak(atmos_o)
+        return
+
+    log.warning(
+        'Atmosphere solve did not converge; holding levels from the %s '
+        '(%d consecutive iterations)',
+        atmos_o.levels_source,
+        atmos_o.levels_carried,
+    )
+    _alert_on_long_streak(atmos_o)
+
+    for key in LEVEL_KEYS:
+        if key in atmos_o.levels_converged and key in hf_row:
+            log.warning(
+                '    %-5s %.5e  ->  %.5e'
+                % (key, float(hf_row[key]), atmos_o.levels_converged[key])
+            )
+    for key in keys:
+        if key in atmos_o.levels_converged and key in hf_row:
+            hf_row[key] = atmos_o.levels_converged[key]
 
 
 def run_atmosphere(
@@ -201,6 +344,15 @@ def run_atmosphere(
     for key in atm_output.keys():
         if key in hf_row.keys():
             hf_row[key] = atm_output[key]
+
+    # Keep escape and the observables off a structure the solver rejected. This
+    # runs on the merged row, after the module output and the module's direct
+    # writes to `hf_row` are both in place, and before the quantities derived
+    # from the levels below.
+    previous_row = None
+    if hf_all is not None and len(hf_all) > 0:
+        previous_row = hf_all.iloc[-1].to_dict()
+    carry_converged_levels(atmos_o, hf_row, previous_row=previous_row)
 
     # Copy special cases
     hf_row['rho_obs'] = 3 * hf_row['M_planet'] / (4 * pi * hf_row['R_obs'] ** 3)

--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -12,7 +12,7 @@ from numpy import pi, unique
 if TYPE_CHECKING:
     from proteus.config import Config
 
-from proteus.atmos_clim.common import Atmos_t, get_spfile_path
+from proteus.atmos_clim.common import Atmos_t, LevelsSource, get_spfile_path
 from proteus.utils.constants import const_R, gas_list
 from proteus.utils.helper import UpdateStatusfile, safe_rm
 
@@ -23,7 +23,13 @@ log = logging.getLogger('fwl.' + __name__)
 # each level keeps a radius, pressure, temperature and gravity that describe the
 # same structure. Fluxes and surface state are deliberately absent: the coupling
 # and the deadlock detector both need to see those move when a solve fails.
-LEVEL_KEYS = ('R_obs', 'p_obs', 'T_obs', 'g_obs', 'R_xuv', 'p_xuv')
+LEVEL_KEYS = ('R_obs', 'p_obs', 'T_obs', 'g_obs', 'R_xuv', 'p_xuv', 'T_xuv', 'g_xuv')
+
+# Phrase used for each level source in the substitution warning.
+_SOURCE_PHRASE = {
+    LevelsSource.CONVERGED_SOLVE: 'last converged solve',
+    LevelsSource.COMMITTED_ROW: 'last committed row',
+}
 
 # Composition at the XUV level, read off the same structure and used by BOREAS
 # to set the mean molecular weight of the outflow. Carried with the levels, so
@@ -62,11 +68,11 @@ def _alert_on_long_streak(atmos_o: Atmos_t):
     planet that has moved on, and the deadlock detector cannot see it: that
     detector fires only when the interior has stopped moving as well.
     """
-    if atmos_o.levels_carried >= CARRIED_LEVELS_ALERT:
+    if atmos_o.levels_stale_iters >= CARRIED_LEVELS_ALERT:
         log.error(
             'Atmosphere levels have been unresolved for %d consecutive iterations; '
             'escape is running on a structure this run has not converged',
-            atmos_o.levels_carried,
+            atmos_o.levels_stale_iters,
         )
 
 
@@ -84,17 +90,17 @@ def carry_converged_levels(atmos_o: Atmos_t, hf_row: dict, previous_row: dict | 
     prescribed-temperature branches) always report convergence, so this records
     their levels and never substitutes.
 
-    A resumed run starts with an empty record, since the record is not written
-    to the output files. If its very first solve is rejected it falls back on the
-    last committed row, which was written before this run began and is the state
-    escape would have used in any case. That row is the last one written, not
-    necessarily one that converged, so the substitution says which of the two
-    sources it used.
+    The record of converged levels lives only in memory, so a resumed run starts
+    without one. If the first solve after the resume is rejected, the fallback is
+    taken from the last helpfile row instead: that row was written before this
+    run began, and it is the state escape used on the resumed iteration anyway.
+    The warning states which of the two sources was used, because a helpfile row
+    is not guaranteed to come from a converged solve.
 
-    Later solves never reach back to the committed rows. Once this run has begun
-    writing rows, an empty record means every solve so far was rejected, so those
-    rows carry rejected levels themselves and are worth no more than the levels
-    in hand.
+    The helpfile fallback applies to the first solve only. If every solve since
+    then was rejected, the record is empty, but each helpfile row written since
+    the resume contains rejected levels too, so there is nothing better to read
+    back and the rejected levels are kept.
 
     Parameters
     ----------
@@ -118,27 +124,27 @@ def carry_converged_levels(atmos_o: Atmos_t, hf_row: dict, previous_row: dict | 
     # does not empty the record of that level.
     if atmos_o.converged:
         atmos_o.levels_converged.update(_finite_levels(hf_row, keys))
-        atmos_o.levels_source = 'last converged solve'
-        atmos_o.levels_carried = 0
+        atmos_o.levels_source = LevelsSource.CONVERGED_SOLVE
+        atmos_o.levels_stale_iters = 0
         return
 
     # First solve of this run, and it failed. The last committed row predates
     # the run, which is the situation a resumed run is in, so fall back on that.
     if atmos_o.solves_seen == 1 and previous_row:
         atmos_o.levels_converged.update(_finite_levels(previous_row, keys))
-        atmos_o.levels_source = 'last committed row'
+        atmos_o.levels_source = LevelsSource.COMMITTED_ROW
 
     # Counts every iteration whose levels this run did not resolve itself, so a
     # run with nothing to fall back on is counted too. That case is the worse
     # of the two, since escape then runs on the rejected structure directly.
-    atmos_o.levels_carried += 1
+    atmos_o.levels_stale_iters += 1
 
     if not atmos_o.levels_converged:
         log.warning(
             'Atmosphere solve did not converge and no earlier levels are '
             'available; using the levels of the rejected structure '
             '(%d consecutive iterations)',
-            atmos_o.levels_carried,
+            atmos_o.levels_stale_iters,
         )
         _alert_on_long_streak(atmos_o)
         return
@@ -146,14 +152,14 @@ def carry_converged_levels(atmos_o: Atmos_t, hf_row: dict, previous_row: dict | 
     log.warning(
         'Atmosphere solve did not converge; holding levels from the %s '
         '(%d consecutive iterations)',
-        atmos_o.levels_source,
-        atmos_o.levels_carried,
+        _SOURCE_PHRASE[atmos_o.levels_source],
+        atmos_o.levels_stale_iters,
     )
     _alert_on_long_streak(atmos_o)
 
     for key in LEVEL_KEYS:
         if key in atmos_o.levels_converged and key in hf_row:
-            log.warning(
+            log.debug(
                 '    %-5s %.5e  ->  %.5e'
                 % (key, float(hf_row[key]), atmos_o.levels_converged[key])
             )
@@ -353,6 +359,11 @@ def run_atmosphere(
     if hf_all is not None and len(hf_all) > 0:
         previous_row = hf_all.iloc[-1].to_dict()
     carry_converged_levels(atmos_o, hf_row, previous_row=previous_row)
+
+    # Persist the solve outcome, so a row whose levels were carried can be
+    # identified from the output alone rather than from the log.
+    hf_row['atm_converged'] = 1.0 if atmos_o.converged else -1.0
+    hf_row['atm_levels_stale'] = float(atmos_o.levels_stale_iters)
 
     # Copy special cases
     hf_row['rho_obs'] = 3 * hf_row['M_planet'] / (4 * pi * hf_row['R_obs'] ** 3)

--- a/src/proteus/config/_escape.py
+++ b/src/proteus/config/_escape.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from attrs import define, field
-from attrs.validators import ge, in_, le
+from attrs.validators import ge, gt, in_, le
 
 from ._converters import none_if_none, zero_if_none
 
@@ -153,6 +153,13 @@ class Escape:
         Parameters for dummy escape module.
     boreas: EscapeBoreas
         Parameters for BOREAS escape module.
+    hill_clamp: bool
+        Limit the XUV level to the Hill radius. Gas beyond the Hill radius is
+        not bound to the planet, so an XUV radius outside it sizes the escape
+        cross-section with material the planet does not hold.
+    hill_clamp_frac: float
+        Fraction of the Hill radius used as that limit, when hill_clamp is
+        enabled.
     """
 
     module: str | None = field(
@@ -166,6 +173,9 @@ class Escape:
     boreas: EscapeBoreas = field(factory=EscapeBoreas, validator=valid_escapeboreas)
 
     reservoir: str = field(default='outgas', validator=valid_reservoir)
+
+    hill_clamp: bool = field(default=True)
+    hill_clamp_frac: float = field(default=1.0, validator=(gt(0.0), le(1.0)))
 
     @property
     def xuv_defined_by_radius(self) -> bool:

--- a/src/proteus/escape/boreas.py
+++ b/src/proteus/escape/boreas.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from proteus.atmos_clim.common import clip_radius_to_hill
 from proteus.escape.common import calc_unfract_fluxes
 from proteus.utils.constants import AU, element_list, gas_list
 from proteus.utils.helper import UpdateStatusfile, eval_gas_mmw
@@ -86,6 +87,37 @@ def _set_boreas_params(config: Config, hf_row: dict) -> boreas.ModelParams:
     return params
 
 
+def bound_escape_level(config: Config, hf_row: dict, r_xuv: float) -> float:
+    """Bound the escape level to the Hill radius and scale the rate with it.
+
+    BOREAS solves for its own XUV radius, and everything computed from that
+    radius collects XUV over the corresponding cross-section. Gas beyond the
+    Hill radius is not bound to the planet, so when the solved radius exceeds
+    it, the bulk rate already stored in ``hf_row`` is scaled by the area ratio
+    of the clipped level, and the clipped radius is returned so the
+    per-element rates are sized from the same cross-section.
+
+    Parameters
+    ----------
+        config : Config
+            Configuration options for PROTEUS.
+        hf_row : dict
+            Current helpfile row, holding ``esc_rate_total``; modified in
+            place when the level is clipped.
+        r_xuv : float
+            XUV radius solved by BOREAS [m].
+
+    Returns
+    ----------
+        float
+            The bounded XUV radius [m].
+    """
+    r_clip = clip_radius_to_hill(config, hf_row, r_xuv)
+    if r_clip < r_xuv:
+        hf_row['esc_rate_total'] *= (r_clip / r_xuv) ** 2
+    return r_clip
+
+
 def run_boreas(config: Config, hf_row: dict, dirs: dict):
     """Run BOREAS escape model.
 
@@ -137,10 +169,11 @@ def run_boreas(config: Config, hf_row: dict, dirs: dict):
     regime_map = {'RL': 'recomb-limited', 'EL': 'energy-limited', 'DL': 'diffusion-limited'}
     log.info('Escape regime is ' + regime_map[fr_result['regime']])
 
-    # Store bulk outputs (rate, sound speed, escape level)
+    # Store bulk outputs (rate, sound speed, escape level). The level is
+    # bounded to the Hill radius, scaling the rate with the clipped area.
     hf_row['esc_rate_total'] = fr_result['Mdot'] * 1e-3  # g/s   ->  kg/s
     hf_row['cs_xuv'] = fr_result['cs'] * 1e-2  # cm/s  ->  m/s
-    hf_row['R_xuv'] = fr_result['RXUV'] * 1e-2  # cm    ->  m
+    hf_row['R_xuv'] = bound_escape_level(config, hf_row, fr_result['RXUV'] * 1e-2)  # m
     hf_row['p_xuv'] = 0.0  # to be calc'd by atmosphere module
 
     # If not doing fractionation, overwrite fluxes...

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -1287,26 +1287,12 @@ def WriteHelpfileToCSV(output_dir: str, current_hf: pd.DataFrame):
 
 def ReadHelpfileFromCSV(output_dir: str):
     """
-    Read helpfile from disk CSV file to DataFrame.
-
-    The loaded columns are reconciled against the current schema, so a run can
-    be resumed with a PROTEUS whose schema has since gained columns: keys the
-    file does not have are filled with zero, matching the value they hold on a
-    fresh row before their module first writes them. Columns the schema no
-    longer defines are dropped.
+    Read helpfile from disk CSV file to DataFrame
     """
     fpath = os.path.join(output_dir, 'runtime_helpfile.csv')
     if not os.path.exists(fpath):
         raise Exception("Cannot find helpfile at '%s'" % fpath)
-    df = pd.read_csv(fpath, sep=r'\s+')
-    missing = [key for key in GetHelpfileKeys() if key not in df.columns]
-    if missing:
-        log.warning(
-            'Helpfile lacks %d column(s) added since it was written; filling with zero: %s',
-            len(missing),
-            missing,
-        )
-    return df.reindex(columns=GetHelpfileKeys(), fill_value=0.0)
+    return pd.read_csv(fpath, sep=r'\s+')
 
 
 def _netcdf_readable(path: str) -> bool:

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -815,6 +815,8 @@ def GetHelpfileKeys():
         'tau_atm_surface',  # optical depth at surface, at ref wavelength [1]
         'atm_Ra_max',      # maximum Rayleigh number across levels [1]
         'atm_t_conv_over_t_rad',  # convective vs radiative timescale ratio [1]
+        'atm_converged',    # atmosphere solve outcome: +1 converged, -1 rejected, 0 no solve [1]
+        'atm_levels_stale',  # consecutive iterations without a converged solve of this run [1]
         'F_tidal',          # tidal heat flux arising at surface [W m-2]
         'F_radio',          # radiogenic heat flux arising at surface [W m-2]
         'F_cmb',             # heat flux at the CMB (signed, +out-of-core) [W m-2]
@@ -990,6 +992,8 @@ def GetHelpfileKeys():
     # Atmospheric escape
     keys.append('p_xuv')                # pressure of XUV absorption [bar]
     keys.append('R_xuv')                # radius of XUV absorption [m]
+    keys.append('T_xuv')                # temperature at R_xuv [K]
+    keys.append('g_xuv')                # gravity at R_xuv [m s-2]
     keys.append('cs_xuv')               # sound speed, at R_xuv [m s-1]
     keys.append('esc_rate_total')       # bulk escape rate [kg s-1]
     for e in element_list:
@@ -1283,12 +1287,26 @@ def WriteHelpfileToCSV(output_dir: str, current_hf: pd.DataFrame):
 
 def ReadHelpfileFromCSV(output_dir: str):
     """
-    Read helpfile from disk CSV file to DataFrame
+    Read helpfile from disk CSV file to DataFrame.
+
+    The loaded columns are reconciled against the current schema, so a run can
+    be resumed with a PROTEUS whose schema has since gained columns: keys the
+    file does not have are filled with zero, matching the value they hold on a
+    fresh row before their module first writes them. Columns the schema no
+    longer defines are dropped.
     """
     fpath = os.path.join(output_dir, 'runtime_helpfile.csv')
     if not os.path.exists(fpath):
         raise Exception("Cannot find helpfile at '%s'" % fpath)
-    return pd.read_csv(fpath, sep=r'\s+')
+    df = pd.read_csv(fpath, sep=r'\s+')
+    missing = [key for key in GetHelpfileKeys() if key not in df.columns]
+    if missing:
+        log.warning(
+            'Helpfile lacks %d column(s) added since it was written; filling with zero: %s',
+            len(missing),
+            missing,
+        )
+    return df.reindex(columns=GetHelpfileKeys(), fill_value=0.0)
 
 
 def _netcdf_readable(path: str) -> bool:

--- a/tests/atmos_clim/test_agni.py
+++ b/tests/atmos_clim/test_agni.py
@@ -236,6 +236,8 @@ class _FakeAtmosphere:
         self.p_oboa = 1e5
         self.tmp_surf = 1500.0
         self.tmp_magma = 1500.0
+        # Cell-centre gravity, read at the XUV level
+        self.g = [9.8]
         # Solver flags
         self.is_converged = True
         # Allocation flag, gating write_atmos_ncdf
@@ -565,6 +567,7 @@ def _build_complete_atmos_stub() -> SimpleNamespace:
         p_oboa=1e5,
         tmp_surf=1500.0,
         tmp_magma=1500.0,
+        g=[9.8],
         is_converged=True,
         transparent=False,
         flux_d_sw=[100.0],
@@ -965,6 +968,9 @@ def _make_run_agni_atmos(*, transparent=False):
     atmos.gas_ovmr = {'H2O': [0.9], 'CO2': [0.1]}
     atmos.p = [1e3, 1e5]
     atmos.r = [6.5e6, 6.4e6]
+    # Cell-centre profiles read at the XUV level; two entries to match p
+    atmos.tmp = [280.0, 900.0]
+    atmos.g = [9.5, 9.8]
     atmos.is_converged = True
     atmos.tau_band = [[0.01, 0.02], [0.5, 0.6]]
     atmos.diagnostic_Ra = [0.1, 5.0]
@@ -1217,6 +1223,60 @@ def test_run_agni_opaque_gobs_inverse_square_of_robs(monkeypatch):
 
     # Discrimination guard: rules out a pass-through of the surface gravity
     assert output['g_obs'] != pytest.approx(g_surf, rel=1e-3)
+
+
+@pytest.mark.physics_invariant
+def test_run_agni_xuv_level_temperature_and_gravity_from_profiles(monkeypatch):
+    """T_xuv and g_xuv are read off the cell-centre profiles at the XUV level.
+
+    With p_xuv = 1e-3 bar = 100 Pa against a profile p = [1e3, 1e5] Pa, the
+    nearest level is the upper cell, so T_xuv = 280 K and g_xuv = 9.5 m/s2.
+    The lower cell holds 900 K and 9.8 m/s2, so reading the wrong end of the
+    column misses by a factor of 3.2 in temperature, far outside tolerance.
+    """
+    atmos = _make_run_agni_atmos(transparent=False)
+    config = _make_run_agni_config(solve_energy=False)
+    hf_row = {
+        'P_surf': 100.0,
+        'p_xuv': 1e-3,
+        'R_xuv': 6.5e6,
+        'R_int': 6.371e6,
+        'gravity': 9.8,
+        'Time': 100.0,
+    }
+    for g in ['H2O', 'CO2']:
+        hf_row[g + '_vmr'] = 0.5
+
+    dirs = {'output': '/tmp/fake', 'output/plots': '/tmp/fake_plots'}
+    fake_jl = SimpleNamespace(
+        AGNI=SimpleNamespace(
+            atmosphere=SimpleNamespace(estimate_photosphere_b=lambda *a, **kw: None),
+            save=SimpleNamespace(write_ncdf=lambda a, p: None),
+            plotting=SimpleNamespace(plot_contfunc1=lambda a, p: None),
+            chemistry=SimpleNamespace(calc_composition_b=lambda *a: False),
+            setpt=SimpleNamespace(
+                dry_adiabat_b=lambda a: None,
+                saturation_b=lambda a, g: None,
+                stratosphere_b=lambda a, v: None,
+            ),
+            energy=SimpleNamespace(
+                calc_fluxes_b=lambda a, **kw: None,
+                fill_Kzz_b=lambda a: None,
+            ),
+        ),
+    )
+    monkeypatch.setattr(agni_mod, 'jl', fake_jl)
+    monkeypatch.setattr(agni_mod, 'sync_log_files', lambda *a: [])
+    # The real interpolator, so the pin discriminates which cell was read
+
+    _, output = agni_mod.run_agni(atmos, 1, dirs, config, hf_row)
+
+    assert output['T_xuv'] == pytest.approx(280.0, rel=1e-12)
+    assert output['g_xuv'] == pytest.approx(9.5, rel=1e-12)
+    assert output['R_xuv'] == pytest.approx(6.5e6, rel=1e-12)
+    # Discrimination: the other end of the column is far outside tolerance.
+    assert output['T_xuv'] != pytest.approx(900.0, rel=1e-2)
+    assert output['g_xuv'] != pytest.approx(9.8, rel=1e-3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/atmos_clim/test_agni.py
+++ b/tests/atmos_clim/test_agni.py
@@ -982,7 +982,12 @@ def _make_run_agni_atmos(*, transparent=False):
 
 
 def _make_run_agni_config(
-    *, solve_energy=True, prevent_warming=False, oceans=False, xuv_defined_by_radius=False
+    *,
+    solve_energy=True,
+    prevent_warming=False,
+    oceans=False,
+    xuv_defined_by_radius=False,
+    hill_clamp=False,
 ):
     """Build the config namespace run_agni reads."""
     return SimpleNamespace(
@@ -1005,7 +1010,11 @@ def _make_run_agni_config(
             surf_state_int=1,
         ),
         planet=SimpleNamespace(prevent_warming=prevent_warming),
-        escape=SimpleNamespace(xuv_defined_by_radius=xuv_defined_by_radius),
+        escape=SimpleNamespace(
+            xuv_defined_by_radius=xuv_defined_by_radius,
+            hill_clamp=hill_clamp,
+            hill_clamp_frac=1.0,
+        ),
         params=SimpleNamespace(
             out=SimpleNamespace(
                 logging='WARNING',
@@ -1277,6 +1286,94 @@ def test_run_agni_xuv_level_temperature_and_gravity_from_profiles(monkeypatch):
     # Discrimination: the other end of the column is far outside tolerance.
     assert output['T_xuv'] != pytest.approx(900.0, rel=1e-2)
     assert output['g_xuv'] != pytest.approx(9.8, rel=1e-3)
+
+
+def _make_run_agni_jl():
+    """Julia stand-in for the run_agni post-solve path."""
+    return SimpleNamespace(
+        AGNI=SimpleNamespace(
+            atmosphere=SimpleNamespace(estimate_photosphere_b=lambda *a, **kw: None),
+            save=SimpleNamespace(write_ncdf=lambda a, p: None),
+            plotting=SimpleNamespace(plot_contfunc1=lambda a, p: None),
+            chemistry=SimpleNamespace(calc_composition_b=lambda *a: False),
+            setpt=SimpleNamespace(
+                dry_adiabat_b=lambda a: None,
+                saturation_b=lambda a, g: None,
+                stratosphere_b=lambda a, v: None,
+            ),
+            energy=SimpleNamespace(
+                calc_fluxes_b=lambda a, **kw: None,
+                fill_Kzz_b=lambda a: None,
+            ),
+        ),
+    )
+
+
+def _clip_test_hf_row():
+    """Row for the clip tests: Hill radius between the two profile cells."""
+    hf_row = {
+        'P_surf': 100.0,
+        'p_xuv': 1e-3,
+        'R_xuv': 6.5e6,
+        'R_int': 6.371e6,
+        'gravity': 9.8,
+        'Time': 100.0,
+        'hill_radius': 6.42e6,
+    }
+    for g in ['H2O', 'CO2']:
+        hf_row[g + '_vmr'] = 0.5
+    return hf_row
+
+
+@pytest.mark.physics_invariant
+def test_run_agni_clips_the_xuv_level_to_the_hill_radius(monkeypatch):
+    """With the clip enabled and a Hill radius inside the unclipped XUV level,
+    the level moves to the Hill radius and p, T, g are re-read there, so the
+    whole group describes the clipped level rather than mixing two levels.
+
+    Unclipped, p_xuv = 1e-3 bar lands on the upper cell (r = 6.5e6 m, 280 K,
+    9.5 m/s2). The Hill radius at 6.42e6 m forces the level down; the nearest
+    profile point is then the lower cell, so every quantity flips to its other
+    end: p 1e5 Pa, T 900 K, g 9.8 m/s2. A clip that moved only the radius
+    would keep 280 K and fail by a factor of 3.2.
+    """
+    atmos = _make_run_agni_atmos(transparent=False)
+    config = _make_run_agni_config(solve_energy=False, hill_clamp=True)
+    hf_row = _clip_test_hf_row()
+
+    dirs = {'output': '/tmp/fake', 'output/plots': '/tmp/fake_plots'}
+    monkeypatch.setattr(agni_mod, 'jl', _make_run_agni_jl())
+    monkeypatch.setattr(agni_mod, 'sync_log_files', lambda *a: [])
+
+    _, output = agni_mod.run_agni(atmos, 1, dirs, config, hf_row)
+
+    # The level sits at the Hill radius, not at the unclipped 6.5e6 m.
+    assert output['R_xuv'] == pytest.approx(6.42e6, rel=1e-12)
+    # Pressure, temperature and gravity are re-read at the clipped level.
+    assert output['p_xuv'] == pytest.approx(1.0, rel=1e-12)  # 1e5 Pa in bar
+    assert output['T_xuv'] == pytest.approx(900.0, rel=1e-12)
+    assert output['g_xuv'] == pytest.approx(9.8, rel=1e-12)
+    # Discrimination: the unclipped level's values are far outside tolerance.
+    assert output['T_xuv'] != pytest.approx(280.0, rel=1e-2)
+    assert output['p_xuv'] != pytest.approx(1e-3, rel=1e-2)
+
+
+def test_run_agni_clip_disabled_leaves_the_level_alone(monkeypatch):
+    """With the clip disabled the same setup keeps the unclipped level, so the
+    clip cannot silently engage for configs that turned it off."""
+    atmos = _make_run_agni_atmos(transparent=False)
+    config = _make_run_agni_config(solve_energy=False, hill_clamp=False)
+    hf_row = _clip_test_hf_row()
+
+    dirs = {'output': '/tmp/fake', 'output/plots': '/tmp/fake_plots'}
+    monkeypatch.setattr(agni_mod, 'jl', _make_run_agni_jl())
+    monkeypatch.setattr(agni_mod, 'sync_log_files', lambda *a: [])
+
+    _, output = agni_mod.run_agni(atmos, 1, dirs, config, hf_row)
+
+    assert output['R_xuv'] == pytest.approx(6.5e6, rel=1e-12)
+    assert output['T_xuv'] == pytest.approx(280.0, rel=1e-12)
+    assert output['g_xuv'] == pytest.approx(9.5, rel=1e-12)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/atmos_clim/test_atmos_clim.py
+++ b/tests/atmos_clim/test_atmos_clim.py
@@ -712,6 +712,56 @@ def test_rundummyatm_output_keys():
     assert output['P_surf_clim'] > 0.0
 
 
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_rundummyatm_clips_the_xuv_radius_to_the_hill_radius():
+    """With the clip enabled and a Hill radius below the observed radius, the
+    dummy XUV level moves to the Hill radius while the observed level stays,
+    and g_xuv strengthens by the inverse square of the ratio.
+
+    Discrimination: without the clip the XUV level coincides with the observed
+    one and g_xuv equals g_obs; with it, g_xuv exceeds g_obs by the squared
+    radius ratio, which the final pin resolves far outside tolerance.
+    """
+    from proteus.atmos_clim.dummy import RunDummyAtm
+
+    config = MagicMock()
+    config.atmos_clim.dummy.gamma = 0.5
+    config.atmos_clim.dummy.height_factor = 1.0
+    config.atmos_clim.dummy.fixed_flux = -1.0
+    config.orbit.zenith_angle = 0.0
+    config.orbit.s0_factor = 1.0
+    config.atmos_clim.surf_greyalbedo = 0.1
+    config.atmos_clim.surf_state = 'fixed'
+    config.planet.prevent_warming = False
+    config.escape.hill_clamp = True
+    config.escape.hill_clamp_frac = 1.0
+
+    hf_row = {
+        'T_magma': 2500.0,
+        'albedo_pl': 0.1,
+        'F_ins': 1000.0,
+        'atm_kg_per_mol': 0.029,
+        'gravity': 9.8,
+        'R_int': 6.371e6,
+        'P_surf': 1e5,
+    }
+    output = RunDummyAtm({}, config, dict(hf_row))
+    r_obs = output['R_obs']
+    assert r_obs > 6.371e6  # the scale height lifted the observed level
+
+    # Hill radius between R_int and R_obs, so the clip engages.
+    hf_row['hill_radius'] = 6.371e6 + 0.4 * (r_obs - 6.371e6)
+    clipped = RunDummyAtm({}, config, dict(hf_row))
+
+    assert clipped['R_xuv'] == pytest.approx(hf_row['hill_radius'], rel=1e-12)
+    assert clipped['R_obs'] == pytest.approx(r_obs, rel=1e-12)  # untouched
+    expected_g = 9.8 * (6.371e6 / hf_row['hill_radius']) ** 2
+    assert clipped['g_xuv'] == pytest.approx(expected_g, rel=1e-10)
+    assert clipped['g_xuv'] > clipped['g_obs']  # deeper level, stronger gravity
+    assert clipped['g_xuv'] != pytest.approx(clipped['g_obs'], rel=1e-3)
+
+
 # =======================================================================================
 # SECTION: RunDummyAtm() fixed_flux bypass mode
 # =======================================================================================

--- a/tests/atmos_clim/test_atmos_clim.py
+++ b/tests/atmos_clim/test_atmos_clim.py
@@ -690,11 +690,19 @@ def test_rundummyatm_output_keys():
         'albedo',
         'p_xuv',
         'R_xuv',
+        'T_xuv',
+        'g_xuv',
         'p_obs',
         'P_surf_clim',
     ]
     for key in required_keys:
         assert key in output
+    # The dummy XUV level coincides with the observed one, so its temperature
+    # is the surface temperature and its gravity matches g_obs; hardcoded
+    # zeros would fail both pins.
+    assert output['T_xuv'] == pytest.approx(output['T_surf'], rel=1e-12)
+    assert output['g_xuv'] == pytest.approx(output['g_obs'], rel=1e-12)
+    assert output['g_xuv'] > 0.0
     # Positivity guard on the physical quantities: temperature, radii,
     # and pressures must all be strictly positive. A regression that
     # populated these keys with default zeros or NaN would still pass

--- a/tests/atmos_clim/test_common.py
+++ b/tests/atmos_clim/test_common.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 from proteus.atmos_clim.common import (
+    clip_radius_to_hill,
     find_latest_atmosphere_time,
     get_oarr_from_parr,
     get_radius_from_pressure,
@@ -616,3 +617,62 @@ def test_find_latest_atmosphere_time_empty_returns_none(tmp_path):
     assert find_latest_atmosphere_time(str(tmp_path)) is None
     # Also handles a missing data directory without raising.
     assert find_latest_atmosphere_time(str(tmp_path / 'nonexistent')) is None
+
+
+# ---------------------------------------------------------------------------
+# clip_radius_to_hill: the XUV level never sizes escape beyond the Hill radius
+# ---------------------------------------------------------------------------
+
+
+def _clip_config(enabled: bool = True, frac: float = 1.0):
+    """Escape-config namespace carrying only what the clip reads."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(escape=SimpleNamespace(hill_clamp=enabled, hill_clamp_frac=frac))
+
+
+@pytest.mark.physics_invariant
+def test_clip_radius_to_hill_bounds_the_radius():
+    """A radius beyond the Hill radius comes back at frac * R_Hill, and one
+    inside comes back untouched, so the escape cross-section is bounded.
+
+    The energy-limited rate goes as the radius cubed: the unclipped input at
+    6x the Hill radius would inflate the rate 216-fold, so the discriminating
+    check is that the clipped output removes that factor entirely.
+    """
+    hf_row = {'hill_radius': 1.0e8, 'R_int': 6.4e6}
+
+    clipped = clip_radius_to_hill(_clip_config(), hf_row, 6.0e8)
+    assert clipped == pytest.approx(1.0e8, rel=1e-12)
+    assert (6.0e8 / clipped) ** 3 == pytest.approx(216.0, rel=1e-9)
+
+    inside = clip_radius_to_hill(_clip_config(), hf_row, 7.0e7)
+    assert inside == pytest.approx(7.0e7, rel=1e-12)
+
+    # The fraction scales the limit, not the radius.
+    half = clip_radius_to_hill(_clip_config(frac=0.5), hf_row, 6.0e8)
+    assert half == pytest.approx(5.0e7, rel=1e-12)
+
+
+@pytest.mark.physics_invariant
+def test_clip_radius_to_hill_never_goes_below_the_solid_body():
+    """The limit floors at R_int: the solid body is bound by definition, so a
+    Hill radius inside the planet must not shrink the level below the surface.
+    """
+    hf_row = {'hill_radius': 3.0e6, 'R_int': 6.4e6}  # Hill inside the planet
+    clipped = clip_radius_to_hill(_clip_config(), hf_row, 1.0e7)
+    assert clipped == pytest.approx(6.4e6, rel=1e-12)
+    # Discrimination: the naive frac * R_Hill limit is a factor 2.1 smaller.
+    assert clipped != pytest.approx(3.0e6, rel=1e-1)
+
+
+def test_clip_radius_to_hill_skips_when_disabled_or_unset():
+    """Disabled config or a Hill radius that is zero (before the first orbit
+    update) or non-finite leaves the radius untouched rather than clipping
+    against a value that does not exist.
+    """
+    r = 6.0e8
+    assert clip_radius_to_hill(_clip_config(enabled=False), {'hill_radius': 1.0e8}, r) == r
+    assert clip_radius_to_hill(_clip_config(), {'hill_radius': 0.0}, r) == r
+    assert clip_radius_to_hill(_clip_config(), {'hill_radius': float('nan')}, r) == r
+    assert clip_radius_to_hill(_clip_config(), {}, r) == r

--- a/tests/atmos_clim/test_janus.py
+++ b/tests/atmos_clim/test_janus.py
@@ -437,6 +437,67 @@ def test_run_janus_gobs_inverse_square_of_robs(monkeypatch, tmp_path):
     # Discrimination guard: the stale grav_z value is the surface gravity
     assert output['g_obs'] != pytest.approx(g_surf, rel=1e-3)
 
+    # The XUV level follows the same conventions: temperature off the profile
+    # (patched interpolation returns the last entry) and gravity by the
+    # inverse-square law at r_xuv, which the patch also pins to the last entry
+    # of the radius array, so it coincides with the observed level here.
+    assert output['T_xuv'] == pytest.approx(500.0, rel=1e-12)
+    assert output['g_xuv'] == pytest.approx(g_obs_expected, rel=1e-10)
+    assert output['g_xuv'] != pytest.approx(g_surf, rel=1e-3)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_run_janus_failed_hydrostatic_falls_back_to_surface_values(monkeypatch, tmp_path):
+    """A failed hydrostatic integration leaves the heights unusable, so the
+    XUV-level outputs fall back to the surface values instead of dividing by a
+    height the solver never produced.
+
+    With `atm.z` zeroed by the failure, `r_arr = z + R_int` puts every level at
+    the surface, and the patched interpolation returns the last entry, so a
+    regression that skipped the fallback would compute g_xuv from r_xuv = R_int
+    and still pass a positivity check; the discriminating signal is that T_xuv
+    reads the surface temperature rather than the top of the stale profile.
+    """
+    g_surf = 9.81
+    R_int = 6.371e6
+
+    solved_atm = _build_run_atm(g_surf=g_surf, z_obs_height=8.0e4, stale_grav=g_surf)
+    solved_atm.height_error = True
+    solved_atm.z = np.zeros(3, dtype=float)
+
+    monkeypatch.setattr('janus.modules.MCPA', lambda *a, **kw: solved_atm)
+    monkeypatch.setattr(janus_mod, 'UpdateStateAtm', lambda *a, **kw: None)
+    monkeypatch.setattr(
+        janus_mod, 'get_oarr_from_parr', lambda p_arr, o_arr, val: (0, o_arr[-1])
+    )
+
+    config = _build_run_config()
+    hf_row = {
+        'Time': 100.0,
+        'R_int': R_int,
+        'gravity': g_surf,
+        'p_xuv': 1e-3,  # bar
+        'T_surf': 1400.0,
+    }
+
+    _, output = RunJANUS(
+        SimpleNamespace(),
+        {'output': str(tmp_path)},
+        config,
+        hf_row,
+        None,
+        write_in_tmp_dir=False,
+    )
+
+    # Surface fallbacks on both levels, not values read off the failed column.
+    assert output['R_obs'] == pytest.approx(R_int, rel=1e-12)
+    assert output['T_obs'] == pytest.approx(1400.0, rel=1e-12)
+    assert output['T_xuv'] == pytest.approx(1400.0, rel=1e-12)
+    assert output['g_xuv'] == pytest.approx(g_surf, rel=1e-12)
+    # Discrimination: the stale profile top is far from the surface temperature.
+    assert output['T_xuv'] != pytest.approx(500.0, rel=1e-2)
+
 
 @pytest.mark.unit
 @patch('proteus.atmos_clim.janus.os.remove')

--- a/tests/atmos_clim/test_janus.py
+++ b/tests/atmos_clim/test_janus.py
@@ -337,7 +337,7 @@ def test_update_state_atm_default_tropopause_uses_floor():
     assert fake_atm.trppT < 10.0
 
 
-def _build_run_config():
+def _build_run_config(*, hill_clamp=False):
     """Config namespace covering the fields ``RunJANUS`` reads."""
     return SimpleNamespace(
         atmos_clim=SimpleNamespace(
@@ -347,7 +347,9 @@ def _build_run_config():
             janus=SimpleNamespace(tropopause=None, F_atm_bc=0),
         ),
         planet=SimpleNamespace(prevent_warming=False),
-        escape=SimpleNamespace(xuv_defined_by_radius=False),
+        escape=SimpleNamespace(
+            xuv_defined_by_radius=False, hill_clamp=hill_clamp, hill_clamp_frac=1.0
+        ),
     )
 
 
@@ -561,3 +563,50 @@ def test_write_atmos_ncdf_uses_rounded_time_convention():
     assert '1000_atm.nc' not in str(atm.write_ncdf.call_args)
     # Discrimination on the directory: the file lands under data/, not output/.
     assert atm.write_ncdf.call_args.args[0].endswith('/data/1001_atm.nc')
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_run_janus_clips_the_xuv_radius_to_the_hill_radius(monkeypatch, tmp_path):
+    """With the clip enabled and a Hill radius inside the unclipped XUV level,
+    JANUS reports the level at the Hill radius with gravity re-derived there.
+
+    The patched interpolation pins the unclipped level to the top of the
+    column at 6.451e6 m; the Hill radius at 6.4e6 m is below it, so R_xuv
+    must come back at exactly the Hill radius and g_xuv at the inverse-square
+    value for that radius, not for the column top.
+    """
+    g_surf = 9.81
+    R_int = 6.371e6
+
+    solved_atm = _build_run_atm(g_surf=g_surf, z_obs_height=8.0e4, stale_grav=g_surf)
+    monkeypatch.setattr('janus.modules.MCPA', lambda *a, **kw: solved_atm)
+    monkeypatch.setattr(janus_mod, 'UpdateStateAtm', lambda *a, **kw: None)
+    monkeypatch.setattr(
+        janus_mod, 'get_oarr_from_parr', lambda p_arr, o_arr, val: (0, o_arr[-1])
+    )
+
+    config = _build_run_config(hill_clamp=True)
+    hf_row = {
+        'Time': 100.0,
+        'R_int': R_int,
+        'gravity': g_surf,
+        'p_xuv': 1e-3,  # bar
+        'T_surf': 1400.0,
+        'hill_radius': 6.4e6,
+    }
+
+    _, output = RunJANUS(
+        SimpleNamespace(),
+        {'output': str(tmp_path)},
+        config,
+        hf_row,
+        None,
+        write_in_tmp_dir=False,
+    )
+
+    assert output['R_xuv'] == pytest.approx(6.4e6, rel=1e-12)
+    expected_g = g_surf * (R_int / 6.4e6) ** 2
+    assert output['g_xuv'] == pytest.approx(expected_g, rel=1e-10)
+    # Discrimination: the unclipped column top gives a discriminably weaker g.
+    assert output['g_xuv'] != pytest.approx(g_surf * (R_int / 6.451e6) ** 2, rel=1e-3)

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -2,9 +2,12 @@
 
 Covers ``update_wtg_surf`` (weak-temperature-gradient surface parameter),
 ``update_bolometry`` (transit + eclipse depth closed-form relations),
-and ``ShallowMixedOceanLayer`` (thin-ocean thermal evolution via
-scipy.solve_ivp). The heavy ``run_atmosphere`` dispatch is exercised
-by integration tests in nightly tier.
+``ShallowMixedOceanLayer`` (thin-ocean thermal evolution via scipy.solve_ivp),
+``write_atmosphere_snapshot`` (per-module snapshot dispatch), and
+``carry_converged_levels`` (photospheric and XUV levels are not taken from a
+structure the solver rejected). The ``run_atmosphere`` paths reached here are
+those a mocked atmosphere module can drive; the full coupled dispatch is
+exercised by integration tests in the nightly tier.
 
 Testing standards:
   - docs/How-to/testing.md
@@ -17,12 +20,14 @@ import math
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
 import proteus.atmos_clim.wrapper as atmos_wrapper
+from proteus.atmos_clim.common import Atmos_t
 from proteus.utils.constants import const_R
 
-pytestmark = [pytest.mark.unit, pytest.mark.timeout(30), pytest.mark.physics_invariant]
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
 
 # ---------------------------------------------------------------------------
@@ -30,6 +35,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30), pytest.mark.physics_inv
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.physics_invariant
 def test_update_wtg_surf_closed_form_at_unit_inputs():
     """``update_wtg_surf`` computes wtg_surf = sqrt(R_mix * T_surf) /
     (omega * R_int) where omega = 2*pi / axial_period. With chosen
@@ -62,6 +68,7 @@ def test_update_wtg_surf_closed_form_at_unit_inputs():
     assert 1e-3 < hf_row['wtg_surf'] < 10.0
 
 
+@pytest.mark.physics_invariant
 def test_update_wtg_surf_scales_inversely_with_planet_rotation_rate():
     """A slower-rotating planet (larger axial_period -> smaller omega)
     has a LARGER wtg_surf, because the WTG approximation is more valid
@@ -98,6 +105,7 @@ def test_update_wtg_surf_scales_inversely_with_planet_rotation_rate():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.physics_invariant
 def test_update_bolometry_transit_depth_is_ratio_of_radii_squared():
     """Transit depth = (R_obs / R_star)^2. With Earth-like geometry
     (R_obs ~ 6e6 m, R_star ~ 7e8 m), the depth is ~(6e6/7e8)^2 ~ 7e-5
@@ -126,6 +134,7 @@ def test_update_bolometry_transit_depth_is_ratio_of_radii_squared():
     assert 1e-5 < hf_row['transit_depth'] < 1e-3
 
 
+@pytest.mark.physics_invariant
 def test_update_bolometry_eclipse_depth_is_flux_ratio_times_radius_ratio_squared():
     """Eclipse depth = ((F_olr + F_sct) / F_ins) * (R_obs / separation)^2.
     The F_olr + F_sct is the planet's thermal+scattered flux at TOA;
@@ -156,6 +165,7 @@ def test_update_bolometry_eclipse_depth_is_flux_ratio_times_radius_ratio_squared
     assert 1e-12 < hf_row['eclipse_depth'] < 1e-7
 
 
+@pytest.mark.physics_invariant
 def test_update_bolometry_eclipse_depth_scales_with_flux_excess():
     """At fixed geometry, doubling (F_olr + F_sct) doubles the eclipse
     depth (linear in planet's emission flux). Discrimination: a
@@ -187,6 +197,7 @@ def test_update_bolometry_eclipse_depth_scales_with_flux_excess():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.physics_invariant
 def test_shallow_mixed_ocean_layer_cools_under_positive_net_flux():
     """A positive ``F_net`` (upward) draws heat out of the ocean layer.
 
@@ -213,6 +224,7 @@ def test_shallow_mixed_ocean_layer_cools_under_positive_net_flux():
     assert 0.5 < drop < 5.0
 
 
+@pytest.mark.physics_invariant
 def test_shallow_mixed_ocean_layer_warms_under_negative_net_flux():
     """Negative ``F_net`` (downward heating) raises the layer's
     temperature. The sign behaviour pins that F_net is treated as an
@@ -233,6 +245,7 @@ def test_shallow_mixed_ocean_layer_warms_under_negative_net_flux():
     assert 0.1 < rise < 2.0
 
 
+@pytest.mark.physics_invariant
 def test_shallow_mixed_ocean_layer_zero_flux_keeps_temperature_constant():
     """F_net = 0 is the conservative-isolated-layer limit: dT/dt = 0,
     so T_cur must equal T_pre to machine precision. This pins the
@@ -437,3 +450,511 @@ def test_run_atmosphere_keeps_the_column_janus_solved():
     assert run_janus.call_args.args[0] is seed
     assert atmos_o._atm is seed
     assert atmos_o._atm_janus_last is solved
+
+
+# ---------------------------------------------------------------------------
+# carry_converged_levels: levels of a rejected structure are not used
+# ---------------------------------------------------------------------------
+
+
+def _levels(r_obs: float, r_xuv: float, h2o_vmr: float = 0.4) -> dict:
+    """Build a helpfile row carrying one consistent set of levels.
+
+    Pressures, temperature and gravity are scaled off the radii, so a
+    substitution that touched only the radii would leave a level whose pressure
+    no longer matches it, and the test can see that. The XUV composition is
+    carried too, since BOREAS reads it alongside the radius.
+    """
+    return {
+        'R_obs': r_obs,
+        'p_obs': 1.0e-3 * (2.0e7 / r_obs) ** 2,  # bar
+        'T_obs': 900.0 * (2.0e7 / r_obs),  # K
+        'g_obs': 9.8 * (2.0e7 / r_obs) ** 2,  # m s-2
+        'R_xuv': r_xuv,
+        'p_xuv': 1.0e-6 * (2.4e7 / r_xuv) ** 2,  # bar
+        'H2O_vmr_xuv': h2o_vmr,
+    }
+
+
+@pytest.mark.physics_invariant
+def test_carry_levels_substitutes_last_converged_after_failed_solve():
+    """A converged solve records its levels; the next solve that fails has its
+    photospheric and XUV levels replaced by the recorded ones.
+
+    The energy-limited escape rate goes as R_xuv**3, so the discriminating
+    quantity is the cube of the radius ratio, not the ratio itself. The
+    rejected structure is inflated 12-fold in radius, which is 1728-fold in
+    escape rate; a substitution that held a squared quantity, or held nothing,
+    lands at 144 or 1728 and is far outside the tolerance on 1.
+    """
+    atmos_o = Atmos_t()
+    assert atmos_o.levels_converged == {}
+
+    good = _levels(r_obs=2.0e7, r_xuv=2.4e7, h2o_vmr=0.4)
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, dict(good))
+    assert atmos_o.levels_converged['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+
+    # A rejected structure that has ballooned well past any bound atmosphere.
+    bad = _levels(r_obs=2.4e8, r_xuv=2.88e8, h2o_vmr=0.9)
+    rejected_r_xuv = bad['R_xuv']
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, bad)
+
+    # Every level came back to the converged structure, pressures and the
+    # composition BOREAS reads included.
+    for key, val in good.items():
+        assert bad[key] == pytest.approx(val, rel=1e-12)
+
+    # Escape rate ratio the substitution removes, and the guard that the
+    # rejected value was discriminably different in the first place.
+    assert (rejected_r_xuv / good['R_xuv']) ** 3 == pytest.approx(1728.0, rel=1e-9)
+    assert (bad['R_xuv'] / good['R_xuv']) ** 3 == pytest.approx(1.0, rel=1e-9)
+    assert rejected_r_xuv > 10.0 * good['R_xuv']
+
+
+def test_carry_levels_keeps_fluxes_and_surface_state_moving():
+    """Only level properties are carried. Fluxes and surface temperature must
+    pass through untouched, because the coupling advances on them and the
+    deadlock detector fires on an interior state that has stopped moving.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+
+    failed = _levels(2.4e8, 2.88e8)
+    failed.update({'F_atm': 4.21e3, 'T_surf': 2870.0, 'albedo': 0.31})
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, failed)
+
+    assert failed['F_atm'] == pytest.approx(4.21e3, rel=1e-12)
+    assert failed['T_surf'] == pytest.approx(2870.0, rel=1e-12)
+    assert failed['albedo'] == pytest.approx(0.31, rel=1e-12)
+    # ... while the levels did move back.
+    assert failed['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+
+
+def test_carry_levels_falls_back_on_the_last_committed_row_after_a_resume(caplog):
+    """A resumed run starts with an empty record, since the record is not
+    written to the output files. Until it converges a solve of its own it uses
+    the last committed row, which is the state escape would have used anyway.
+
+    Without this a resumed run reopens the defect for its first iterations,
+    which is when escape is already active: resume sets the iteration counter
+    past the point where escape switches on.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = False
+    committed = _levels(2.0e7, 2.4e7)
+    rejected = _levels(2.4e8, 2.88e8)
+
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        atmos_wrapper.carry_converged_levels(atmos_o, rejected, previous_row=committed)
+
+    assert rejected['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    assert rejected['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+    # The warning names the source it actually used, since a committed row is
+    # not necessarily one that converged.
+    assert 'last committed row' in caplog.text
+
+    # A second failure before anything converges must not start calling the
+    # same never-converged levels a converged solve.
+    caplog.clear()
+    again = _levels(2.4e8, 2.88e8)
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        atmos_wrapper.carry_converged_levels(atmos_o, again, previous_row=committed)
+    assert again['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+    assert 'last committed row' in caplog.text
+    assert 'last converged solve' not in caplog.text
+    # A converged solve of this run then supersedes the committed row.
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(3.1e7, 3.7e7))
+    later = _levels(2.4e8, 2.88e8)
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, later, previous_row=committed)
+    assert later['R_obs'] == pytest.approx(3.1e7, rel=1e-12)
+
+
+def test_carry_levels_without_any_earlier_levels_keeps_the_rejected_ones(caplog):
+    """With no converged solve and no committed row there is nothing to fall
+    back on. The rejected levels are used unchanged and the run says so, rather
+    than silently substituting a level nobody computed.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = False
+    rejected = _levels(2.4e8, 2.88e8)
+
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        atmos_wrapper.carry_converged_levels(atmos_o, rejected, previous_row=None)
+
+    assert rejected['R_xuv'] == pytest.approx(2.88e8, rel=1e-12)
+    assert rejected['R_obs'] == pytest.approx(2.4e8, rel=1e-12)
+    assert atmos_o.levels_converged == {}
+    assert 'no earlier levels' in caplog.text
+
+
+def test_carry_levels_holds_across_consecutive_failures(caplog):
+    """A run of failed solves keeps falling back on the same converged levels.
+    A rejected solve must never write to the record, or the second failure
+    would hold the first failure's inflated radius and the fix would decay
+    over a streak of failures.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+
+    atmos_o.converged = False
+    first = _levels(2.4e8, 2.88e8)
+    second = _levels(9.6e8, 1.152e9)
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        atmos_wrapper.carry_converged_levels(atmos_o, first)
+        atmos_wrapper.carry_converged_levels(atmos_o, second)
+
+    assert 'last converged solve' in caplog.text
+    assert 'last committed row' not in caplog.text
+
+    assert first['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    assert second['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    assert atmos_o.levels_converged['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    # Both failures were reported, not just the first.
+    assert caplog.text.count('did not converge') == 2
+
+
+def test_carry_levels_ignores_a_non_finite_level():
+    """A solve that returns NaN for a level has not measured it. Recording that
+    value would leave a record that cannot be fallen back on, so non-finite
+    values are skipped and the previous finite value stands.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+
+    poisoned = _levels(2.0e7, 2.4e7)
+    poisoned['R_xuv'] = float('nan')
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, poisoned)
+    assert atmos_o.levels_converged['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+
+    failed = _levels(2.4e8, 2.88e8)
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, failed)
+    assert failed['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+
+
+def test_carry_levels_record_survives_a_module_that_omits_a_level():
+    """The record is merged, not replaced, so a converged solve that omits one
+    level leaves the earlier value for that level in place instead of dropping
+    it. A dropped key would silently return the rejected value to escape.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+
+    partial = {'R_obs': 3.1e7, 'p_obs': 4.2e-4}
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, partial)
+
+    failed = _levels(2.4e8, 2.88e8)
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, failed)
+
+    assert failed['R_obs'] == pytest.approx(3.1e7, rel=1e-12)  # the newer value
+    assert failed['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)  # the retained one
+
+
+def test_carry_levels_leaves_a_row_that_lacks_the_key_alone():
+    """Keys absent from the row are neither recorded nor written back, so a
+    module that reports fewer levels does not gain invented ones.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, {'R_obs': 2.0e7, 'R_xuv': 2.4e7})
+    assert set(atmos_o.levels_converged) == {'R_obs', 'R_xuv'}
+
+    failed = {'R_obs': 2.4e8, 'p_obs': 5.0e-5}
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, failed)
+
+    assert failed['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+    assert failed['p_obs'] == pytest.approx(5.0e-5, rel=1e-12)  # nothing recorded for it
+    assert 'R_xuv' not in failed  # not invented out of the record
+
+
+@pytest.mark.physics_invariant
+def test_run_atmosphere_carries_levels_into_the_row_escape_reads():
+    """The wiring test: `run_atmosphere` puts the carried levels into `hf_row`,
+    which is where escape reads R_xuv on the following iteration, and the
+    observables derived from R_obs follow the carried radius.
+
+    Escape runs before the atmosphere within an iteration, so the radius it
+    uses is the one the previous atmosphere call left in the row. A fix that
+    only corrected the module output, without it reaching the row, would leave
+    escape reading the rejected radius exactly as before.
+    """
+    atmos_o = Atmos_t()
+    atmos_o._atm = object()
+
+    config = SimpleNamespace(
+        atmos_clim=SimpleNamespace(
+            module='agni',
+            albedo_pl=0.0,
+            rayleigh=False,
+            cloud_enabled=False,
+            surf_state='fixed',
+        ),
+        interior_energetics=SimpleNamespace(module='aragog'),
+    )
+    hf_row = {
+        'T_magma': 1800.0,
+        'M_planet': 6.0e24,
+        'F_int': 120.0,
+        'F_atm': 100.0,
+        'axial_period': 86400.0,
+        'atm_kg_per_mol': 0.029,
+        'T_surf': 0.0,
+        'R_int': 6.371e6,
+        'R_star': 6.96e8,
+        'F_olr': 200.0,
+        'F_sct': 100.0,
+        'F_ins': 1361.0,
+        'separation': 1.5e11,
+        **{key: 0.0 for key in _levels(1.0, 1.0)},
+    }
+
+    def _call(levels, converged):
+        out = dict(levels)
+        out.update({'albedo': 0.2, 'F_atm': 100.0, 'agni_converged': converged})
+        vmr = out.pop('H2O_vmr_xuv')
+
+        def _run_agni(atm, *args, **kwargs):
+            # AGNI writes the XUV composition straight into the row, so the
+            # mock has to as well or the test would not exercise that path.
+            hf_row['H2O_vmr_xuv'] = vmr
+            return atm, out
+
+        with (
+            patch(
+                'proteus.atmos_clim.agni.update_agni_atmos', side_effect=lambda a, *_, **__: a
+            ),
+            patch('proteus.atmos_clim.agni.run_agni', side_effect=_run_agni),
+        ):
+            atmos_wrapper.run_atmosphere(
+                atmos_o,
+                config,
+                {'output': '/tmp/x'},
+                {'total': 5},
+                [1.0],
+                [1.0],
+                False,
+                None,
+                hf_row,
+            )
+
+    _call(_levels(r_obs=2.0e7, r_xuv=2.4e7, h2o_vmr=0.4), converged=True)
+    assert hf_row['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+
+    _call(_levels(r_obs=2.4e8, r_xuv=2.88e8, h2o_vmr=0.9), converged=False)
+
+    # The row escape will read carries the converged radii and the converged
+    # composition, not the rejected ones.
+    assert hf_row['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    assert hf_row['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+    assert hf_row['H2O_vmr_xuv'] == pytest.approx(0.4, rel=1e-12)
+    # Quantities derived from R_obs follow the carried radius, so the row stays
+    # internally consistent rather than mixing two structures.
+    assert hf_row['transit_depth'] == pytest.approx((2.0e7 / 6.96e8) ** 2, rel=1e-9)
+    assert hf_row['rho_obs'] == pytest.approx(
+        3 * 6.0e24 / (4 * math.pi * (2.0e7) ** 3), rel=1e-9
+    )
+    # The flag the deadlock detector reads still reports the failure.
+    assert atmos_o.converged is False
+    # And the transient flag never reaches the row.
+    assert 'agni_converged' not in hf_row
+
+
+@pytest.mark.physics_invariant
+def test_run_atmosphere_takes_the_resume_fallback_from_the_last_committed_row():
+    """On the first iteration after a resume the record is empty, so
+    `run_atmosphere` has to reach into the persisted history for it, and it has
+    to take the LAST committed row.
+
+    Escape is already active at that point, because resume sets the iteration
+    counter past the point where escape switches on. Reaching one row too far
+    back would hand escape a radius from an earlier state of the planet, which
+    for an evolving atmosphere is a different radius, so the two rows here
+    differ by a factor of four.
+    """
+    atmos_o = Atmos_t()
+    atmos_o._atm = object()
+
+    config = SimpleNamespace(
+        atmos_clim=SimpleNamespace(
+            module='agni',
+            albedo_pl=0.0,
+            rayleigh=False,
+            cloud_enabled=False,
+            surf_state='fixed',
+        ),
+        interior_energetics=SimpleNamespace(module='aragog'),
+    )
+    hf_row = {
+        'T_magma': 1800.0,
+        'M_planet': 6.0e24,
+        'F_int': 120.0,
+        'F_atm': 100.0,
+        'axial_period': 86400.0,
+        'atm_kg_per_mol': 0.029,
+        'T_surf': 0.0,
+        'R_int': 6.371e6,
+        'R_star': 6.96e8,
+        'F_olr': 200.0,
+        'F_sct': 100.0,
+        'F_ins': 1361.0,
+        'separation': 1.5e11,
+        **{key: 0.0 for key in _levels(1.0, 1.0)},
+    }
+
+    # Two committed rows: an older one and the one resume must actually use.
+    hf_all = pd.DataFrame([_levels(5.0e6, 6.0e6, 0.1), _levels(2.0e7, 2.4e7, 0.4)])
+
+    rejected = _levels(2.4e8, 2.88e8, 0.9)
+    out = dict(rejected)
+    out.update({'albedo': 0.2, 'F_atm': 100.0, 'agni_converged': False})
+    vmr = out.pop('H2O_vmr_xuv')
+
+    def _run_agni(atm, *args, **kwargs):
+        hf_row['H2O_vmr_xuv'] = vmr
+        return atm, out
+
+    with (
+        patch('proteus.atmos_clim.agni.update_agni_atmos', side_effect=lambda a, *_, **__: a),
+        patch('proteus.atmos_clim.agni.run_agni', side_effect=_run_agni),
+    ):
+        atmos_wrapper.run_atmosphere(
+            atmos_o,
+            config,
+            {'output': '/tmp/x'},
+            {'total': 5},
+            [1.0],
+            [1.0],
+            False,
+            hf_all,
+            hf_row,
+        )
+
+    assert hf_row['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    assert hf_row['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+    assert hf_row['H2O_vmr_xuv'] == pytest.approx(0.4, rel=1e-12)
+    # Discrimination: the older row is a factor of four away, far outside the
+    # tolerance, so reading the wrong row cannot pass as rounding.
+    assert hf_row['R_obs'] != pytest.approx(5.0e6, rel=1e-1)
+    # And the rejected structure did not survive anywhere in the row.
+    assert hf_row['R_xuv'] < 0.1 * rejected['R_xuv']
+
+
+def test_carry_levels_escalates_on_a_long_streak(caplog):
+    """A solver that fails once is a stumble; one that fails for many
+    iterations leaves escape running on a planet the run has not resolved,
+    while the interior keeps evolving underneath it.
+
+    The deadlock detector cannot catch that case, since it only fires when the
+    interior is frozen as well, so the streak is reported here instead. The
+    count is carried on the struct, so it survives across iterations and resets
+    on the next solve that converges.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+
+    atmos_o.converged = False
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        for _ in range(atmos_wrapper.CARRIED_LEVELS_ALERT - 1):
+            atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.4e8, 2.88e8))
+
+    assert atmos_o.levels_carried == atmos_wrapper.CARRIED_LEVELS_ALERT - 1
+    errors = [r for r in caplog.records if r.levelname == 'ERROR']
+    assert not errors  # one short of the threshold, so nothing has escalated
+
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.4e8, 2.88e8))
+    errors = [r for r in caplog.records if r.levelname == 'ERROR']
+    assert len(errors) == 1
+    assert str(atmos_wrapper.CARRIED_LEVELS_ALERT) in errors[0].getMessage()
+
+    # A solve that converges clears the streak, so the next failure starts over.
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+    assert atmos_o.levels_carried == 0
+
+
+def test_carry_levels_does_not_trust_rows_this_run_rejected(caplog):
+    """Only the first solve of a run may fall back on the committed rows.
+
+    A fresh run whose first solve fails commits the rejected levels, since
+    there is nothing better to write. Treating that row as a fallback on the
+    next failure would launder a rejected structure into a trusted one and keep
+    re-propagating it, so a run that has never converged says it has nothing to
+    fall back on instead.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = False
+
+    # First solve of a fresh run: no history at all, so the rejected levels stand.
+    first = _levels(2.4e8, 2.88e8)
+    atmos_wrapper.carry_converged_levels(atmos_o, first, previous_row=None)
+    assert first['R_obs'] == pytest.approx(2.4e8, rel=1e-12)
+
+    # That row is now the committed one. The second failure must not adopt it.
+    second = _levels(4.8e8, 5.76e8)
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        atmos_wrapper.carry_converged_levels(atmos_o, second, previous_row=first)
+
+    assert second['R_obs'] == pytest.approx(4.8e8, rel=1e-12)
+    assert atmos_o.levels_converged == {}
+    assert 'no earlier levels' in caplog.text
+
+
+def test_carry_levels_escalates_when_there_is_nothing_to_fall_back_on(caplog):
+    """A run that has never converged and has no committed history is the worst
+    case, not an exempt one: escape runs on the rejected structure itself. The
+    streak is counted and escalated there too, so that run is not the one case
+    that reports a bare warning forever.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = False
+
+    with caplog.at_level('WARNING', logger='fwl.proteus.atmos_clim.wrapper'):
+        for _ in range(atmos_wrapper.CARRIED_LEVELS_ALERT):
+            atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.4e8, 2.88e8))
+
+    assert atmos_o.levels_carried == atmos_wrapper.CARRIED_LEVELS_ALERT
+    assert atmos_o.levels_converged == {}  # still nothing recorded
+    errors = [r for r in caplog.records if r.levelname == 'ERROR']
+    assert len(errors) == 1
+    assert 'no earlier levels' in caplog.text
+
+
+def test_carry_levels_counts_converged_solves_towards_the_first_solve_rule():
+    """The first-solve rule counts every solve, not only the failed ones. A run
+    that converges once and then fails is past its first solve, so it must hold
+    its own converged levels and never reach back to the committed rows.
+
+    Counting only failures would let a committed row overwrite the record on
+    the first failure, which is how a level this run never converged gets
+    laundered into the record it trusts.
+    """
+    atmos_o = Atmos_t()
+    atmos_o.converged = True
+    atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
+    assert atmos_o.solves_seen == 1
+
+    committed = _levels(5.0e6, 6.0e6)
+    failed = _levels(2.4e8, 2.88e8)
+    atmos_o.converged = False
+    atmos_wrapper.carry_converged_levels(atmos_o, failed, previous_row=committed)
+
+    # The converged levels of this run, not the committed row.
+    assert failed['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
+    assert failed['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    assert failed['R_obs'] != pytest.approx(5.0e6, rel=1e-1)
+    assert atmos_o.levels_source == 'last converged solve'

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -969,3 +969,81 @@ def test_carry_levels_counts_converged_solves_towards_the_first_solve_rule():
     assert failed['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
     assert failed['R_obs'] != pytest.approx(5.0e6, rel=1e-1)
     assert atmos_o.levels_source is LevelsSource.CONVERGED_SOLVE
+
+
+@pytest.mark.physics_invariant
+def test_run_atmosphere_clips_a_carried_radius_from_an_unclipped_row():
+    """A committed row from before the clip existed can carry an XUV radius of
+    several Hill radii; when the resume fallback substitutes it, the radius is
+    bounded before escape can read it.
+
+    The committed radius here is five Hill radii, the exact pathology of the
+    issue; unbounded it would inflate the energy-limited rate 125-fold, so the
+    discriminating check is that the row ends at the Hill radius itself.
+    """
+    atmos_o = Atmos_t()
+    atmos_o._atm = object()
+
+    config = SimpleNamespace(
+        atmos_clim=SimpleNamespace(
+            module='agni',
+            albedo_pl=0.0,
+            rayleigh=False,
+            cloud_enabled=False,
+            surf_state='fixed',
+        ),
+        interior_energetics=SimpleNamespace(module='aragog'),
+        escape=SimpleNamespace(hill_clamp=True, hill_clamp_frac=1.0),
+    )
+    hf_row = {
+        'T_magma': 1800.0,
+        'M_planet': 6.0e24,
+        'F_int': 120.0,
+        'F_atm': 100.0,
+        'axial_period': 86400.0,
+        'atm_kg_per_mol': 0.029,
+        'T_surf': 0.0,
+        'R_int': 6.371e6,
+        'R_star': 6.96e8,
+        'F_olr': 200.0,
+        'F_sct': 100.0,
+        'F_ins': 1361.0,
+        'separation': 1.5e11,
+        'hill_radius': 1.0e8,
+        **{key: 0.0 for key in _levels(1.0, 1.0)},
+    }
+
+    # One committed row whose radii predate the clip: five Hill radii.
+    hf_all = pd.DataFrame([_levels(4.0e8, 5.0e8, 0.4)])
+
+    rejected = _levels(2.4e9, 2.88e9, 0.9)
+    out = dict(rejected)
+    out.update({'albedo': 0.2, 'F_atm': 100.0, 'agni_converged': False})
+    vmr = out.pop('H2O_vmr_xuv')
+
+    def _run_agni(atm, *args, **kwargs):
+        hf_row['H2O_vmr_xuv'] = vmr
+        return atm, out
+
+    with (
+        patch('proteus.atmos_clim.agni.update_agni_atmos', side_effect=lambda a, *_, **__: a),
+        patch('proteus.atmos_clim.agni.run_agni', side_effect=_run_agni),
+    ):
+        atmos_wrapper.run_atmosphere(
+            atmos_o,
+            config,
+            {'output': '/tmp/x'},
+            {'total': 5},
+            [1.0],
+            [1.0],
+            False,
+            hf_all,
+            hf_row,
+        )
+
+    # The carried radius is bounded at the Hill radius, not at the committed
+    # row's five Hill radii and not at the rejected structure's value.
+    assert hf_row['R_xuv'] == pytest.approx(1.0e8, rel=1e-12)
+    assert hf_row['R_xuv'] != pytest.approx(5.0e8, rel=1e-1)
+    # The rest of the level still comes from the committed row.
+    assert hf_row['H2O_vmr_xuv'] == pytest.approx(0.4, rel=1e-12)

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -24,7 +24,7 @@ import pandas as pd
 import pytest
 
 import proteus.atmos_clim.wrapper as atmos_wrapper
-from proteus.atmos_clim.common import Atmos_t
+from proteus.atmos_clim.common import Atmos_t, LevelsSource
 from proteus.utils.constants import const_R
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
@@ -472,6 +472,8 @@ def _levels(r_obs: float, r_xuv: float, h2o_vmr: float = 0.4) -> dict:
         'g_obs': 9.8 * (2.0e7 / r_obs) ** 2,  # m s-2
         'R_xuv': r_xuv,
         'p_xuv': 1.0e-6 * (2.4e7 / r_xuv) ** 2,  # bar
+        'T_xuv': 400.0 * (2.4e7 / r_xuv),  # K
+        'g_xuv': 6.8 * (2.4e7 / r_xuv) ** 2,  # m s-2
         'H2O_vmr_xuv': h2o_vmr,
     }
 
@@ -752,6 +754,9 @@ def test_run_atmosphere_carries_levels_into_the_row_escape_reads():
 
     _call(_levels(r_obs=2.0e7, r_xuv=2.4e7, h2o_vmr=0.4), converged=True)
     assert hf_row['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
+    # A converged row is marked as such, with no stale streak.
+    assert hf_row['atm_converged'] == pytest.approx(1.0, rel=1e-12)
+    assert hf_row['atm_levels_stale'] == pytest.approx(0.0, abs=1e-12)
 
     _call(_levels(r_obs=2.4e8, r_xuv=2.88e8, h2o_vmr=0.9), converged=False)
 
@@ -770,6 +775,12 @@ def test_run_atmosphere_carries_levels_into_the_row_escape_reads():
     assert atmos_o.converged is False
     # And the transient flag never reaches the row.
     assert 'agni_converged' not in hf_row
+    # The persisted outcome columns record the rejection and the streak, so a
+    # carried row is identifiable from the output alone.
+    assert hf_row['atm_converged'] == pytest.approx(-1.0, rel=1e-12)
+    assert hf_row['atm_levels_stale'] == pytest.approx(1.0, rel=1e-12)
+    # The carried temperature at the XUV level came back with the radius.
+    assert hf_row['T_xuv'] == pytest.approx(400.0, rel=1e-12)
 
 
 @pytest.mark.physics_invariant
@@ -871,7 +882,7 @@ def test_carry_levels_escalates_on_a_long_streak(caplog):
         for _ in range(atmos_wrapper.CARRIED_LEVELS_ALERT - 1):
             atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.4e8, 2.88e8))
 
-    assert atmos_o.levels_carried == atmos_wrapper.CARRIED_LEVELS_ALERT - 1
+    assert atmos_o.levels_stale_iters == atmos_wrapper.CARRIED_LEVELS_ALERT - 1
     errors = [r for r in caplog.records if r.levelname == 'ERROR']
     assert not errors  # one short of the threshold, so nothing has escalated
 
@@ -884,7 +895,7 @@ def test_carry_levels_escalates_on_a_long_streak(caplog):
     # A solve that converges clears the streak, so the next failure starts over.
     atmos_o.converged = True
     atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.0e7, 2.4e7))
-    assert atmos_o.levels_carried == 0
+    assert atmos_o.levels_stale_iters == 0
 
 
 def test_carry_levels_does_not_trust_rows_this_run_rejected(caplog):
@@ -927,7 +938,7 @@ def test_carry_levels_escalates_when_there_is_nothing_to_fall_back_on(caplog):
         for _ in range(atmos_wrapper.CARRIED_LEVELS_ALERT):
             atmos_wrapper.carry_converged_levels(atmos_o, _levels(2.4e8, 2.88e8))
 
-    assert atmos_o.levels_carried == atmos_wrapper.CARRIED_LEVELS_ALERT
+    assert atmos_o.levels_stale_iters == atmos_wrapper.CARRIED_LEVELS_ALERT
     assert atmos_o.levels_converged == {}  # still nothing recorded
     errors = [r for r in caplog.records if r.levelname == 'ERROR']
     assert len(errors) == 1
@@ -957,4 +968,4 @@ def test_carry_levels_counts_converged_solves_towards_the_first_solve_rule():
     assert failed['R_obs'] == pytest.approx(2.0e7, rel=1e-12)
     assert failed['R_xuv'] == pytest.approx(2.4e7, rel=1e-12)
     assert failed['R_obs'] != pytest.approx(5.0e6, rel=1e-1)
-    assert atmos_o.levels_source == 'last converged solve'
+    assert atmos_o.levels_source is LevelsSource.CONVERGED_SOLVE

--- a/tests/config/test_escape_validators.py
+++ b/tests/config/test_escape_validators.py
@@ -1,0 +1,63 @@
+"""Unit tests for the escape configuration schema in ``proteus.config._escape``.
+
+Covers the Hill-clip fields: the enabled-by-default state, the (0, 1] bounds
+on ``hill_clamp_frac``, and the interaction with module selection.
+
+Testing standards:
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proteus.config._escape import Escape
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+
+def test_hill_clamp_defaults_to_enabled_with_full_hill_radius():
+    """A fresh escape config clips at the full Hill radius by default.
+
+    The default matters physically: gas beyond the Hill radius is not bound
+    to the planet, so an unclipped default would size escape from material
+    the planet does not hold. The v2-to-v3 migration pins the field off for
+    older configs, so this default only reaches configs written against the
+    current schema.
+    """
+    cfg = Escape(module='zephyrus')
+    assert cfg.hill_clamp is True
+    assert cfg.hill_clamp_frac == pytest.approx(1.0, rel=1e-12)
+    # The default holds regardless of the escape module chosen.
+    assert Escape(module='dummy').hill_clamp is True
+    assert Escape(module=None).hill_clamp is True
+
+
+def test_hill_clamp_frac_rejects_values_outside_unit_interval():
+    """The fraction must sit in (0, 1]: zero would clip every level to the
+    solid body, and above one would place the limit outside the bound region,
+    defeating the clip while appearing enabled.
+    """
+    for bad in (0.0, -0.5, 1.0001, 2.0):
+        with pytest.raises(ValueError):
+            Escape(module='zephyrus', hill_clamp_frac=bad)
+    # The boundaries of validity are accepted: just inside zero, and exactly one.
+    assert Escape(module='zephyrus', hill_clamp_frac=1e-6).hill_clamp_frac == pytest.approx(
+        1e-6, rel=1e-12
+    )
+    assert Escape(module='zephyrus', hill_clamp_frac=1.0).hill_clamp_frac == pytest.approx(
+        1.0, rel=1e-12
+    )
+
+
+def test_hill_clamp_can_be_disabled_explicitly():
+    """An explicit ``hill_clamp = false`` survives construction, since A/B
+    comparisons against unclipped behaviour rely on it; the fraction stays
+    validated even while inert.
+    """
+    cfg = Escape(module='zephyrus', hill_clamp=False, hill_clamp_frac=0.5)
+    assert cfg.hill_clamp is False
+    assert cfg.hill_clamp_frac == pytest.approx(0.5, rel=1e-12)
+    with pytest.raises(ValueError):
+        Escape(module='zephyrus', hill_clamp=False, hill_clamp_frac=1.5)

--- a/tests/escape/test_escape_boreas.py
+++ b/tests/escape/test_escape_boreas.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from proteus.config import read_config_object
-from proteus.escape.boreas import BOREAS_GASES, _set_boreas_params
+from proteus.escape.boreas import BOREAS_GASES, _set_boreas_params, bound_escape_level
 from proteus.utils.constants import AU, M_earth, R_earth, element_list
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
@@ -15,8 +15,10 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='session')
 def _skip_if_no_boreas():
+    # Explicit rather than autouse: bound_escape_level below is pure Python
+    # and its tests run without the optional package installed.
     pytest.importorskip('boreas')
 
 
@@ -77,6 +79,7 @@ def boreas_config() -> object:
     return cfg
 
 
+@pytest.mark.usefixtures('_skip_if_no_boreas')
 def test_boreas_params(boreas_config):
     """``_set_boreas_params`` populates the BOREAS parameter object from
     ``hf_row``, with FXUV converted from W/m^2 to mW/m^2 (factor 1e3) and
@@ -99,6 +102,7 @@ def test_boreas_params(boreas_config):
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
+@pytest.mark.usefixtures('_skip_if_no_boreas')
 def test_run_boreas_unit_conversions_and_fractionation(boreas_config, monkeypatch):
     """RunBOREAS converts BOREAS CGS outputs to SI and stores them in
     hf_row. The conversion factors are the physics contract:
@@ -170,6 +174,7 @@ def test_run_boreas_unit_conversions_and_fractionation(boreas_config, monkeypatc
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures('_skip_if_no_boreas')
 def test_run_boreas_raises_on_solver_failure(boreas_config, monkeypatch):
     """When the BOREAS mass-loss solver raises internally, RunBOREAS
     must catch the exception, update the statusfile to code 28, and
@@ -201,6 +206,7 @@ def test_run_boreas_raises_on_solver_failure(boreas_config, monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
+@pytest.mark.usefixtures('_skip_if_no_boreas')
 def test_run_boreas_zero_xuv_flux(boreas_config, monkeypatch):
     """F_xuv = 0.0 represents the pre-XUV era (young star before
     chromospheric activity ramps up, or a planet far enough from
@@ -259,3 +265,38 @@ def test_run_boreas_zero_xuv_flux(boreas_config, monkeypatch):
     # The FXUV parameter passed to BOREAS is in mW/m^2 (factor 1e3);
     # verify the conversion did not produce a non-zero artifact
     assert hf_row['F_xuv'] == pytest.approx(0.0, abs=1e-12)
+
+
+@pytest.mark.physics_invariant
+def test_bound_escape_level_scales_the_rate_with_the_clipped_area():
+    """A solved XUV radius beyond the Hill radius is clipped, and the bulk rate
+    already stored in the row scales with the area ratio, so the rate and the
+    recorded radius describe the same cross-section.
+
+    The solved radius is 5 Hill radii, so the area ratio is 1/25: a bound that
+    clipped the radius but left the rate would be off by that factor, far
+    outside tolerance, and the reverse error (cubing instead of squaring)
+    lands at 1/125 and also fails.
+    """
+    from types import SimpleNamespace
+
+    config = SimpleNamespace(escape=SimpleNamespace(hill_clamp=True, hill_clamp_frac=1.0))
+    hf_row = {'hill_radius': 1.0e8, 'R_int': 6.4e6, 'esc_rate_total': 2.5e10}
+
+    r = bound_escape_level(config, hf_row, 5.0e8)
+
+    assert r == pytest.approx(1.0e8, rel=1e-12)
+    assert hf_row['esc_rate_total'] == pytest.approx(2.5e10 / 25.0, rel=1e-12)
+    assert hf_row['esc_rate_total'] != pytest.approx(2.5e10 / 125.0, rel=1e-2)
+
+    # Inside the Hill radius nothing changes, neither radius nor rate.
+    hf_row['esc_rate_total'] = 2.5e10
+    r_in = bound_escape_level(config, hf_row, 7.0e7)
+    assert r_in == pytest.approx(7.0e7, rel=1e-12)
+    assert hf_row['esc_rate_total'] == pytest.approx(2.5e10, rel=1e-12)
+
+    # Disabled, the solved radius passes through even beyond the Hill radius.
+    config.escape.hill_clamp = False
+    r_off = bound_escape_level(config, hf_row, 5.0e8)
+    assert r_off == pytest.approx(5.0e8, rel=1e-12)
+    assert hf_row['esc_rate_total'] == pytest.approx(2.5e10, rel=1e-12)

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -84,6 +84,8 @@ _REVIEWED_NEUTRAL = frozenset(
         'atmos_clim.agni.spectral_file',
         'atmos_clim.dummy.fixed_flux',
         'atmos_clim.janus.cloud_alpha',
+        # Inert while escape.hill_clamp is pinned off for migrated configs.
+        'escape.hill_clamp_frac',
         'interior_energetics.adams_williamson_beta',
         'interior_energetics.adams_williamson_rhos',
         'interior_energetics.adiabatic_bulk_modulus',

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -343,6 +343,19 @@ def test_kappah_floor_and_maximum_rel_overrides():
     assert mig.OVERRIDES['params.dt.maximum_rel'] == 0.0
 
 
+def test_hill_clamp_override_reproduces_unclipped_2_0_escape():
+    """2.0 sized escape from the unmodified XUV radius; the 3.0 default clips
+    it to the Hill radius. The override pins the clip off, so a migrated
+    config keeps its 2.0 escape rates rather than silently gaining the bound.
+    """
+    assert mig.OVERRIDES['escape.hill_clamp'] is False
+    # The live 3.0 default is the opposite; that difference is what the pin
+    # exists to bridge, so it is asserted here too.
+    from proteus.config._escape import Escape
+
+    assert Escape(module='zephyrus').hill_clamp is True
+
+
 def test_bol_scale_window_override_reproduces_unwindowed_2_0_scaling():
     """2.0 had no time-gating on bol_scale: a non-unity factor applied for
     the whole run. The live 3.0 default (bol_scale_start=None) disables

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -431,6 +431,50 @@ def test_write_and_read_helpfile_roundtrip():
 
 
 @pytest.mark.unit
+def test_read_helpfile_backfills_columns_added_since_the_file_was_written():
+    """A helpfile written before the schema gained a column must still resume.
+
+    The resume path seeds `hf_row` from the last row of the loaded file, and
+    `ExtendHelpfile` raises on a row that lacks a schema key, so a file from an
+    older PROTEUS would otherwise make every resume fail. Missing columns are
+    filled with zero, the value they hold on a fresh row before their module
+    first writes them, and the recorded columns keep their values exactly.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        row = ZeroHelpfileRow()
+        row['Time'] = 3.0e7
+        row['T_surf'] = 1650.0
+        hf = CreateHelpfileFromDict(row)
+        # Drop columns to mimic a file written before they existed, one from
+        # the middle of the schema and one from the end. Written directly in
+        # the on-disk format, since the writer itself refuses a partial schema.
+        hf_old = hf.drop(columns=['T_xuv', 'g_xuv', 'atm_levels_stale'])
+        hf_old.to_csv(
+            os.path.join(tmpdir, 'runtime_helpfile.csv'),
+            index=False,
+            sep='\t',
+            float_format='%.10e',
+        )
+
+        hf_read = ReadHelpfileFromCSV(tmpdir)
+
+        # The dropped columns are back, zero-filled, in schema order.
+        assert list(hf_read.columns) == GetHelpfileKeys()
+        assert hf_read['T_xuv'].iloc[0] == pytest.approx(0.0, abs=1e-300)
+        assert hf_read['g_xuv'].iloc[0] == pytest.approx(0.0, abs=1e-300)
+        assert hf_read['atm_levels_stale'].iloc[0] == pytest.approx(0.0, abs=1e-300)
+        # Recorded values survive untouched, so the backfill cannot have
+        # shifted columns against each other.
+        assert hf_read['Time'].iloc[0] == pytest.approx(3.0e7)
+        assert hf_read['T_surf'].iloc[0] == pytest.approx(1650.0)
+
+        # The row a resume would build from this file extends cleanly.
+        resumed_row = hf_read.iloc[-1].to_dict()
+        extended = ExtendHelpfile(hf_read, resumed_row)
+        assert len(extended) == 2
+
+
+@pytest.mark.unit
 def test_write_helpfile_preserves_prior_file_on_failed_write():
     """A crash or full disk mid-write must not destroy the existing helpfile.
 

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -431,50 +431,6 @@ def test_write_and_read_helpfile_roundtrip():
 
 
 @pytest.mark.unit
-def test_read_helpfile_backfills_columns_added_since_the_file_was_written():
-    """A helpfile written before the schema gained a column must still resume.
-
-    The resume path seeds `hf_row` from the last row of the loaded file, and
-    `ExtendHelpfile` raises on a row that lacks a schema key, so a file from an
-    older PROTEUS would otherwise make every resume fail. Missing columns are
-    filled with zero, the value they hold on a fresh row before their module
-    first writes them, and the recorded columns keep their values exactly.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        row = ZeroHelpfileRow()
-        row['Time'] = 3.0e7
-        row['T_surf'] = 1650.0
-        hf = CreateHelpfileFromDict(row)
-        # Drop columns to mimic a file written before they existed, one from
-        # the middle of the schema and one from the end. Written directly in
-        # the on-disk format, since the writer itself refuses a partial schema.
-        hf_old = hf.drop(columns=['T_xuv', 'g_xuv', 'atm_levels_stale'])
-        hf_old.to_csv(
-            os.path.join(tmpdir, 'runtime_helpfile.csv'),
-            index=False,
-            sep='\t',
-            float_format='%.10e',
-        )
-
-        hf_read = ReadHelpfileFromCSV(tmpdir)
-
-        # The dropped columns are back, zero-filled, in schema order.
-        assert list(hf_read.columns) == GetHelpfileKeys()
-        assert hf_read['T_xuv'].iloc[0] == pytest.approx(0.0, abs=1e-300)
-        assert hf_read['g_xuv'].iloc[0] == pytest.approx(0.0, abs=1e-300)
-        assert hf_read['atm_levels_stale'].iloc[0] == pytest.approx(0.0, abs=1e-300)
-        # Recorded values survive untouched, so the backfill cannot have
-        # shifted columns against each other.
-        assert hf_read['Time'].iloc[0] == pytest.approx(3.0e7)
-        assert hf_read['T_surf'].iloc[0] == pytest.approx(1650.0)
-
-        # The row a resume would build from this file extends cleanly.
-        resumed_row = hf_read.iloc[-1].to_dict()
-        extended = ExtendHelpfile(hf_read, resumed_row)
-        assert len(extended) == 2
-
-
-@pytest.mark.unit
 def test_write_helpfile_preserves_prior_file_on_failed_write():
     """A crash or full disk mid-write must not destroy the existing helpfile.
 

--- a/tools/migrate_config_v2_to_v3.py
+++ b/tools/migrate_config_v2_to_v3.py
@@ -257,6 +257,9 @@ OVERRIDES = {
     # 2.0 had no time-gating on bol_scale
     'star.bol_scale_start': 0.0,
     'star.bol_scale_duration': 100.0,
+    # 2.0 sized escape from the unmodified XUV radius; the 3.0 default clips
+    # it to the Hill radius. Pin off so migrated runs reproduce 2.0 rates.
+    'escape.hill_clamp': False,
 }
 
 # Element-budget fields consumed by the element handler (not mapped directly).


### PR DESCRIPTION
## Description

Closes #807.

When AGNI rejects its solution it still returns an atmospheric structure, and PROTEUS read the photospheric and XUV levels off that structure. Escape reads `R_xuv` from the previous iteration and the energy-limited rate goes as its cube, so a convergence failure turned into a large mass-loss rate that looked like a physical result. In the runs where I found this, escape was computing a rate from a radius of six to twenty-two Hill radii, and the affected cases lost their envelopes in one or two steps.

Two mechanisms address this, one for rejected solves and one for the level itself.

Each converged solve records `R_obs`, `p_obs`, `T_obs`, `g_obs`, `R_xuv`, `p_xuv`, `T_xuv`, `g_xuv` and the volume mixing ratios at the XUV level, and a rejected solve has those replaced by the record. They are carried as a group, so a held radius is never combined with the pressure, temperature, gravity or composition of a rejected structure; BOREAS reads the composition alongside the radius, so carrying only the radii would have left it mixing two structures. The quantities derived from the radius, `rho_obs` and the transit depth, follow the carried value. Fluxes and surface state are never carried, since the coupling advances on them and the deadlock detector needs to see them stop moving. The record lives in memory only, so a resumed run whose first solve is rejected falls back on the last committed row, written before the run began; later solves do not reach back, since once a run has written rows of its own an empty record means those rows carry rejected levels too.

Independently of convergence, the XUV level is bounded: gas beyond the Hill radius is not bound to the planet, so with `escape.hill_clamp` (on by default) each atmosphere module limits `R_xuv` to `escape.hill_clamp_frac` of the Hill radius, floored at the solid-body radius, and re-reads `p_xuv`, `T_xuv`, `g_xuv` and the XUV mixing ratios at the clipped radius, keeping the level self-consistent. This is also the bound for a run that has never converged a solve, where the carry has nothing to hold. The v2-to-v3 config migration pins the clip off so migrated configs reproduce their previous escape rates. The observed level is not clipped; the orbit module's existing beyond-Hill warning still covers it.

`T_xuv` and `g_xuv` are new outputs in all three atmosphere modules. Two helpfile columns persist the solve outcome: `atm_converged` (+1 converged, -1 rejected, 0 before the first solve) and `atm_levels_stale` (consecutive iterations without a converged solve of the run), which is the recording half of #727. Every substitution is logged with that count and reported at error level past ten in a row, since the deadlock detector fires only when the interior has stopped moving as well. Modules without a nonlinear solve (JANUS, dummy, AGNI's transparent and prescribed-temperature branches) always report convergence.

Resuming a run whose helpfile predates a schema addition remains unchanged by this PR and is filed as #811.

## Validation of changes

macOS 15 (Darwin 25.3.0, arm64), Python 3.12, AGNI 1.12.0, SOCRATES 2603.8.

- `pytest -m "unit and not skip and not slow and not integration" --ignore=tests/examples`: 2932 passed, 11 skipped.
- `ruff check` and `ruff format --check` clean; `bash tools/validate_test_structure.sh` passes.
- 21 new tests across `tests/atmos_clim/` and `tests/config/`. I checked each behaviour by breaking its code path and confirming only the covering test fails: dropping the substitution, dropping the XUV composition from the carried set, reading the wrong committed row, counting only failed solves towards the first-solve rule, replacing the record instead of merging, removing the non-finite filter, hardcoding the logged provenance, removing the streak escalation, dropping the R_int floor from the clip, clipping the radius without re-reading the pressure, and ignoring the config switch.
- The wiring is covered as well as the helpers: mocked-AGNI tests drive `run_atmosphere` for a rejected solve mid-run and for the first solve after a resume, asserting on `hf_row`, which is what escape reads; module-level clip tests pin the re-read `p/T/g` at the clipped radius against profile values chosen so reading the wrong end of the column fails by a factor of 3.2.
- A full dummy-module run confirms the new helpfile columns populate with no NaN or unknown-key warnings.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
