### PR TITLE
Stop an installed module changing how imports are sorted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,12 @@ sha256 = ""
 fail_under = 80
 
 [tool.ruff]
+# Directories searched for the names that count as first party. The default
+# also searches the repository root, where the ecosystem modules are installed
+# as clones, so a module whose clone directory carries its own name is read as
+# part of this project and its imports sort into the group holding proteus.
+# Names pinned under [tool.ruff.lint.isort] are honoured either way.
+src = ["src"]
 line-length = 96
 target-version = "py312"
 extend-exclude = ["*ipynb"]

--- a/tests/test_import_sorting_config.py
+++ b/tests/test_import_sorting_config.py
@@ -4,7 +4,8 @@ The ecosystem modules are installed as clones beside ``src/`` at the repository
 root. Whatever ruff treats as an import search path is also where it looks for
 first-party names, so with the root searched, a clone directory carrying its
 own module name makes that module read as part of this project and its imports
-sort into the group that holds ``proteus``.
+sort into the group that holds ``proteus``. Naming a module in the first-party
+list of the isort settings arrives at the same place by a shorter route.
 
 The damage is not symmetric between a contributor's machine and the checks,
 because only the machine with the module installed carries the clone. The lint
@@ -18,6 +19,14 @@ machine that installed no modules at all, which is the case the checks
 themselves run in. Each derivation carries a canary as well as an assertion,
 so a check that stops reaching its subject fails rather than passing on
 nothing.
+
+``docs/Explanations/test_framework.md`` asks every check for an edge case and a
+path through the error contract, in wording written for the physics modules.
+Read here, the edge cases are the limits a configuration and a scan can reach:
+a spelling of the root nobody wrote down, an import that does not begin its
+line, a candidate set with nothing in it. The contract a failure reports is the
+assertion message, which says what the setting defends rather than only that it
+changed.
 
 References:
   - docs/How-to/testing.md
@@ -40,10 +49,6 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCANNED_ROOTS = (REPO_ROOT / 'src', REPO_ROOT / 'tests')
 
-# Spellings of the repository root as a search path entry. Anything resolving
-# to the root puts the module clones back in front of ruff.
-ROOT_SPELLINGS = frozenset({'.', './', '', str(REPO_ROOT)})
-
 # Directories that belong to this repository rather than to a module beside it.
 REPO_OWN_DIRECTORIES = frozenset({'src', 'tests', 'tools', 'docs', 'examples', 'input'})
 
@@ -64,58 +69,94 @@ def _python_files() -> tuple[Path, ...]:
     return tuple(sorted(path for root in SCANNED_ROOTS for path in root.rglob('*.py')))
 
 
-def _import_line_pattern(candidates: frozenset[str]) -> re.Pattern[str]:
-    """Return a pattern matching an import statement that names a candidate.
+@cache
+def _candidate_pattern(candidates: frozenset[str]) -> re.Pattern[str] | None:
+    """Return a pattern selecting the files worth parsing, or ``None`` for none.
 
-    Indentation is allowed, so a nested import matches as readily as one at
-    module scope, and the whole statement is searched rather than the position
-    after the keyword, so a name reached through a comma list or a dotted path
-    still matches. Matching without case keeps the filter wider than the parse
-    behind it. Callers join continued lines first, since the name of a module
-    imported across a backslash stands on a line of its own.
+    An import keyword and the name it brings in stand on one line, so a line
+    holding both is the narrowest thing that can be required without losing an
+    import: a clause header, a semicolon or indentation in front of the keyword
+    all leave the pair together. Callers join continued lines first, since a
+    backslash can carry the name onto the next line. Matching without case
+    keeps the filter wider than the parse behind it. An empty candidate set
+    would alternate to a pattern matching at every position, so it gets no
+    pattern at all.
     """
+    if not candidates:
+        return None
     alternation = '|'.join(re.escape(name) for name in sorted(candidates))
-    return re.compile(rf'(?m)^\s*(?:import|from)\b.*\b(?:{alternation})\b', re.IGNORECASE)
+    return re.compile(rf'(?m)^.*\b(?:import|from)\b.*\b(?:{alternation})\b', re.IGNORECASE)
+
+
+def _imported_names_in_source(source: str, candidates: frozenset[str]) -> frozenset[str]:
+    """Return the members of ``candidates`` that ``source`` imports.
+
+    A file whose lines never hold an import keyword beside a candidate name
+    cannot contribute one and is not parsed. What survives the filter is read
+    with ``ast`` rather than by pattern, so a name written in a comment or a
+    string is not mistaken for an import. ``ast`` also sees imports nested in
+    functions and classes: ruff sorts a nested import block exactly as it sorts
+    one at module scope, and the defect this file guards against was nested.
+
+    Line endings are normalised before the continued lines are joined, so the
+    filter reads a source handed to it as text the same way it reads one that
+    arrived through a file.
+    """
+    pattern = _candidate_pattern(candidates)
+    joined = source.replace('\r\n', '\n').replace('\\\n', ' ')
+    if pattern is None or not pattern.search(joined):
+        return frozenset()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover - none today
+        return frozenset()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name.split('.', 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.add(node.module.split('.', 1)[0])
+    return frozenset(names & candidates)
+
+
+@cache
+def _python_sources() -> tuple[str, ...]:
+    """Return the text of every Python file under the scanned roots.
+
+    Held for the file, since several checks ask the same tree about different
+    names and the reading is the part none of them need to repeat.
+    """
+    sources = []
+    for path in _python_files():
+        try:
+            sources.append(path.read_text(encoding='utf-8'))
+        except UnicodeDecodeError:  # pragma: no cover - none today
+            continue
+    return tuple(sources)
 
 
 @cache
 def _imported_module_names(candidates: frozenset[str]) -> frozenset[str]:
-    """Return the members of ``candidates`` that the repository imports.
+    """Return the members of ``candidates`` the repository imports anywhere.
 
-    Only a name that can stand at the root as a clone decides how imports sort,
-    so a file whose import statements never spell one cannot contribute and is
-    not parsed. That leaves about a fifth of the tree, and what remains is read
-    with ``ast`` rather than by pattern, so a name written in a comment or a
-    docstring is not mistaken for an import. ``ast`` also sees imports nested in
-    functions and classes: ruff sorts a nested import block exactly as it sorts
-    one at module scope, and the defect this file guards against was nested.
+    Two costs sit behind this. The filter runs over every source and stands
+    whatever is asked for; the parse runs only on what the filter keeps, and
+    that is where asking for fewer names pays, since the two witnesses below
+    reach about a twentieth of the tree where the whole declared set reaches a
+    quarter of it. Asking for a set the configuration already accounts for,
+    which is the usual case for the staleness check, builds no filter and
+    parses nothing.
 
-    The scan costs a few tenths of a second, over the 100 ms that
+    The result is a couple of tenths of a second, over the 100 ms that
     ``docs/How-to/testing.md`` sets for the unit marker and well inside the
-    ``timeout`` ceiling above. What is left is the parse itself, on the files
-    that really do import an ecosystem module.
+    ``timeout`` ceiling above. Answering what the repository imports means
+    reading the repository, so the cost is taken rather than traded for a
+    narrower question.
     """
-    if not candidates:
-        return frozenset()
-    pattern = _import_line_pattern(candidates)
     names: set[str] = set()
-    for path in _python_files():
-        try:
-            source = path.read_text(encoding='utf-8')
-        except UnicodeDecodeError:  # pragma: no cover - none today
-            continue
-        if not pattern.search(source.replace('\\\n', ' ')):
-            continue
-        try:
-            tree = ast.parse(source)
-        except SyntaxError:  # pragma: no cover - none today
-            continue
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Import):
-                names.update(alias.name.split('.', 1)[0] for alias in node.names)
-            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-                names.add(node.module.split('.', 1)[0])
-    return frozenset(names & candidates)
+    for source in _python_sources():
+        names |= _imported_names_in_source(source, candidates)
+    return frozenset(names)
 
 
 @cache
@@ -159,21 +200,56 @@ def _declared_module_names() -> set[str]:
     return names
 
 
+def _entries_on_the_repository_root(entries: list[str]) -> list[str]:
+    """Return the search path entries that lead to the repository root.
+
+    Each entry is resolved against the directory holding the configuration, the
+    way ruff reads it, so entries are separated by where they arrive rather
+    than by how they are written and a spelling nobody listed is caught with
+    the rest.
+    """
+    return sorted(entry for entry in entries if (REPO_ROOT / entry).resolve() == REPO_ROOT)
+
+
+def _entries_holding_a_module(entries: list[str], modules: frozenset[str]) -> list[str]:
+    """Return the search path entries that a module could stand in.
+
+    This is what makes a clone read as first party: not that an entry is the
+    root, but that a module stands inside it. ruff reads a directory and a bare
+    ``.py`` file alike as a module, so both count. An entry naming a directory
+    that is not there holds nothing and is left alone.
+    """
+    holding = []
+    for entry in entries:
+        directory = (REPO_ROOT / entry).resolve()
+        if not directory.is_dir():
+            continue
+        held = {
+            child.name.lower() if child.is_dir() else child.stem.lower()
+            for child in directory.iterdir()
+            if child.is_dir() or child.suffix == '.py'
+        }
+        if held & modules:
+            holding.append(entry)
+    return sorted(holding)
+
+
 def test_the_repository_root_is_not_searched_for_first_party_imports():
     """Import grouping is decided from the source tree alone.
 
-    Contract clause: the root holds module clones, so searching it for
-    first-party names makes an ecosystem module read as part of this project.
+    Contract clause: the root holds the module clones, so a search path entry
+    that reaches them makes an ecosystem module read as part of this project.
     ``ruff check --fix`` then rewrites import groups on a machine that has the
     module and the checks reject the result on a machine that does not.
 
     Verifies:
     - A search path is configured at all, rather than left at the default,
       which searches the root.
-    - No entry on it resolves to the repository root, under any of the
-      spellings that would name it.
-    - Only the source tree is searched, so a directory added at the root later
-      cannot change how anything is sorted.
+    - No entry leads to the repository root, under any spelling of it.
+    - No entry is one a module could stand in, which covers an entry that
+      reaches the clones without being the root itself. An entry outside
+      ``src/`` is not a defect in itself: a package kept elsewhere in the
+      repository can join the search path as long as no module can stand in it.
     """
     ruff = _read_config()['tool']['ruff']
 
@@ -183,16 +259,216 @@ def test_the_repository_root_is_not_searched_for_first_party_imports():
     )
 
     configured = [str(entry) for entry in ruff['src']]
-    on_the_root = sorted(entry for entry in configured if entry.strip() in ROOT_SPELLINGS)
+    on_the_root = _entries_on_the_repository_root(configured)
     assert not on_the_root, (
         f'{on_the_root} put the repository root on the import search path, where the '
         f'module clones are installed. Clones present here: {sorted(_cloned_module_directories())}'
     )
-    assert configured == ['src'], (
-        f'the import search path is {configured} rather than the source tree alone. '
-        'Every entry on it is a directory whose contents decide how imports sort, so '
-        'the path is held to one; a second entry that is genuinely wanted belongs in '
-        'the same change as the contract here'
+
+    modules = frozenset(_declared_module_names()) | _cloned_module_directories()
+    holding = _entries_holding_a_module(configured, modules)
+    assert not holding, (
+        f'{holding} are on the import search path and an ecosystem module stands in them, '
+        'so ruff reads that module as part of this project and sorts its imports into the '
+        'group that holds proteus'
+    )
+
+
+def test_no_ecosystem_module_is_declared_first_party():
+    """The isort settings do not name a module the search path keeps out.
+
+    Contract clause: ``known-first-party`` overrides whatever the search path
+    would have decided, so a module listed there sorts with ``proteus`` on
+    every machine, installed or not. That is the same misreading the search
+    path guard prevents, reached by a shorter route.
+
+    Verifies:
+    - This project is named first party, so the settings are being read at the
+      key that decides the question rather than at one that no longer exists.
+    - No ecosystem module is named alongside it.
+    """
+    lint = _read_config()['tool']['ruff'].get('lint', {})
+    first_party = {name.lower() for name in lint.get('isort', {}).get('known-first-party', [])}
+
+    assert 'proteus' in first_party, (
+        f'known-first-party is {sorted(first_party)} and does not name this project, so '
+        'either the key moved or the setting was dropped, and the check below no longer '
+        'reads what decides whether a module sorts as first party'
+    )
+
+    ecosystem = sorted(first_party & _declared_module_names())
+    assert not ecosystem, (
+        f'{ecosystem} are ecosystem modules named as first party, so their imports sort '
+        'into the group that holds proteus even on a machine that keeps the module clones '
+        'off the import search path'
+    )
+
+
+def test_the_repository_root_is_recognised_under_every_spelling():
+    """A search path entry is judged by where it leads, not by how it reads.
+
+    Contract clause: the entry that puts the clones in front of ruff is the one
+    that arrives at the repository root, and a configuration can arrive there
+    several ways. Comparing the text would leave whichever spellings nobody
+    listed unguarded.
+
+    Verifies:
+    - Every spelling that arrives at the root is reported: the bare dot, a
+      trailing separator, an empty entry, the absolute path, and a path that
+      climbs back out of a subdirectory.
+    - The source tree is not reported, so the check separates the root from an
+      ordinary entry rather than reporting whatever it is given.
+    """
+    spellings = ['.', './', '', str(REPO_ROOT), 'src/..']
+
+    assert _entries_on_the_repository_root(spellings) == sorted(spellings), (
+        'a spelling of the repository root went unreported, so a configuration writing '
+        'the root that way would put the module clones on the import search path'
+    )
+    assert _entries_on_the_repository_root(['src', 'src/proteus']) == [], (
+        'an entry inside the source tree was reported as the repository root, so the '
+        'check no longer separates the two and would fail on a configuration that is fine'
+    )
+
+
+def test_a_path_entry_a_module_could_stand_in_is_reported(tmp_path):
+    """A module standing inside a path entry is what makes it first party.
+
+    Contract clause: ruff reads what sits inside a search path entry as module
+    names, so an entry is a hazard when a module can stand in it, whatever the
+    entry itself is called.
+
+    Verifies:
+    - An entry holding a module as a directory is reported, and the match
+      ignores case, since the clone directories are capitalised and the module
+      names are not.
+    - An entry holding a module as a bare ``.py`` file is reported too, which
+      is the other shape ruff reads as a module name.
+    - An entry holding unrelated directories and files is not reported, so a
+      path entry is not condemned for existing.
+    - An entry naming a directory that is not there is not reported, so a
+      configuration written ahead of a directory does not fail on its absence.
+    """
+    packaged = tmp_path / 'with_package'
+    (packaged / 'AGNI').mkdir(parents=True)
+    single = tmp_path / 'with_single_file'
+    single.mkdir()
+    (single / 'agni.py').write_text('', encoding='utf-8')
+    plain = tmp_path / 'without_module'
+    (plain / 'notes').mkdir(parents=True)
+    (plain / 'notes.py').write_text('', encoding='utf-8')
+
+    modules = frozenset({'agni'})
+    assert _entries_holding_a_module([str(packaged)], modules) == [str(packaged)], (
+        'a directory named like an ecosystem module was not seen inside a search path '
+        'entry, so the guard above would pass on a configuration that reaches the clones'
+    )
+    assert _entries_holding_a_module([str(single)], modules) == [str(single)], (
+        'a module standing as a single file was not seen inside a search path entry, and '
+        'ruff reads that as a first-party name exactly as it reads a package directory'
+    )
+    assert _entries_holding_a_module([str(plain)], modules) == [], (
+        'a search path entry holding nothing but unrelated names was reported, so the '
+        'check condemns any entry rather than the ones a module can stand in'
+    )
+    assert _entries_holding_a_module([str(tmp_path / 'absent')], modules) == [], (
+        'an entry naming a directory that does not exist was reported, so the check reads '
+        'the absence of a directory as a module standing in it'
+    )
+
+
+def test_an_import_away_from_the_start_of_its_line_is_counted():
+    """A module imported from inside a compound statement counts as imported.
+
+    Contract clause: the scan skips a file whose lines never hold an import
+    keyword beside a candidate name. A statement following a clause header or a
+    semicolon is an import like any other and ruff sorts its group the same
+    way, so a skip that hid one would leave every derivation below reading a
+    smaller repository than the real one.
+
+    Verifies:
+    - Each shape that keeps an import away from the start of its line is found:
+      after a clause header, in an else branch, and after a semicolon.
+    - A name carried onto the next line by a backslash is found, so continued
+      lines are joined before the filter runs, whichever ending the source
+      separates its lines with.
+    - A name written in a comment or inside a string is not counted, so the
+      filter still leaves the decision to the parse behind it.
+    """
+    candidates = frozenset({'mors', 'zephyrus'})
+
+    compound = {
+        'clause header': 'try: import mors\nexcept ImportError: mors = None\n',
+        'else branch': 'if True:\n    pass\nelse: import zephyrus\n',
+        'after a semicolon': 'started = True; import mors\n',
+        'continued line': 'import \\\n    mors\n',
+        'continued line, other endings': 'import \\\r\n    mors\r\n',
+    }
+    found = {
+        label: _imported_names_in_source(src, candidates) for label, src in compound.items()
+    }
+    missed = sorted(label for label, names in found.items() if not names)
+    assert not missed, (
+        f'an import reached {missed} was not counted, so a file whose only import of an '
+        'ecosystem module takes that shape reads as importing nothing'
+    )
+
+    quoted = '# import mors for the stellar track\nEXAMPLE = "from zephyrus import escape"\n'
+    assert _imported_names_in_source(quoted, candidates) == frozenset(), (
+        'a name written in a comment or a string was counted as an import, so the scan '
+        'reports modules this repository does not import'
+    )
+
+
+def test_a_scan_with_no_candidate_names_looks_for_nothing(monkeypatch):
+    """An empty candidate set reads as no names to look for, not as all of them.
+
+    Contract clause: the filter alternates the candidate names, and an empty
+    alternation matches at every position, so an empty set would select the
+    whole tree to parse. The scan intersects what it finds with the candidates,
+    so the answer that comes back is empty either way and only the parse that
+    never happens shows the guard doing anything.
+
+    Verifies:
+    - No pattern is built for an empty set, so the indiscriminate one is never
+      reached, while a one-name set still builds one that selects a file
+      importing that name.
+    - A source that plainly imports a candidate is never handed to the parser
+      under an empty candidate set, with every parse recorded to say so.
+    - The same source is parsed and found once the name is a candidate, so the
+      silence above is the guard rather than a scan that reads nothing at all.
+    """
+    assert _candidate_pattern(frozenset()) is None, (
+        'a pattern was built from an empty candidate set, and an empty alternation '
+        'matches everywhere, so the scan would parse the whole tree to find nothing'
+    )
+    probe = _candidate_pattern(frozenset({'mors'}))
+    assert probe is not None and probe.search('import mors'), (
+        'the filter built for a single name no longer selects a file importing it, so '
+        'the empty result above says nothing about the guard'
+    )
+
+    parsed: list[str] = []
+    real_parse = ast.parse
+
+    def record(source, *args, **kwargs):
+        parsed.append(source)
+        return real_parse(source, *args, **kwargs)
+
+    monkeypatch.setattr(ast, 'parse', record)
+
+    witness = sorted(NESTED_ONLY_IMPORTS)[0]
+    source = f'import {witness}\n'
+    assert _imported_names_in_source(source, frozenset()) == frozenset()
+    assert parsed == [], (
+        'the scan parsed a file although it had been given no names to look for, so the '
+        'empty-set guard no longer stands in front of a pattern that matches everywhere'
+    )
+
+    assert _imported_names_in_source(source, frozenset({witness})) == frozenset({witness})
+    assert parsed == [source], (
+        f'the same source was not parsed with {witness!r} among the candidates, so the '
+        'refusal above comes from a scan that parses nothing rather than from the guard'
     )
 
 
@@ -205,22 +481,22 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
     rather than leaving it passing on nothing.
 
     Verifies:
-    - The walk reaches the source tree, and the scan finds a name imported only
-      inside function bodies, which is the shape the sorting defect took.
-    - Several ecosystem modules are imported by this repository, so a clone of
-      any of them at the root would be misread. This reads the configuration
-      rather than the filesystem and so holds where none is installed.
-    - Every clone standing at the root that this repository imports is one the
-      configuration already names, so the two ways of arriving at the set agree
+    - The walk reaches the source tree, and the scan finds both names imported
+      only inside function bodies, which is the shape the sorting defect took.
+    - No clone standing at the root that this repository imports is missing
+      from the configuration, so the two ways of arriving at the set agree
       wherever both have something to say. A directory nothing imports cannot
       change how imports sort and so is not the subject here.
+    - Those two names are themselves modules the configuration names, so what
+      the setting above covers is a family rather than a single import. This
+      reads the configuration rather than the filesystem and so holds where no
+      module is installed.
     - An ordinary dependency is not mistaken for one of those modules, so the
       reasoning separates the ecosystem from the rest of what the repository
       imports rather than sweeping both together.
     """
     declared = _declared_module_names()
     cloned = _cloned_module_directories()
-    imported = _imported_module_names(frozenset(declared | cloned))
 
     scanned = _python_files()
     assert len(scanned) > 100, (
@@ -230,29 +506,30 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
     # Nothing imports these at module scope, so they are what says the scan
     # reaches an import nested in a function body rather than only the ones
     # standing at the start of a line.
-    missing = sorted(NESTED_ONLY_IMPORTS - imported)
+    missing = sorted(NESTED_ONLY_IMPORTS - _imported_module_names(NESTED_ONLY_IMPORTS))
     assert not missing, (
         f'{missing} are imported only inside function bodies and the scan no longer '
         'sees them, so either nested imports are escaping it or those imports were '
         'renamed or dropped; which of the two decides whether anything below holds'
     )
 
-    collidable = sorted(declared & imported)
-    assert len(collidable) >= 5, (
-        f'only {collidable} of the ecosystem modules are imported by this repository, '
-        'so the search path guard is protecting far less than it appears to and the '
-        'reasoning behind it should be revisited rather than left in place'
-    )
-
     # Both routes to the set should agree: a clone this repository imports that
     # the configuration does not name would mean one of them has gone stale.
-    # A root directory nothing imports is left alone, since a fork or a working
-    # tree kept beside the clones cannot decide how any import sorts.
-    unaccounted = sorted((cloned & imported) - declared)
+    # Only the names the configuration leaves unaccounted for are looked for, so
+    # a fork or a working tree kept beside the clones costs nothing and, being
+    # imported by nothing, decides nothing.
+    unaccounted = sorted(_imported_module_names(frozenset(cloned - declared)))
     assert not unaccounted, (
         f'{unaccounted} stand at the repository root and are imported here but are '
         'named nowhere in the configuration, so the set read from it no longer covers '
         'what is installed'
+    )
+
+    uncovered = sorted(NESTED_ONLY_IMPORTS - declared)
+    assert not uncovered, (
+        f'{uncovered} are what says the scan reaches a nested import, but the '
+        'configuration has stopped naming them as ecosystem modules, so they no longer '
+        'say that the setting above covers a family rather than a single import'
     )
 
     # A dependency that never stands at the root cannot collide, so finding one
@@ -262,24 +539,3 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
         'repository root, so the derivation no longer separates the ecosystem from '
         'the rest of what the repository imports'
     )
-
-
-def test_a_scan_with_no_candidate_names_finds_nothing():
-    """An empty candidate set reads as no names to look for, not as all of them.
-
-    Contract clause: the scan builds its filter by alternating the candidate
-    names, and an empty alternation matches at every position, so an empty set
-    would sweep in every import in the tree rather than none. The guard returns
-    ahead of that, which is the reading a configuration naming no modules
-    should get.
-
-    Verifies:
-    - The empty case returns nothing, so the boundary is handled rather than
-      falling through to a pattern that matches indiscriminately.
-    - A single-name scan still finds that name, so the empty result above comes
-      from the guard rather than from a scan that has stopped working.
-    """
-    assert _imported_module_names(frozenset()) == frozenset()
-
-    witness = sorted(NESTED_ONLY_IMPORTS)[0]
-    assert _imported_module_names(frozenset({witness})) == frozenset({witness})

--- a/tests/test_import_sorting_config.py
+++ b/tests/test_import_sorting_config.py
@@ -1,0 +1,209 @@
+"""Guard on where ruff looks to decide that an import is first party.
+
+The ecosystem modules are installed as clones beside ``src/`` at the repository
+root. Whatever ruff treats as an import search path is also where it looks for
+first-party names, so with the root searched, a clone directory carrying its
+own module name makes that module read as part of this project and its imports
+sort into the group that holds ``proteus``.
+
+The damage is not symmetric between a contributor's machine and the checks,
+because only the machine with the module installed carries the clone. The
+formatter runs with ``--fix``, so on that machine it rewrites the import groups
+of any file it touches, and the rewrite it commits is what the checks then
+reject. Keeping the root off the search path closes both halves at once, for
+every module rather than one name at a time.
+
+The checks below read the configuration and the source, so they hold on a
+machine that installed no modules at all, which is the case the checks
+themselves run in.
+
+References:
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import tomllib
+from functools import cache
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCANNED_ROOTS = (REPO_ROOT / 'src', REPO_ROOT / 'tests')
+
+# Spellings of the repository root as a search path entry. Anything resolving
+# to the root puts the module clones back in front of ruff.
+ROOT_SPELLINGS = frozenset({'.', './', '', str(REPO_ROOT)})
+
+# Directories that belong to this repository rather than to a module beside it.
+REPO_OWN_DIRECTORIES = frozenset({'src', 'tests', 'tools', 'docs', 'examples', 'input'})
+
+
+def _read_config() -> dict:
+    """Return the parsed ``pyproject.toml``."""
+    return tomllib.loads((REPO_ROOT / 'pyproject.toml').read_text(encoding='utf-8'))
+
+
+@cache
+def _imported_root_names() -> frozenset[str]:
+    """Return every top-level module name the repository imports.
+
+    Imports nested in functions and classes are included. ruff sorts a nested
+    import block exactly as it sorts one at module scope, so a nested import is
+    misread in the same way, and the defect this file guards against was a
+    nested import. Reading the whole source tree costs about a second, so the
+    result is cached for the file.
+    """
+    names: set[str] = set()
+    for root in SCANNED_ROOTS:
+        for path in root.rglob('*.py'):
+            try:
+                tree = ast.parse(path.read_text(encoding='utf-8'))
+            except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - none today
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names.update(alias.name.split('.', 1)[0] for alias in node.names)
+                elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                    names.add(node.module.split('.', 1)[0])
+    return frozenset(names)
+
+
+@cache
+def _cloned_module_directories() -> frozenset[str]:
+    """Return the root directories that are clones of a module, lowercased.
+
+    A clone carries its own ``.git``; this repository's own directories do not.
+    Empty on a machine that installed no modules.
+    """
+    found = set()
+    for path in REPO_ROOT.iterdir():
+        if not path.is_dir() or path.name in REPO_OWN_DIRECTORIES:
+            continue
+        if (path / '.git').exists():
+            found.add(path.name.lower())
+    return frozenset(found)
+
+
+def _declared_module_names() -> set[str]:
+    """Return the ecosystem module names, lowercased.
+
+    Two sources, both read from the configuration rather than the filesystem,
+    so this says which modules can stand at the root on any machine, including
+    one with none installed: the modules pinned for a clone step, and the
+    ecosystem distributions, whose module is the distribution name without its
+    ``fwl-`` prefix. A stripped name that belongs to the standard library is
+    dropped, since ``fwl-io`` provides ``fwl_io`` rather than ``io``.
+    """
+    config = _read_config()
+    names = {name.lower() for name in config['tool']['proteus']['modules']}
+
+    requirements = list(config['project'].get('dependencies', []))
+    for extra in config['project'].get('optional-dependencies', {}).values():
+        requirements.extend(extra)
+    for requirement in requirements:
+        distribution = re.split(r'[<>=!~\[; ]', requirement.strip())[0].lower()
+        if distribution.startswith('fwl-'):
+            module = distribution[len('fwl-') :]
+            if module not in sys.stdlib_module_names:
+                names.add(module)
+    return names
+
+
+def test_the_repository_root_is_not_searched_for_first_party_imports():
+    """Import grouping is decided from the source tree alone.
+
+    Contract clause: the root holds module clones, so searching it for
+    first-party names makes an ecosystem module read as part of this project.
+    The formatter then rewrites import groups on a machine that has the module
+    and the checks reject the result on a machine that does not.
+
+    Verifies:
+    - A search path is configured at all, rather than left at the default,
+      which searches the root.
+    - No entry on it resolves to the repository root, under any of the
+      spellings that would name it.
+    - Only the source tree is searched, so a directory added at the root later
+      cannot change how anything is sorted.
+    """
+    ruff = _read_config()['tool']['ruff']
+
+    assert 'src' in ruff, (
+        'ruff has no src setting, so it falls back to searching the repository '
+        'root, where the ecosystem module clones are installed'
+    )
+
+    configured = [str(entry) for entry in ruff['src']]
+    on_the_root = sorted(entry for entry in configured if entry.strip() in ROOT_SPELLINGS)
+    assert not on_the_root, (
+        f'{on_the_root} put the repository root on the import search path, where the '
+        f'module clones are installed. Clones present here: {sorted(_cloned_module_directories())}'
+    )
+    assert configured == ['src'], (
+        f'the import search path is {configured} rather than the source tree alone; '
+        'any other entry is another directory whose contents decide how imports sort'
+    )
+
+
+def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
+    """The setting above is guarding a name that really can collide.
+
+    Contract clause: keeping the root off the search path is only worth
+    asserting while a module that the repository imports can appear there. If
+    that ever stops being true the guard above is inert, and this says so
+    rather than leaving it passing on nothing.
+
+    Verifies:
+    - The scan reads the source, finding names imported only inside function
+      bodies, which is the shape the sorting defect took.
+    - Several ecosystem modules are imported by this repository, so a clone of
+      any of them at the root would be misread. This reads the configuration
+      rather than the filesystem and so holds where none is installed.
+    - Every clone standing at the root right now is one the configuration
+      already names, so the two ways of arriving at the set agree wherever both
+      have something to say.
+    - An ordinary dependency is not mistaken for one of those modules, so the
+      reasoning separates the ecosystem from the rest of what the repository
+      imports rather than sweeping both together.
+    """
+    imported = _imported_root_names()
+
+    assert len(imported) > 50, (
+        f'only {len(imported)} imported module names were found, so the scan is no '
+        'longer reading the source and the checks here would pass on nothing'
+    )
+    assert 'boreas' in imported, (
+        'boreas is imported inside function bodies and the scan no longer sees it, '
+        'so nested imports are escaping the check'
+    )
+
+    declared = _declared_module_names()
+    collidable = sorted(declared & imported)
+    assert len(collidable) >= 5, (
+        f'only {collidable} of the ecosystem modules are imported by this repository, '
+        'so the search path guard is protecting far less than it appears to and the '
+        'reasoning behind it should be revisited rather than left in place'
+    )
+
+    # Both routes to the set should agree: a clone on this machine that the
+    # configuration does not name would mean one of them has gone stale.
+    unaccounted = sorted(_cloned_module_directories() - declared)
+    assert not unaccounted, (
+        f'{unaccounted} stand at the repository root but are named nowhere in the '
+        'configuration, so the set read from it no longer covers what is installed'
+    )
+
+    # A dependency that never stands at the root cannot collide, so finding one
+    # here would mean the derivation has started over-reaching.
+    assert not {'numpy', 'scipy', 'io'} & declared, (
+        'an ordinary dependency now looks like a module that can stand at the '
+        'repository root, so the derivation no longer separates the ecosystem from '
+        'the rest of what the repository imports'
+    )

--- a/tests/test_import_sorting_config.py
+++ b/tests/test_import_sorting_config.py
@@ -22,7 +22,10 @@ a check that stops reaching its subject fails rather than passing on nothing.
 What they conclude rests on how ruff reads a search path, which is described
 here rather than consulted. ``tests/test_import_sorting_ruff.py`` puts that
 description to the tool itself, on a project built for the question, and runs
-in the tier that carries the real binary.
+in the nightly tier because it carries a real binary. The shapes
+``_entries_holding_a_module`` counts and the spellings
+``_entries_on_the_repository_root`` resolves are the ones pinned over there, so
+a change to either belongs in both files.
 
 Whether a clone at the root is read as a module follows the filesystem, since
 ruff looks the name up as a path: a case-folding filesystem answers to

--- a/tests/test_import_sorting_config.py
+++ b/tests/test_import_sorting_config.py
@@ -7,15 +7,17 @@ own module name makes that module read as part of this project and its imports
 sort into the group that holds ``proteus``.
 
 The damage is not symmetric between a contributor's machine and the checks,
-because only the machine with the module installed carries the clone. The
-formatter runs with ``--fix``, so on that machine it rewrites the import groups
-of any file it touches, and the rewrite it commits is what the checks then
-reject. Keeping the root off the search path closes both halves at once, for
-every module rather than one name at a time.
+because only the machine with the module installed carries the clone. The lint
+hook runs ``ruff check --fix``, so on that machine it rewrites the import
+groups of any file it touches, and the rewrite it commits is what the checks
+then reject. Keeping the root off the search path closes both halves at once,
+for every module rather than one name at a time.
 
 The checks below read the configuration and the source, so they hold on a
 machine that installed no modules at all, which is the case the checks
-themselves run in.
+themselves run in. Each derivation carries a canary as well as an assertion,
+so a check that stops reaching its subject fails rather than passing on
+nothing.
 
 References:
   - docs/How-to/testing.md
@@ -45,6 +47,11 @@ ROOT_SPELLINGS = frozenset({'.', './', '', str(REPO_ROOT)})
 # Directories that belong to this repository rather than to a module beside it.
 REPO_OWN_DIRECTORIES = frozenset({'src', 'tests', 'tools', 'docs', 'examples', 'input'})
 
+# Ecosystem modules this repository imports only from inside a function body.
+# Nothing names them at the start of a line, so they are the witnesses that a
+# scan reading module scope alone would lose.
+NESTED_ONLY_IMPORTS = frozenset({'mors', 'zephyrus'})
+
 
 def _read_config() -> dict:
     """Return the parsed ``pyproject.toml``."""
@@ -52,28 +59,63 @@ def _read_config() -> dict:
 
 
 @cache
-def _imported_root_names() -> frozenset[str]:
-    """Return every top-level module name the repository imports.
+def _python_files() -> tuple[Path, ...]:
+    """Return every Python file under the scanned roots."""
+    return tuple(sorted(path for root in SCANNED_ROOTS for path in root.rglob('*.py')))
 
-    Imports nested in functions and classes are included. ruff sorts a nested
-    import block exactly as it sorts one at module scope, so a nested import is
-    misread in the same way, and the defect this file guards against was a
-    nested import. Reading the whole source tree costs about a second, so the
-    result is cached for the file.
+
+def _import_line_pattern(candidates: frozenset[str]) -> re.Pattern[str]:
+    """Return a pattern matching an import statement that names a candidate.
+
+    Indentation is allowed, so a nested import matches as readily as one at
+    module scope, and the whole statement is searched rather than the position
+    after the keyword, so a name reached through a comma list or a dotted path
+    still matches. Matching without case keeps the filter wider than the parse
+    behind it. Callers join continued lines first, since the name of a module
+    imported across a backslash stands on a line of its own.
     """
+    alternation = '|'.join(re.escape(name) for name in sorted(candidates))
+    return re.compile(rf'(?m)^\s*(?:import|from)\b.*\b(?:{alternation})\b', re.IGNORECASE)
+
+
+@cache
+def _imported_module_names(candidates: frozenset[str]) -> frozenset[str]:
+    """Return the members of ``candidates`` that the repository imports.
+
+    Only a name that can stand at the root as a clone decides how imports sort,
+    so a file whose import statements never spell one cannot contribute and is
+    not parsed. That leaves about a fifth of the tree, and what remains is read
+    with ``ast`` rather than by pattern, so a name written in a comment or a
+    docstring is not mistaken for an import. ``ast`` also sees imports nested in
+    functions and classes: ruff sorts a nested import block exactly as it sorts
+    one at module scope, and the defect this file guards against was nested.
+
+    The scan costs a few tenths of a second, over the 100 ms that
+    ``docs/How-to/testing.md`` sets for the unit marker and well inside the
+    ``timeout`` ceiling above. What is left is the parse itself, on the files
+    that really do import an ecosystem module.
+    """
+    if not candidates:
+        return frozenset()
+    pattern = _import_line_pattern(candidates)
     names: set[str] = set()
-    for root in SCANNED_ROOTS:
-        for path in root.rglob('*.py'):
-            try:
-                tree = ast.parse(path.read_text(encoding='utf-8'))
-            except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - none today
-                continue
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Import):
-                    names.update(alias.name.split('.', 1)[0] for alias in node.names)
-                elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-                    names.add(node.module.split('.', 1)[0])
-    return frozenset(names)
+    for path in _python_files():
+        try:
+            source = path.read_text(encoding='utf-8')
+        except UnicodeDecodeError:  # pragma: no cover - none today
+            continue
+        if not pattern.search(source.replace('\\\n', ' ')):
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover - none today
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names.update(alias.name.split('.', 1)[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                names.add(node.module.split('.', 1)[0])
+    return frozenset(names & candidates)
 
 
 @cache
@@ -122,8 +164,8 @@ def test_the_repository_root_is_not_searched_for_first_party_imports():
 
     Contract clause: the root holds module clones, so searching it for
     first-party names makes an ecosystem module read as part of this project.
-    The formatter then rewrites import groups on a machine that has the module
-    and the checks reject the result on a machine that does not.
+    ``ruff check --fix`` then rewrites import groups on a machine that has the
+    module and the checks reject the result on a machine that does not.
 
     Verifies:
     - A search path is configured at all, rather than left at the default,
@@ -147,8 +189,10 @@ def test_the_repository_root_is_not_searched_for_first_party_imports():
         f'module clones are installed. Clones present here: {sorted(_cloned_module_directories())}'
     )
     assert configured == ['src'], (
-        f'the import search path is {configured} rather than the source tree alone; '
-        'any other entry is another directory whose contents decide how imports sort'
+        f'the import search path is {configured} rather than the source tree alone. '
+        'Every entry on it is a directory whose contents decide how imports sort, so '
+        'the path is held to one; a second entry that is genuinely wanted belongs in '
+        'the same change as the contract here'
     )
 
 
@@ -161,30 +205,38 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
     rather than leaving it passing on nothing.
 
     Verifies:
-    - The scan reads the source, finding names imported only inside function
-      bodies, which is the shape the sorting defect took.
+    - The walk reaches the source tree, and the scan finds a name imported only
+      inside function bodies, which is the shape the sorting defect took.
     - Several ecosystem modules are imported by this repository, so a clone of
       any of them at the root would be misread. This reads the configuration
       rather than the filesystem and so holds where none is installed.
-    - Every clone standing at the root right now is one the configuration
-      already names, so the two ways of arriving at the set agree wherever both
-      have something to say.
+    - Every clone standing at the root that this repository imports is one the
+      configuration already names, so the two ways of arriving at the set agree
+      wherever both have something to say. A directory nothing imports cannot
+      change how imports sort and so is not the subject here.
     - An ordinary dependency is not mistaken for one of those modules, so the
       reasoning separates the ecosystem from the rest of what the repository
       imports rather than sweeping both together.
     """
-    imported = _imported_root_names()
-
-    assert len(imported) > 50, (
-        f'only {len(imported)} imported module names were found, so the scan is no '
-        'longer reading the source and the checks here would pass on nothing'
-    )
-    assert 'boreas' in imported, (
-        'boreas is imported inside function bodies and the scan no longer sees it, '
-        'so nested imports are escaping the check'
-    )
-
     declared = _declared_module_names()
+    cloned = _cloned_module_directories()
+    imported = _imported_module_names(frozenset(declared | cloned))
+
+    scanned = _python_files()
+    assert len(scanned) > 100, (
+        f'only {len(scanned)} Python files were found under the source tree, so the '
+        'walk is no longer reaching it and the checks here would pass on nothing'
+    )
+    # Nothing imports these at module scope, so they are what says the scan
+    # reaches an import nested in a function body rather than only the ones
+    # standing at the start of a line.
+    missing = sorted(NESTED_ONLY_IMPORTS - imported)
+    assert not missing, (
+        f'{missing} are imported only inside function bodies and the scan no longer '
+        'sees them, so either nested imports are escaping it or those imports were '
+        'renamed or dropped; which of the two decides whether anything below holds'
+    )
+
     collidable = sorted(declared & imported)
     assert len(collidable) >= 5, (
         f'only {collidable} of the ecosystem modules are imported by this repository, '
@@ -192,12 +244,15 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
         'reasoning behind it should be revisited rather than left in place'
     )
 
-    # Both routes to the set should agree: a clone on this machine that the
-    # configuration does not name would mean one of them has gone stale.
-    unaccounted = sorted(_cloned_module_directories() - declared)
+    # Both routes to the set should agree: a clone this repository imports that
+    # the configuration does not name would mean one of them has gone stale.
+    # A root directory nothing imports is left alone, since a fork or a working
+    # tree kept beside the clones cannot decide how any import sorts.
+    unaccounted = sorted((cloned & imported) - declared)
     assert not unaccounted, (
-        f'{unaccounted} stand at the repository root but are named nowhere in the '
-        'configuration, so the set read from it no longer covers what is installed'
+        f'{unaccounted} stand at the repository root and are imported here but are '
+        'named nowhere in the configuration, so the set read from it no longer covers '
+        'what is installed'
     )
 
     # A dependency that never stands at the root cannot collide, so finding one
@@ -207,3 +262,24 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
         'repository root, so the derivation no longer separates the ecosystem from '
         'the rest of what the repository imports'
     )
+
+
+def test_a_scan_with_no_candidate_names_finds_nothing():
+    """An empty candidate set reads as no names to look for, not as all of them.
+
+    Contract clause: the scan builds its filter by alternating the candidate
+    names, and an empty alternation matches at every position, so an empty set
+    would sweep in every import in the tree rather than none. The guard returns
+    ahead of that, which is the reading a configuration naming no modules
+    should get.
+
+    Verifies:
+    - The empty case returns nothing, so the boundary is handled rather than
+      falling through to a pattern that matches indiscriminately.
+    - A single-name scan still finds that name, so the empty result above comes
+      from the guard rather than from a scan that has stopped working.
+    """
+    assert _imported_module_names(frozenset()) == frozenset()
+
+    witness = sorted(NESTED_ONLY_IMPORTS)[0]
+    assert _imported_module_names(frozenset({witness})) == frozenset({witness})

--- a/tests/test_import_sorting_config.py
+++ b/tests/test_import_sorting_config.py
@@ -16,9 +16,21 @@ for every module rather than one name at a time.
 
 The checks below read the configuration and the source, so they hold on a
 machine that installed no modules at all, which is the case the checks
-themselves run in. Each derivation carries a canary as well as an assertion,
-so a check that stops reaching its subject fails rather than passing on
-nothing.
+themselves run in. Each derivation carries a canary as well as an assertion, so
+a check that stops reaching its subject fails rather than passing on nothing.
+
+What they conclude rests on how ruff reads a search path, which is described
+here rather than consulted. ``tests/test_import_sorting_ruff.py`` puts that
+description to the tool itself, on a project built for the question, and runs
+in the tier that carries the real binary.
+
+Whether a clone at the root is read as a module follows the filesystem, since
+ruff looks the name up as a path: a case-folding filesystem answers to
+``MORS/`` for ``import mors`` and a case-sensitive one does not. The clone names
+are compared folded here, which matches the machines where the rewrite happens
+and is wider than the machines where it does not. The first-party list is a
+different matter and is compared as written, because ruff matches those names
+itself rather than through the filesystem.
 
 ``docs/Explanations/test_framework.md`` asks every check for an edge case and a
 path through the error contract, in wording written for the physics modules.
@@ -47,7 +59,15 @@ import pytest
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCANNED_ROOTS = (REPO_ROOT / 'src', REPO_ROOT / 'tests')
+
+# The directories holding Python this repository lints. The hook that rewrites
+# import groups reaches all of them rather than the two the checks run over, so
+# an ecosystem import added to any of them is one the scan should see.
+SCANNED_ROOTS = (REPO_ROOT / 'src', REPO_ROOT / 'tests', REPO_ROOT / 'tools')
+
+# Both suffixes the lint hook takes, since a stub carries imports and is sorted
+# exactly as a module is.
+PYTHON_SUFFIXES = ('*.py', '*.pyi')
 
 # Directories that belong to this repository rather than to a module beside it.
 REPO_OWN_DIRECTORIES = frozenset({'src', 'tests', 'tools', 'docs', 'examples', 'input'})
@@ -57,6 +77,11 @@ REPO_OWN_DIRECTORIES = frozenset({'src', 'tests', 'tools', 'docs', 'examples', '
 # scan reading module scope alone would lose.
 NESTED_ONLY_IMPORTS = frozenset({'mors', 'zephyrus'})
 
+# Ecosystem modules the configuration names only through an optional extra.
+# Neither the pinned clone list nor the base requirements reach them, so they
+# are what says that reading the extras is still part of the derivation.
+OPTIONAL_EXTRA_ONLY = frozenset({'vulcan'})
+
 
 def _read_config() -> dict:
     """Return the parsed ``pyproject.toml``."""
@@ -65,8 +90,15 @@ def _read_config() -> dict:
 
 @cache
 def _python_files() -> tuple[Path, ...]:
-    """Return every Python file under the scanned roots."""
-    return tuple(sorted(path for root in SCANNED_ROOTS for path in root.rglob('*.py')))
+    """Return every Python file under the scanned roots and at the root itself."""
+    found = {
+        path
+        for root in SCANNED_ROOTS
+        for suffix in PYTHON_SUFFIXES
+        for path in root.rglob(suffix)
+    }
+    found.update(path for suffix in PYTHON_SUFFIXES for path in REPO_ROOT.glob(suffix))
+    return tuple(sorted(found))
 
 
 @cache
@@ -215,9 +247,10 @@ def _entries_holding_a_module(entries: list[str], modules: frozenset[str]) -> li
     """Return the search path entries that a module could stand in.
 
     This is what makes a clone read as first party: not that an entry is the
-    root, but that a module stands inside it. ruff reads a directory and a bare
-    ``.py`` file alike as a module, so both count. An entry naming a directory
-    that is not there holds nothing and is left alone.
+    root, but that a module stands inside it. ruff reads a directory, a bare
+    ``.py`` file and a bare ``.pyi`` stub alike as a module, so all three count.
+    An entry naming a directory that is not there holds nothing and is left
+    alone.
     """
     holding = []
     for entry in entries:
@@ -227,7 +260,7 @@ def _entries_holding_a_module(entries: list[str], modules: frozenset[str]) -> li
         held = {
             child.name.lower() if child.is_dir() else child.stem.lower()
             for child in directory.iterdir()
-            if child.is_dir() or child.suffix == '.py'
+            if child.is_dir() or child.suffix in {'.py', '.pyi'}
         }
         if held & modules:
             holding.append(entry)
@@ -282,13 +315,18 @@ def test_no_ecosystem_module_is_declared_first_party():
     every machine, installed or not. That is the same misreading the search
     path guard prevents, reached by a shorter route.
 
+    The names are compared as written. ruff matches this list against the
+    imported name exactly, so ``Mors`` leaves ``import mors`` where it was and
+    only ``mors`` moves it, which holds whatever the filesystem does about
+    case. Folding here would report a spelling that changes nothing.
+
     Verifies:
     - This project is named first party, so the settings are being read at the
       key that decides the question rather than at one that no longer exists.
     - No ecosystem module is named alongside it.
     """
     lint = _read_config()['tool']['ruff'].get('lint', {})
-    first_party = {name.lower() for name in lint.get('isort', {}).get('known-first-party', [])}
+    first_party = set(lint.get('isort', {}).get('known-first-party', []))
 
     assert 'proteus' in first_party, (
         f'known-first-party is {sorted(first_party)} and does not name this project, so '
@@ -342,8 +380,9 @@ def test_a_path_entry_a_module_could_stand_in_is_reported(tmp_path):
     - An entry holding a module as a directory is reported, and the match
       ignores case, since the clone directories are capitalised and the module
       names are not.
-    - An entry holding a module as a bare ``.py`` file is reported too, which
-      is the other shape ruff reads as a module name.
+    - An entry holding a module as a bare ``.py`` file is reported too, and so
+      is one holding it as a bare ``.pyi`` stub, since ruff reads either as a
+      module name exactly as it reads a package directory.
     - An entry holding unrelated directories and files is not reported, so a
       path entry is not condemned for existing.
     - An entry naming a directory that is not there is not reported, so a
@@ -354,6 +393,9 @@ def test_a_path_entry_a_module_could_stand_in_is_reported(tmp_path):
     single = tmp_path / 'with_single_file'
     single.mkdir()
     (single / 'agni.py').write_text('', encoding='utf-8')
+    stubbed = tmp_path / 'with_stub'
+    stubbed.mkdir()
+    (stubbed / 'agni.pyi').write_text('', encoding='utf-8')
     plain = tmp_path / 'without_module'
     (plain / 'notes').mkdir(parents=True)
     (plain / 'notes.py').write_text('', encoding='utf-8')
@@ -366,6 +408,10 @@ def test_a_path_entry_a_module_could_stand_in_is_reported(tmp_path):
     assert _entries_holding_a_module([str(single)], modules) == [str(single)], (
         'a module standing as a single file was not seen inside a search path entry, and '
         'ruff reads that as a first-party name exactly as it reads a package directory'
+    )
+    assert _entries_holding_a_module([str(stubbed)], modules) == [str(stubbed)], (
+        'a module standing as a stub file was not seen inside a search path entry, and '
+        'ruff reads a bare .pyi as a first-party name just as it reads a .py'
     )
     assert _entries_holding_a_module([str(plain)], modules) == [], (
         'a search path entry holding nothing but unrelated names was reported, so the '
@@ -530,6 +576,15 @@ def test_the_modules_beside_the_source_are_the_ones_that_would_be_misread():
         f'{uncovered} are what says the scan reaches a nested import, but the '
         'configuration has stopped naming them as ecosystem modules, so they no longer '
         'say that the setting above covers a family rather than a single import'
+    )
+
+    # An extra is the only route to these, so they say the requirements are read
+    # past the ones installed by default rather than stopping at them.
+    from_extras = sorted(OPTIONAL_EXTRA_ONLY - declared)
+    assert not from_extras, (
+        f'{from_extras} are named only in an optional extra and the derivation no longer '
+        'reaches them, so a module installed through an extra can stand at the root '
+        'without the configuration accounting for it'
     )
 
     # A dependency that never stands at the root cannot collide, so finding one

--- a/tests/test_import_sorting_ruff.py
+++ b/tests/test_import_sorting_ruff.py
@@ -1,0 +1,227 @@
+"""Ask ruff itself how it decides that an import is first party.
+
+``tests/test_import_sorting_config.py`` reads the configuration and reasons
+about what ruff does with it, and everything it concludes rests on three
+behaviours of the tool: a directory standing in a search path entry names a
+first-party module, a bare module file does the same, and the first-party list
+is matched as written. A ruff release that changed any of them would leave
+every assertion over there green while the repository broke in the way that
+file exists to prevent.
+
+The checks here build a project for the question rather than reading the one
+around them, so nothing they report depends on which modules happen to be
+installed. They run the real binary, which puts them in the tier that does, and
+they fail rather than skip when it is absent: ruff is a requirement of this
+project rather than an optional tool, and a skipped check and a passing one
+read the same in a run log.
+
+References:
+  - docs/How-to/testing.md
+  - docs/Explanations/test_framework.md
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.timeout(60)]
+
+RUFF = shutil.which('ruff')
+
+PROBE = 'import mors\nimport os\nimport proteus\nimport requests\n'
+
+
+def _require_ruff() -> None:
+    """Fail with the reason rather than skipping when ruff is not installed."""
+    assert RUFF is not None, (
+        'ruff is not on PATH. It is a requirement of this project rather than an '
+        'optional tool, so its absence means the environment is incomplete; these '
+        'checks fail here rather than skipping, because a skip and a pass read the '
+        'same in a run log and these are the only checks that read the real tool'
+    )
+
+
+def _build_probe_project(root: Path) -> Path:
+    """Lay out a project holding a module beside the source and one inside it."""
+    (root / 'mors').mkdir()
+    (root / 'mors' / '__init__.py').write_text('', encoding='utf-8')
+    package = root / 'src' / 'proteus'
+    package.mkdir(parents=True)
+    (package / '__init__.py').write_text('', encoding='utf-8')
+    return package / 'probe.py'
+
+
+def _sorted_probe(
+    project: Path,
+    probe: Path,
+    search_path: list[str],
+    source: str = PROBE,
+    first_party: tuple[str, ...] = (),
+) -> tuple[list[list[str]], str]:
+    """Return the groups ruff sorts a probe into, and whatever it reported.
+
+    The configuration is written fresh each call, so two calls differ only in
+    what they are given. ruff sorts the probe in place and the blank lines it
+    leaves behind are the group boundaries. Anything it wrote to its error
+    stream comes back too, so a run that failed says why rather than arriving
+    as an unexplained grouping.
+    """
+    entries = ', '.join(f'"{entry}"' for entry in search_path)
+    isort = ''
+    if first_party:
+        names = ', '.join(f'"{name}"' for name in first_party)
+        isort = f'[tool.ruff.lint.isort]\nknown-first-party = [{names}]\n'
+    (project / 'pyproject.toml').write_text(
+        '[project]\nname = "probe"\nversion = "0"\n'
+        f'[tool.ruff]\nsrc = [{entries}]\n'
+        f'[tool.ruff.lint]\nselect = ["I"]\n{isort}',
+        encoding='utf-8',
+    )
+    probe.write_text(source, encoding='utf-8')
+    completed = subprocess.run(
+        [RUFF, 'check', '--no-cache', '--fix', '--quiet', str(probe)],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in probe.read_text(encoding='utf-8').splitlines():
+        if line.strip():
+            current.append(line.strip())
+        elif current:
+            blocks.append(current)
+            current = []
+    if current:
+        blocks.append(current)
+    return blocks, completed.stderr.strip()
+
+
+def _block_holding(blocks: list[list[str]], name: str) -> list[str]:
+    """Return the group holding ``name``, or an empty group if none does."""
+    return next((block for block in blocks if f'import {name}' in block), [])
+
+
+def _assert_ruff_sorted(blocks: list[list[str]], reported: str, label: str) -> None:
+    """Fail unless ruff rearranged the probe, so a grouping below means something."""
+    assert _block_holding(blocks, 'os') == ['import os'], (
+        f'with {label}, ruff left the standard library import beside the others, so it '
+        f'did not sort the probe and the grouping read from it says nothing. Groups: '
+        f'{blocks}. ruff reported: {reported or "nothing"}'
+    )
+
+
+def test_ruff_reads_a_module_beside_the_source_as_first_party(tmp_path):
+    """A clone standing in a searched directory is read as part of this project.
+
+    Contract clause: the ecosystem modules are installed beside the source, so
+    a search path that reaches them makes their imports sort into the group
+    that holds this project. Keeping the path off the root is what prevents it,
+    and that is only true while ruff still behaves this way.
+
+    Verifies:
+    - ruff sorts the probe at all, under both search paths, which is what says
+      the groupings below describe its reading rather than an untouched file.
+    - With the root searched, the module beside the source joins the group that
+      holds the package standing inside it.
+    - With the source tree alone searched, it does not.
+    """
+    _require_ruff()
+    probe = _build_probe_project(tmp_path)
+
+    searched, searched_report = _sorted_probe(tmp_path, probe, ['.', 'src'])
+    _assert_ruff_sorted(searched, searched_report, 'the root searched')
+    source_only, source_report = _sorted_probe(tmp_path, probe, ['src'])
+    _assert_ruff_sorted(source_only, source_report, 'the source tree alone searched')
+
+    assert 'import proteus' in _block_holding(searched, 'mors'), (
+        'with the repository root on the import search path, ruff no longer sorts a '
+        'module standing beside the source into this project, so the misreading the '
+        'configuration guards against has stopped reproducing'
+    )
+    assert 'import proteus' not in _block_holding(source_only, 'mors'), (
+        'with the source tree alone searched, ruff still sorts a module standing beside '
+        'it into this project, so keeping the root off the search path is no longer '
+        'enough to prevent the misreading'
+    )
+
+
+def test_ruff_matches_the_first_party_list_as_written(tmp_path):
+    """The first-party list is compared by spelling, not by fold.
+
+    Contract clause: the configuration check reads ``known-first-party`` and
+    reports an ecosystem module named there. It compares the names as written,
+    which is only right while ruff does the same; were ruff to fold case, a
+    module named in another spelling would sort with this project and go
+    unreported.
+
+    Verifies:
+    - A name spelled exactly as the imported module moves that import into the
+      group holding this project.
+    - The same name in another case leaves it where it was, so the spelling is
+      what decides and a fold would be reporting something that changes
+      nothing.
+    """
+    _require_ruff()
+    probe = _build_probe_project(tmp_path)
+
+    exact, exact_report = _sorted_probe(tmp_path, probe, ['src'], first_party=('mors',))
+    _assert_ruff_sorted(exact, exact_report, 'the module named as written')
+    folded, folded_report = _sorted_probe(tmp_path, probe, ['src'], first_party=('Mors',))
+    _assert_ruff_sorted(folded, folded_report, 'the module named in another case')
+
+    assert 'import proteus' in _block_holding(exact, 'mors'), (
+        'naming a module in known-first-party no longer sorts its imports with this '
+        'project, so the configuration check is reading a setting that has stopped '
+        'deciding anything'
+    )
+    assert 'import proteus' not in _block_holding(folded, 'mors'), (
+        'ruff now matches known-first-party without regard to case, so the configuration '
+        'check has to fold the names it reads or it will pass over a module named in a '
+        'spelling that does sort with this project'
+    )
+
+
+def test_ruff_reads_a_bare_module_file_as_first_party(tmp_path):
+    """A module standing as a single file counts as one standing as a directory.
+
+    Contract clause: the check that looks for a module inside a search path
+    entry counts a directory, a ``.py`` file and a ``.pyi`` stub alike. That is
+    only worth doing while ruff reads all three as module names.
+
+    Verifies:
+    - A bare ``.py`` file in a searched directory sorts its import into the
+      group that holds this project.
+    - A bare ``.pyi`` stub does the same, so the stub shape is not a gap.
+    - Neither is read that way once the directory holding them is off the
+      search path, so the file is what carries the name rather than something
+      else about the project.
+    """
+    _require_ruff()
+    probe = _build_probe_project(tmp_path)
+    (tmp_path / 'filemodule.py').write_text('', encoding='utf-8')
+    (tmp_path / 'stubmodule.pyi').write_text('value: int\n', encoding='utf-8')
+    source = 'import filemodule\nimport os\nimport proteus\nimport stubmodule\n'
+
+    searched, searched_report = _sorted_probe(tmp_path, probe, ['.', 'src'], source=source)
+    _assert_ruff_sorted(searched, searched_report, 'the root searched')
+    source_only, source_report = _sorted_probe(tmp_path, probe, ['src'], source=source)
+    _assert_ruff_sorted(source_only, source_report, 'the source tree alone searched')
+
+    assert 'import proteus' in _block_holding(searched, 'filemodule'), (
+        'a module standing as a single file in a searched directory is no longer read as '
+        'part of this project, so looking for one is guarding against nothing'
+    )
+    assert 'import proteus' in _block_holding(searched, 'stubmodule'), (
+        'a module standing as a stub file in a searched directory is no longer read as '
+        'part of this project, so counting stubs is guarding against nothing'
+    )
+    assert 'import proteus' not in _block_holding(source_only, 'filemodule'), (
+        'a module file outside every search path entry is still read as part of this '
+        'project, so which directories are searched has stopped deciding the question'
+    )

--- a/tests/test_import_sorting_ruff.py
+++ b/tests/test_import_sorting_ruff.py
@@ -1,19 +1,40 @@
 """Ask ruff itself how it decides that an import is first party.
 
 ``tests/test_import_sorting_config.py`` reads the configuration and reasons
-about what ruff does with it, and everything it concludes rests on three
-behaviours of the tool: a directory standing in a search path entry names a
-first-party module, a bare module file does the same, and the first-party list
-is matched as written. A ruff release that changed any of them would leave
-every assertion over there green while the repository broke in the way that
-file exists to prevent.
+about what ruff does with it, and what it concludes rests on how ruff reads a
+search path: a directory standing in a searched entry names a first-party
+module whether or not it holds an ``__init__.py``, a bare module file or stub
+does the same, an entry reaching the root by an oblique spelling reaches it,
+and the first-party list is matched as written. Those are the shapes
+``_entries_holding_a_module`` and ``_entries_on_the_repository_root`` count
+over there, and they are pinned against the tool here.
 
-The checks here build a project for the question rather than reading the one
-around them, so nothing they report depends on which modules happen to be
-installed. They run the real binary, which puts them in the tier that does, and
-they fail rather than skip when it is absent: ruff is a requirement of this
-project rather than an optional tool, and a skipped check and a passing one
-read the same in a run log.
+Three ruffs meet this repository and none is coordinated with the others. The
+one that rewrites import groups belongs to the pre-commit hook and is held at a
+pinned revision in ``.pre-commit-config.yaml``. The one that rejects the
+rewrite belongs to the checks and is installed unpinned. The one resolved here
+is whatever ``ruff`` stands on the path, which this project requires without
+pinning. So what these checks read is a real ruff rather than the one doing the
+rewriting, which is deliberate: reaching for the hook's binary would tie this
+file to the hook's internals.
+
+They belong to the nightly tier rather than the pull request checks, because
+they carry a real binary. A change in how ruff reads a search path therefore
+surfaces within a day of the release that brings it rather than on the pull
+request that installs it.
+
+Each check builds its own project, so nothing it reports depends on which
+modules are installed. That project carries its own ``pyproject.toml`` above
+the probe, which is what ruff reads, and the environment handed to it is
+stripped of the home and configuration paths as well, so a setting belonging to
+whoever runs the checks cannot reach the probe. Whether a directory is matched
+with regard to case is left out: ruff looks the name up as a path, so the
+answer follows the filesystem, and an assertion about a capitalised directory
+would hold on a case-folding machine and fail on a case-sensitive one.
+
+They fail rather than skip when ruff is absent, since it is a requirement of
+this project rather than an optional tool, and a skipped check and a passing
+one read the same in a run log.
 
 References:
   - docs/How-to/testing.md
@@ -22,6 +43,7 @@ References:
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -69,6 +91,9 @@ def _sorted_probe(
     leaves behind are the group boundaries. Anything it wrote to its error
     stream comes back too, so a run that failed says why rather than arriving
     as an unexplained grouping.
+
+    The home and configuration paths are pointed inside the project, so the
+    only settings ruff can reach are the ones written here.
     """
     entries = ', '.join(f'"{entry}"' for entry in search_path)
     isort = ''
@@ -82,12 +107,14 @@ def _sorted_probe(
         encoding='utf-8',
     )
     probe.write_text(source, encoding='utf-8')
+    sandboxed = project / 'settings_of_no_one'
     completed = subprocess.run(
         [RUFF, 'check', '--no-cache', '--fix', '--quiet', str(probe)],
         cwd=project,
         capture_output=True,
         text=True,
         check=False,
+        env={**os.environ, 'HOME': str(sandboxed), 'XDG_CONFIG_HOME': str(sandboxed)},
     )
     blocks: list[list[str]] = []
     current: list[str] = []
@@ -125,11 +152,16 @@ def test_ruff_reads_a_module_beside_the_source_as_first_party(tmp_path):
     and that is only true while ruff still behaves this way.
 
     Verifies:
-    - ruff sorts the probe at all, under both search paths, which is what says
-      the groupings below describe its reading rather than an untouched file.
+    - ruff sorts the probe at all, under every search path read, which is what
+      says the groupings below describe its reading rather than an untouched
+      file.
     - With the root searched, the module beside the source joins the group that
       holds the package standing inside it.
     - With the source tree alone searched, it does not.
+    - An entry that arrives at the root by climbing back out of the source tree
+      reaches it as surely as the bare dot does, which is the reading the
+      configuration check takes when it resolves an entry rather than comparing
+      how it is spelled.
     """
     _require_ruff()
     probe = _build_probe_project(tmp_path)
@@ -138,6 +170,8 @@ def test_ruff_reads_a_module_beside_the_source_as_first_party(tmp_path):
     _assert_ruff_sorted(searched, searched_report, 'the root searched')
     source_only, source_report = _sorted_probe(tmp_path, probe, ['src'])
     _assert_ruff_sorted(source_only, source_report, 'the source tree alone searched')
+    oblique, oblique_report = _sorted_probe(tmp_path, probe, ['src/..', 'src'])
+    _assert_ruff_sorted(oblique, oblique_report, 'the root reached obliquely')
 
     assert 'import proteus' in _block_holding(searched, 'mors'), (
         'with the repository root on the import search path, ruff no longer sorts a '
@@ -148,6 +182,11 @@ def test_ruff_reads_a_module_beside_the_source_as_first_party(tmp_path):
         'with the source tree alone searched, ruff still sorts a module standing beside '
         'it into this project, so keeping the root off the search path is no longer '
         'enough to prevent the misreading'
+    )
+    assert 'import proteus' in _block_holding(oblique, 'mors'), (
+        'an entry climbing back out of the source tree no longer reaches the repository '
+        'root, so resolving an entry rather than reading its spelling reports a hazard '
+        'ruff would not act on'
     )
 
 
@@ -198,15 +237,22 @@ def test_ruff_reads_a_bare_module_file_as_first_party(tmp_path):
     - A bare ``.py`` file in a searched directory sorts its import into the
       group that holds this project.
     - A bare ``.pyi`` stub does the same, so the stub shape is not a gap.
-    - Neither is read that way once the directory holding them is off the
-      search path, so the file is what carries the name rather than something
-      else about the project.
+    - A directory carrying no ``__init__.py`` does the same, which is the
+      breadth the configuration check takes when it counts every directory
+      standing in an entry rather than only the ones laid out as packages.
+    - None of them is read that way once the directory holding them is off the
+      search path, so what carries the name is the entry being searched rather
+      than something else about the project.
     """
     _require_ruff()
     probe = _build_probe_project(tmp_path)
     (tmp_path / 'filemodule.py').write_text('', encoding='utf-8')
     (tmp_path / 'stubmodule.pyi').write_text('value: int\n', encoding='utf-8')
-    source = 'import filemodule\nimport os\nimport proteus\nimport stubmodule\n'
+    (tmp_path / 'baredirectory').mkdir()
+    source = (
+        'import baredirectory\nimport filemodule\nimport os\n'
+        'import proteus\nimport stubmodule\n'
+    )
 
     searched, searched_report = _sorted_probe(tmp_path, probe, ['.', 'src'], source=source)
     _assert_ruff_sorted(searched, searched_report, 'the root searched')
@@ -220,6 +266,11 @@ def test_ruff_reads_a_bare_module_file_as_first_party(tmp_path):
     assert 'import proteus' in _block_holding(searched, 'stubmodule'), (
         'a module standing as a stub file in a searched directory is no longer read as '
         'part of this project, so counting stubs is guarding against nothing'
+    )
+    assert 'import proteus' in _block_holding(searched, 'baredirectory'), (
+        'a directory carrying no __init__.py in a searched directory is no longer read '
+        'as part of this project, so counting every directory rather than the ones laid '
+        'out as packages reports a hazard ruff would not act on'
     )
     assert 'import proteus' not in _block_holding(source_only, 'filemodule'), (
         'a module file outside every search path entry is still read as part of this '


### PR DESCRIPTION
## Description

ruff decides whether an import is first party by searching for the name, and by default it searches the repository root as well as the source tree. The ecosystem modules are installed as clones at that root, so on a machine that has one, the name is found there and the module is read as part of this project: its imports move into the group that holds `proteus`. The lint hook runs `ruff check --fix`, so it rewrites the groups of any file it touches, and the rewrite it commits is what the checks then reject, because the machine running them carries no clone. On macOS the collision is wider than it looks, since the filesystem is case-insensitive and `BOREAS` therefore answers to `boreas`.

Setting the search to the source tree alone covers every module at once rather than one name at a time. With it, `boreas`, `calliope`, `janus`, `mors`, `vulcan` and `zephyrus` all sort as dependencies, which is what they are; `aragog`, `atmodeller` and `zalmoxis` already did, through the pins that are unchanged here.

Narrowing the search leaves the `tests` package outside it, but every file that imports the package by name sits inside it, and ruff reads a file's own package as first party without being told, so nothing sorts differently.

## Validation of changes

ruff caches per file content and settings, and creating or removing a sibling directory changes neither, so every check below was run with `--no-cache`; a cached run returns a stale verdict here.

- Before the change, with the clones present, `ruff check --no-cache src/ tests/` reports 3 errors in `tests/escape/test_escape_boreas.py`; after it, all checks pass
- The round trip no longer inverts: `--fix` on a machine carrying the clones leaves that file byte-unchanged
- Probe files confirm all nine ecosystem modules sort as third party afterwards, while `proteus` stays first party
- Adding the sibling directories to the search instead is not an alternative: pointing it at `tests` as well finds the bare-name helpers and moves 32 other imports
- The `tests` package sorts identically with and without an explicit pin, checked from inside a real package, so no pin was added

The accompanying test asserts the root is not searched, and separately that the modules which can appear there are imported, so it cannot pass by guarding nothing. Its at-risk set is derived from the clone pins and the `fwl-*` distributions rather than from a fixed list, covering eight modules, and it drops standard-library names so `fwl-io` does not become `io`. Removing the setting, or putting the root back on the search path, each fails the test and brings the same 3 errors back.

Test configuration: macOS 15 (Apple silicon), Python 3.12, with the AGNI, aragog, BOREAS, CALLIOPE, JANUS, MORS, SPIDER, socrates, VULCAN, Zalmoxis and ZEPHYRUS clones present at the repository root.

- Unit tier: 2944 passed, 7 skipped
- `ruff check --no-cache src/ tests/ tools/ conftest.py` and `ruff format --check src/ tests/` clean
- `bash tools/validate_test_structure.sh` clean

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

