### PR TITLE
Recover from a rejected atmosphere profile and end a run that never converges

### DIFF
--- a/docs/Explanations/coupling_loop.md
+++ b/docs/Explanations/coupling_loop.md
@@ -142,6 +142,7 @@ consecutive iterations (if `params.stop.strict = true`) or one iteration
 | Radiative equilibrium | `params.stop.radeqm` | $\|F_\mathrm{int} - F_\mathrm{atm}\|$ within tolerance |
 | Atmosphere loss | `params.stop.escape` | Surface pressure below `p_stop` |
 | Disintegration | `params.stop.disint` | Planet inside Roche limit or spinning beyond breakup |
+| Unconverged atmosphere | none, always active | 150 consecutive iterations without a converged atmosphere solve |
 
 ## Mass conservation
 
@@ -208,8 +209,13 @@ branches) always report convergence and are unaffected.
 Each warning counts the consecutive iterations whose levels the run did not
 resolve itself, the ones with nothing to fall back on included, and past ten in a
 row the run reports it at error level. A streak that long means the interior is
-evolving while the levels stand still, which the deadlock detector above cannot
-catch: it fires only when the interior has stopped moving too.
+evolving while the levels stand still, which the deadlock detector above does not
+see, since it fires only when the interior has stopped moving too. A separate
+limit covers it: after 150 consecutive iterations without a converged atmosphere
+the run ends, whatever the interior is doing. The two are sized for different
+things, so the frozen-interior detector still fires at three iterations when
+neither side is moving, and the longer count only ends a run whose atmosphere
+never comes back on its own.
 
 Two helpfile columns persist the outcome, so a carried row is identifiable from
 the output alone: `atm_converged` records the solve outcome of each row (+1

--- a/docs/Reference/config/params.md
+++ b/docs/Reference/config/params.md
@@ -131,3 +131,16 @@ to be satisfied for two consecutive iterations before terminating.
 | `offset_roche` | float | `0` | Correction to Roche limit \[m] |
 | `spin_enabled` | bool | `true` | Check rotational breakup |
 | `offset_spin` | float | `0` | Correction to breakup period \[s] |
+
+### Unconverged atmosphere `[params.stop.stall]`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enabled` | bool | `true` | Terminate when the atmosphere stops converging |
+| `maximum` | int | `150` | Stop after this many consecutive iterations without a converged atmosphere solve |
+
+The default is measured rather than chosen. Across 27 stalled cases the deepest
+streak a run recovered from is 126 consecutive rejected solves, and the deepest
+streak that never converged is 233. Raising `maximum` past the second defeats
+the criterion, and lowering it below the first ends runs that would have come
+back on their own.

--- a/input/all_options.toml
+++ b/input/all_options.toml
@@ -98,6 +98,10 @@ config_version = "3.0"
             spin_enabled      = true         # check rotational breakup
             offset_spin       = 0            # correction to breakup period [s]
 
+        [params.stop.stall]                  # unconverged atmosphere criterion
+            enabled           = true
+            maximum           = 150          # stop after this many consecutive iterations without a converged atmosphere
+
 # ----------------------------------------------------
 
 # Bulk planet properties, initial temperature, and volatile inventory

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -681,28 +681,48 @@ def init_agni_atmos(dirs: dict, config: Config, hf_row: dict):
 
     # Otherwise, set profile initial guess
     else:
-        # do as requested by user in the config
-        log.info(f'Initialising T(p) as {config.atmos_clim.agni.ini_profile}')
-        match config.atmos_clim.agni.ini_profile:
-            case 'loglinear':
-                jl.AGNI.setpt.loglinear_b(atmos, -0.5 * hf_row['T_surf'])
-            case 'isothermal':
-                jl.AGNI.setpt.isothermal_b(atmos, hf_row['T_surf'])
-            case 'dry_adiabat':
-                jl.AGNI.setpt.dry_adiabat_b(atmos)
-            case 'analytic':
-                jl.AGNI.setpt.analytic_b(atmos)
-            case _:
-                UpdateStatusfile(dirs, 20)
-                raise ValueError('Invalid initial T(p) profile selected')
-
-        # lower-limit on initial profile
-        jl.AGNI.setpt.stratosphere_b(atmos, min(400.0, hf_row['T_surf']))
+        _set_guess_profile(atmos, hf_row, dirs, config)
 
     # Logging
     sync_log_files(dirs['output'])
 
     return atmos
+
+
+def _set_guess_profile(atmos, hf_row: dict, dirs: dict, config: Config):
+    """Set the temperature profile to the initial guess requested in the config.
+
+    The guess is anchored on the surface boundary condition, so it needs no
+    usable temperature structure on the struct beforehand.
+
+    Parameters
+    ----------
+        atmos : AGNI.atmosphere.Atmos_t
+            AGNI atmosphere struct, with its pressure grid already generated
+        hf_row : dict
+            Dictionary containing simulation variables for current iteration
+        dirs : dict
+            Directories dictionary
+        config: Config
+            PROTEUS config object
+    """
+
+    log.info(f'Initialising T(p) as {config.atmos_clim.agni.ini_profile}')
+    match config.atmos_clim.agni.ini_profile:
+        case 'loglinear':
+            jl.AGNI.setpt.loglinear_b(atmos, -0.5 * hf_row['T_surf'])
+        case 'isothermal':
+            jl.AGNI.setpt.isothermal_b(atmos, hf_row['T_surf'])
+        case 'dry_adiabat':
+            jl.AGNI.setpt.dry_adiabat_b(atmos)
+        case 'analytic':
+            jl.AGNI.setpt.analytic_b(atmos)
+        case _:
+            UpdateStatusfile(dirs, 20)
+            raise ValueError('Invalid initial T(p) profile selected')
+
+    # lower-limit on initial profile
+    jl.AGNI.setpt.stratosphere_b(atmos, min(400.0, hf_row['T_surf']))
 
 
 def deallocate_atmos(atmos):
@@ -711,6 +731,116 @@ def deallocate_atmos(atmos):
     """
     jl.AGNI.atmosphere.deallocate_b(atmos)
     safe_rm(str(atmos.fastchem_work))
+
+
+def _check_stored_profile(p_old, t_old) -> tuple[bool, str]:
+    """Check that the profile held on the struct can be interpolated.
+
+    The interpolation onto the new pressure grid takes the base-10 logarithm
+    of the stored pressures, so a pressure that is not finite and positive
+    aborts the run inside scipy. A temperature that is not finite and positive
+    is carried into the new profile and poisons the next solve.
+
+    Parameters
+    ----------
+        p_old : array_like
+            Cell-centre pressures held on the struct [Pa]
+        t_old : array_like
+            Cell-centre temperatures held on the struct [K]
+
+    Returns
+    -------
+        usable : bool
+            True if the profile can be interpolated onto a new grid.
+        reason : str
+            Empty string if usable, otherwise which quantity went bad.
+    """
+
+    p_arr = np.asarray(p_old, dtype=float)
+    t_arr = np.asarray(t_old, dtype=float)
+
+    if p_arr.size == 0 or t_arr.size == 0:
+        return False, 'the stored profile is empty'
+
+    if p_arr.size != t_arr.size:
+        return False, (
+            f'the stored profile holds {p_arr.size} pressures for {t_arr.size} temperatures'
+        )
+
+    n_bad = int(np.sum(~np.isfinite(p_arr)))
+    if n_bad:
+        return False, f'atmos.p holds {n_bad} non-finite value(s)'
+
+    n_bad = int(np.sum(p_arr <= 0.0))
+    if n_bad:
+        return False, f'atmos.p holds {n_bad} value(s) <= 0 Pa'
+
+    n_bad = int(np.sum(~np.isfinite(t_arr)))
+    if n_bad:
+        return False, f'atmos.tmp holds {n_bad} non-finite value(s)'
+
+    n_bad = int(np.sum(t_arr <= 0.0))
+    if n_bad:
+        return False, f'atmos.tmp holds {n_bad} value(s) <= 0 K'
+
+    return True, ''
+
+
+def _rebuild_agni_profile(atmos, hf_row: dict, dirs: dict, config: Config, reason: str):
+    """Discard the profile held on the struct and set the initial guess again.
+
+    Used when the stored profile cannot be interpolated onto the new pressure
+    grid. The surface boundary condition is all the guess needs, so the run
+    continues from a clean structure; a boundary condition that is itself
+    unusable ends the run as an atmosphere failure.
+
+    Parameters
+    ----------
+        atmos : AGNI.atmosphere.Atmos_t
+            AGNI atmosphere struct
+        hf_row : dict
+            Dictionary containing simulation variables for current iteration
+        dirs : dict
+            Directories dictionary
+        config: Config
+            PROTEUS config object
+        reason : str
+            Which quantity on the stored profile went bad
+
+    Returns
+    -------
+        atmos : AGNI.atmosphere.Atmos_t
+            Atmosphere struct carrying the new guess profile
+    """
+
+    log.warning('Cannot use the stored temperature profile: %s', reason)
+
+    t_surf = float(hf_row['T_surf'])
+    p_surf = float(hf_row['P_surf'])
+
+    if not np.isfinite(t_surf) or t_surf <= 0.0:
+        UpdateStatusfile(dirs, 22)
+        raise RuntimeError(
+            f'Cannot rebuild the temperature profile ({reason}) because T_surf = {t_surf} K'
+        )
+
+    if not np.isfinite(p_surf) or p_surf <= 0.0:
+        UpdateStatusfile(dirs, 22)
+        raise RuntimeError(
+            f'Cannot rebuild the temperature profile ({reason}) because P_surf = {p_surf} bar'
+        )
+
+    log.warning('Rebuilding it from the surface boundary condition')
+
+    # Same grid update as the interpolated path, done here because the guess
+    # routines write onto the new grid
+    atmos.p_oboa = 1.0e5 * p_surf
+    atmos.p_boa = atmos.p_oboa
+    jl.AGNI.atmosphere.generate_pgrid_b(atmos)
+
+    _set_guess_profile(atmos, hf_row, dirs, config)
+
+    return atmos
 
 
 def update_agni_atmos(atmos, hf_row: dict, dirs: dict, config: Config):
@@ -770,6 +900,13 @@ def update_agni_atmos(atmos, hf_row: dict, dirs: dict, config: Config):
     # Store old/current log-pressure vs temperature arrays
     p_old = list(atmos.p)  # pascals
     t_old = list(atmos.tmp)
+
+    # A solve that was rejected can leave a profile that cannot be
+    # interpolated, so rebuild it from the surface boundary condition instead.
+    usable, reason = _check_stored_profile(p_old, t_old)
+    if not usable:
+        return _rebuild_agni_profile(atmos, hf_row, dirs, config, reason)
+
     nlev_c = len(p_old)
 
     #    extend to lower pressures

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -733,13 +733,15 @@ def deallocate_atmos(atmos):
     safe_rm(str(atmos.fastchem_work))
 
 
-def _check_stored_profile(p_old, t_old) -> tuple[bool, str]:
+def _validate_stored_profile(p_old, t_old) -> tuple[bool, str]:
     """Check that the profile held on the struct can be interpolated.
 
-    The interpolation onto the new pressure grid takes the base-10 logarithm
-    of the stored pressures, so a pressure that is not finite and positive
-    aborts the run inside scipy. A temperature that is not finite and positive
-    is carried into the new profile and poisons the next solve.
+    The interpolation onto the new pressure grid takes the base-10 logarithm of
+    the stored pressures, so pressures that are not finite, positive and rising
+    with depth abort the run inside scipy. A temperature that is not finite and
+    positive is carried into the new profile and poisons the next solve. The
+    arrays are taken directly rather than read off the struct, because the
+    caller has already materialised them for the interpolation itself.
 
     Parameters
     ----------
@@ -774,6 +776,10 @@ def _check_stored_profile(p_old, t_old) -> tuple[bool, str]:
     n_bad = int(np.sum(p_arr <= 0.0))
     if n_bad:
         return False, f'atmos.p holds {n_bad} value(s) <= 0 Pa'
+
+    n_bad = int(np.sum(np.diff(p_arr) <= 0.0))
+    if n_bad:
+        return False, f'atmos.p stops rising with depth at {n_bad} level(s)'
 
     n_bad = int(np.sum(~np.isfinite(t_arr)))
     if n_bad:
@@ -832,15 +838,28 @@ def _rebuild_agni_profile(atmos, hf_row: dict, dirs: dict, config: Config, reaso
 
     log.warning('Rebuilding it from the surface boundary condition')
 
-    # Same grid update as the interpolated path, done here because the guess
-    # routines write onto the new grid
-    atmos.p_oboa = 1.0e5 * p_surf
-    atmos.p_boa = atmos.p_oboa
-    jl.AGNI.atmosphere.generate_pgrid_b(atmos)
+    # The guess routines write onto the new grid, so lay it down first
+    _apply_surface_pressure(atmos, p_surf)
 
     _set_guess_profile(atmos, hf_row, dirs, config)
 
     return atmos
+
+
+def _apply_surface_pressure(atmos, p_surf: float):
+    """Move the bottom of the atmosphere to the surface and regrid onto it.
+
+    Parameters
+    ----------
+        atmos : AGNI.atmosphere.Atmos_t
+            AGNI atmosphere struct
+        p_surf : float
+            Surface pressure [bar]
+    """
+
+    atmos.p_oboa = 1.0e5 * float(p_surf)
+    atmos.p_boa = atmos.p_oboa
+    jl.AGNI.atmosphere.generate_pgrid_b(atmos)
 
 
 def update_agni_atmos(atmos, hf_row: dict, dirs: dict, config: Config):
@@ -903,7 +922,7 @@ def update_agni_atmos(atmos, hf_row: dict, dirs: dict, config: Config):
 
     # A solve that was rejected can leave a profile that cannot be
     # interpolated, so rebuild it from the surface boundary condition instead.
-    usable, reason = _check_stored_profile(p_old, t_old)
+    usable, reason = _validate_stored_profile(p_old, t_old)
     if not usable:
         return _rebuild_agni_profile(atmos, hf_row, dirs, config, reason)
 
@@ -921,10 +940,8 @@ def update_agni_atmos(atmos, hf_row: dict, dirs: dict, config: Config):
     itp = PchipInterpolator(np.log10(p_old), t_old)
 
     # ---------------------
-    # Update surface pressure [Pa] and generate new grid
-    atmos.p_oboa = 1.0e5 * float(hf_row['P_surf'])
-    atmos.p_boa = atmos.p_oboa
-    jl.AGNI.atmosphere.generate_pgrid_b(atmos)
+    # Update surface pressure and generate new grid
+    _apply_surface_pressure(atmos, hf_row['P_surf'])
 
     # ---------------------
     # Set temperatures at all levels

--- a/src/proteus/atmos_clim/agni.py
+++ b/src/proteus/atmos_clim/agni.py
@@ -792,6 +792,51 @@ def _validate_stored_profile(p_old, t_old) -> tuple[bool, str]:
     return True, ''
 
 
+def _validate_surface_state(hf_row: dict, dirs: dict):
+    """End the run if the surface boundary condition cannot be used.
+
+    Checking the stored profile is not enough on its own: a healthy profile
+    carried alongside a surface state an upstream failure has spoiled passes
+    that check and then reaches the interpolation, where a non-finite surface
+    pressure sets the top of the pressure grid and raises inside scipy. The
+    temperatures reach the solver instead, which starts from a value that is
+    not a temperature. Every comparison against a value that is not a number
+    is false, so each quantity is tested rather than compared.
+
+    Zero means different things either side of the boundary condition. A
+    temperature of zero is not a temperature, but a surface pressure of zero
+    is a planet that has lost its atmosphere, which transparent mode below
+    handles and which desiccation produces deliberately. Pressure is therefore
+    held to being finite and non-negative, and only the temperatures to being
+    positive.
+
+    Parameters
+    ----------
+        hf_row : dict
+            Dictionary containing simulation variables for current iteration
+        dirs : dict
+            Directories dictionary
+
+    Raises
+    ------
+        RuntimeError
+            If a temperature is not finite and positive, or the surface
+            pressure is not finite and non-negative.
+    """
+
+    checks = (
+        ('T_surf', 'K', False),
+        ('T_magma', 'K', False),
+        ('P_surf', 'bar', True),
+    )
+    for name, unit, zero_ok in checks:
+        value = float(hf_row[name])
+        bad = value < 0.0 if zero_ok else value <= 0.0
+        if not np.isfinite(value) or bad:
+            UpdateStatusfile(dirs, 22)
+            raise RuntimeError(f'Cannot update the atmosphere because {name} = {value} {unit}')
+
+
 def _rebuild_agni_profile(atmos, hf_row: dict, dirs: dict, config: Config, reason: str):
     """Discard the profile held on the struct and set the initial guess again.
 
@@ -899,6 +944,7 @@ def update_agni_atmos(atmos, hf_row: dict, dirs: dict, config: Config):
 
     # ---------------------
     # Update surface temperature(s)
+    _validate_surface_state(hf_row, dirs)
     atmos.tmp_surf = float(hf_row['T_surf'])
     atmos.tmp_magma = float(hf_row['T_magma'])
 

--- a/src/proteus/config/_params.py
+++ b/src/proteus/config/_params.py
@@ -321,6 +321,27 @@ class StopClock:
 
 
 @define
+class StopStall:
+    """Parameters for the unconverged-atmosphere stopping criteria.
+
+    Attributes
+    ----------
+    enabled: bool
+        Enable criteria if True
+    maximum: int
+        Model will terminate after this many consecutive iterations without a
+        converged atmosphere solve, whatever the interior is doing. Sized on 27
+        stalled GJ 9827 d cases as they stood on 2026-08-08: the deepest streak
+        a run recovered from is 126 and the deepest open one, which never
+        converged, is 233. Raising it past the open streak defeats the
+        criterion; lowering it below the recovered one ends runs that come back.
+    """
+
+    enabled: bool = field(default=True)
+    maximum: int = field(default=150, validator=gt(0))
+
+
+@define
 class StopParams:
     """Parameters for termination criteria.
 
@@ -342,6 +363,8 @@ class StopParams:
         Parameters for planet disintegration criteria.
     clock: StopClock
         Parameters for maximum clock runtime criteria.
+    stall: StopStall
+        Parameters for the unconverged-atmosphere criteria.
     """
 
     iters: StopIters = field(factory=StopIters)
@@ -351,6 +374,7 @@ class StopParams:
     escape: StopEscape = field(factory=StopEscape)
     disint: StopDisint = field(factory=StopDisint)
     clock: StopClock = field(factory=StopClock)
+    stall: StopStall = field(factory=StopStall)
 
     strict: bool = field(default=False)
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -46,10 +46,10 @@ from proteus.utils.logs import (
 _IT_TIMING_ENABLED = os.environ.get('PROTEUS_TIMING', '').lower() in ('1', 'true', 'yes', 'on')
 
 # Consecutive iterations without a converged atmosphere after which a run ends,
-# whatever the interior is doing. Measured over 27 stalled cases: the deepest
-# stall a run recovered from is 126 iterations and the deepest seen is 233, so
-# this sits above the first with margin. It has to stay above the streak the
-# atmosphere wrapper reports at error level.
+# whatever the interior is doing, and always above the streak the atmosphere
+# wrapper reports at error level. Sized on 27 stalled GJ 9827 d cases as they
+# stood on 2026-08-08: deepest recovered streak 126, deepest open streak 233,
+# which never converged. This clears the recovery and stays under the open one.
 ATMOS_STALL_MAX = 150
 
 # Consecutive iterations of a failed atmosphere solve on an interior that has

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -134,8 +134,12 @@ class Proteus:
         self.hf_all = None
 
         # Caps on the two abort paths. Fixed for the run rather than reset per
-        # start, unlike the counters they are compared with.
-        self.atmos_stall_max = ATMOS_STALL_MAX
+        # start, unlike the counters they are compared with. The stall cap is a
+        # stop criterion like the seven beside it, so the config carries it and
+        # the constant is only the default that config field already holds.
+        stall_cfg = getattr(self.config.params.stop, 'stall', None)
+        self.atmos_stall_enabled = True if stall_cfg is None else bool(stall_cfg.enabled)
+        self.atmos_stall_max = ATMOS_STALL_MAX if stall_cfg is None else int(stall_cfg.maximum)
         self.agni_deadlock_max = AGNI_DEADLOCK_MAX
 
         # Loop counters
@@ -229,7 +233,7 @@ class Proteus:
             return
 
         stalled = int(self.atmos_o.levels_stale_iters)
-        if stalled >= self.atmos_stall_max:
+        if self.atmos_stall_enabled and stalled >= self.atmos_stall_max:
             log.error(
                 'Atmosphere has not converged for %d consecutive iterations, so escape '
                 'and the observables are running on a structure this run never resolved. '

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -51,6 +51,11 @@ _IT_TIMING_ENABLED = os.environ.get('PROTEUS_TIMING', '').lower() in ('1', 'true
 # while still recovers on its own before anything gives up on it.
 ATMOS_STALL_MAX = 25
 
+# Consecutive iterations of a failed atmosphere solve on an interior that has
+# not moved, after which a run ends. Much shorter than the cap above, because
+# neither side of the coupling can leave that state on its own.
+AGNI_DEADLOCK_MAX = 3
+
 
 class Proteus:
     def __init__(self, *, config_path: Path | str) -> None:
@@ -127,9 +132,10 @@ class Proteus:
         # Helpfile variables from all previous iterations
         self.hf_all = None
 
-        # Cap on consecutive unresolved atmosphere solves. Fixed for the run
-        # rather than reset per start, unlike the counters it is compared with.
+        # Caps on the two abort paths. Fixed for the run rather than reset per
+        # start, unlike the counters they are compared with.
         self.atmos_stall_max = ATMOS_STALL_MAX
+        self.agni_deadlock_max = AGNI_DEADLOCK_MAX
 
         # Loop counters
         self.init_stage = False
@@ -839,7 +845,6 @@ class Proteus:
         # and PROTEUS would otherwise silently accept a frozen state and
         # advance Time indefinitely.
         self.agni_deadlock_count = 0
-        self.agni_deadlock_max = 3
 
         # Main loop
         # Collects the index of the snapshots that already underwent a VULCAN calculation to avoid repeating:

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -46,10 +46,11 @@ from proteus.utils.logs import (
 _IT_TIMING_ENABLED = os.environ.get('PROTEUS_TIMING', '').lower() in ('1', 'true', 'yes', 'on')
 
 # Consecutive iterations without a converged atmosphere after which a run ends,
-# whatever the interior is doing. It has to stay above the streak the
-# atmosphere wrapper reports at error level, so a solver that stumbles for a
-# while still recovers on its own before anything gives up on it.
-ATMOS_STALL_MAX = 25
+# whatever the interior is doing. Measured over 27 stalled cases: the deepest
+# stall a run recovered from is 126 iterations and the deepest seen is 233, so
+# this sits above the first with margin. It has to stay above the streak the
+# atmosphere wrapper reports at error level.
+ATMOS_STALL_MAX = 150
 
 # Consecutive iterations of a failed atmosphere solve on an interior that has
 # not moved, after which a run ends. Much shorter than the cap above, because

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -45,6 +45,12 @@ from proteus.utils.logs import (
 # in the loop body.
 _IT_TIMING_ENABLED = os.environ.get('PROTEUS_TIMING', '').lower() in ('1', 'true', 'yes', 'on')
 
+# Consecutive iterations without a converged atmosphere after which a run ends,
+# whatever the interior is doing. It has to stay above the streak the
+# atmosphere wrapper reports at error level, so a solver that stumbles for a
+# while still recovers on its own before anything gives up on it.
+ATMOS_STALL_MAX = 25
+
 
 class Proteus:
     def __init__(self, *, config_path: Path | str) -> None:
@@ -120,6 +126,10 @@ class Proteus:
 
         # Helpfile variables from all previous iterations
         self.hf_all = None
+
+        # Cap on consecutive unresolved atmosphere solves. Fixed for the run
+        # rather than reset per start, unlike the counters it is compared with.
+        self.atmos_stall_max = ATMOS_STALL_MAX
 
         # Loop counters
         self.init_stage = False
@@ -830,12 +840,6 @@ class Proteus:
         # advance Time indefinitely.
         self.agni_deadlock_count = 0
         self.agni_deadlock_max = 3
-
-        # Consecutive iterations without a converged atmosphere after which the
-        # run aborts whatever the interior is doing. Well above the streak the
-        # atmosphere wrapper already reports at error level, so a solver that
-        # stumbles for a while still recovers on its own.
-        self.atmos_stall_max = 25
 
         # Main loop
         # Collects the index of the snapshots that already underwent a VULCAN calculation to avoid repeating:

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -196,6 +196,12 @@ class Proteus:
           deadlock).
         - When the counter reaches ``agni_deadlock_max``, write
           status code 22 and raise ``RuntimeError`` to abort the run.
+        - Independently of the interior, abort once the atmosphere has
+          gone ``atmos_stall_max`` consecutive iterations without a
+          converged solve. An interior that keeps cooling on carried
+          levels holds the deadlock counter at 0 forever, so without
+          this the run spends its whole budget on an atmosphere it
+          never resolved.
 
         On the first iteration ``hf_all`` is None: no previous row
         exists, so the deadlock cannot fire. The counter stays at 0.
@@ -204,6 +210,22 @@ class Proteus:
         if self.atmos_o.converged:
             self.agni_deadlock_count = 0
             return
+
+        stalled = int(self.atmos_o.levels_stale_iters)
+        if stalled >= self.atmos_stall_max:
+            log.error(
+                'Atmosphere has not converged for %d consecutive iterations, so escape '
+                'and the observables are running on a structure this run never resolved. '
+                'Aborting rather than spending the remaining budget on it. Try (a) a '
+                'shorter interior dt, (b) a more robust AGNI solver mode, or (c) '
+                'checking whether the surface boundary condition has left the regime '
+                'AGNI can represent.',
+                stalled,
+            )
+            UpdateStatusfile(self.directories, 22)
+            raise RuntimeError(
+                f'Atmosphere stalled: {stalled} consecutive solves without convergence.'
+            )
 
         if self.hf_all is not None and len(self.hf_all) >= 1:
             prev = self.hf_all.iloc[-1]
@@ -688,6 +710,13 @@ class Proteus:
                         self.config.params.stop.solid.phi_crit,
                     )
 
+            # Restore the count of consecutive unresolved atmosphere solves, so
+            # a run that stalls is not handed a fresh allowance by every
+            # resume. Absent in helpfiles written before the column existed,
+            # which read as a run that has not stalled.
+            stale = self.hf_row.get('atm_levels_stale', 0.0)
+            self.atmos_o.levels_stale_iters = int(stale) if np.isfinite(stale) else 0
+
             # Interior initial condition
             self.interior_o.ic = 2
 
@@ -801,6 +830,12 @@ class Proteus:
         # advance Time indefinitely.
         self.agni_deadlock_count = 0
         self.agni_deadlock_max = 3
+
+        # Consecutive iterations without a converged atmosphere after which the
+        # run aborts whatever the interior is doing. Well above the streak the
+        # atmosphere wrapper already reports at error level, so a solver that
+        # stumbles for a while still recovers on its own.
+        self.atmos_stall_max = 25
 
         # Main loop
         # Collects the index of the snapshots that already underwent a VULCAN calculation to avoid repeating:

--- a/tests/atmos_clim/test_agni.py
+++ b/tests/atmos_clim/test_agni.py
@@ -5,6 +5,10 @@ This module tests the AGNI atmosphere interface including:
 - Aerosol discovery (_determine_aerosols)
 - Condensate species determination (_determine_condensates)
 - AGNI atmosphere initialization (init_agni_atmos)
+- Temperature-profile carry-over between iterations (_check_stored_profile,
+  update_agni_atmos), covering pressure and temperature positivity, profile
+  monotonicity under interpolation, and the atmosphere-failure contract when
+  the surface boundary condition cannot seed a new profile
 
 See also:
 - docs/How-to/testing.md
@@ -17,10 +21,13 @@ import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
+from scipy.interpolate import PchipInterpolator
 
 import proteus.atmos_clim.agni as agni_mod
 from proteus.atmos_clim.agni import (
+    _check_stored_profile,
     _determine_aerosols,
     _determine_condensates,
     init_agni_atmos,
@@ -1720,3 +1727,440 @@ def test_write_atmos_ncdf_skips_unallocated_struct(monkeypatch, caplog):
     # skip above is attributable to the flag and not to the fake or the path.
     write_atmos_ncdf(SimpleNamespace(is_alloc=True), {'output': '/tmp/run'}, 1000.6)
     fake_write.assert_called_once()
+
+
+class _ProfileAtmosphere:
+    """Struct stand-in carrying a temperature profile on a pressure grid.
+
+    Holds the fields `update_agni_atmos` reads and writes. The grid routine
+    and the profile-guess routines of `_ProfileAGNI` operate on it, so a test
+    can read the profile the function leaves behind rather than only the calls
+    it made.
+    """
+
+    def __init__(self, p_centres, t_centres):
+        self.p = list(p_centres)
+        self.tmp = list(t_centres)
+        # Level edges bracket the cell centres, so there is one more of them
+        self.pl = (
+            [self.p[0] / 2.0]
+            + [0.5 * (a + b) for a, b in zip(self.p[:-1], self.p[1:])]
+            + [self.p[-1] * 2.0]
+        )
+        self.tmpl = [self.tmp[0]] * (len(self.tmp) + 1)
+        self.p_boa = self.pl[-1]
+        self.p_oboa = self.pl[-1]
+        self.tmp_surf = 1500.0
+        self.tmp_magma = 1500.0
+        self.instellation = 1361.0
+        self.albedo_b = 0.0
+        self.transparent = False
+        # Broadcast assignment mirrors the Julia arrays the real struct holds
+        self.gas_vmr = {'H2O': np.ones(len(self.p))}
+        self.gas_ovmr = {'H2O': np.ones(len(self.p))}
+
+
+class _ProfileAGNI:
+    """AGNI stand-in whose grid and profile routines write real numbers.
+
+    `generate_pgrid_b` lays a log-spaced grid between a fixed top pressure and
+    the surface pressure held on the struct; `isothermal_b` fills the profile;
+    `stratosphere_b` applies its argument as a floor. The guess routines each
+    record their call so a test can tell which branch of the config ran.
+    """
+
+    P_TOP = 1.0  # [Pa]
+
+    def __init__(self):
+        self.calls = []
+        self.guess_arg = None
+        self.atmosphere = SimpleNamespace(generate_pgrid_b=self._generate_pgrid_b)
+        self.setpt = SimpleNamespace(
+            loglinear_b=self._record('loglinear'),
+            isothermal_b=self._isothermal_b,
+            dry_adiabat_b=self._record('dry_adiabat'),
+            analytic_b=self._record('analytic'),
+            stratosphere_b=self._stratosphere_b,
+        )
+
+    def _record(self, name):
+        """Stub that notes the guess that ran and the value it was given."""
+
+        def _stub(atmos, *args):
+            self.calls.append(name)
+            self.guess_arg = args[0] if args else None
+            # A guess routine always leaves a profile behind, whatever its shape
+            atmos.tmp = [1.0] * len(atmos.p)
+            atmos.tmpl = [1.0] * len(atmos.pl)
+
+        return _stub
+
+    def _generate_pgrid_b(self, atmos):
+        self.calls.append('generate_pgrid')
+        nlev_c = len(atmos.p)
+        edges = np.logspace(np.log10(self.P_TOP), np.log10(atmos.p_boa), nlev_c + 1)
+        atmos.pl = [float(x) for x in edges]
+        atmos.p = [float(np.sqrt(a * b)) for a, b in zip(edges[:-1], edges[1:])]
+
+    def _isothermal_b(self, atmos, value):
+        self.calls.append('isothermal')
+        atmos.tmp = [float(value)] * len(atmos.p)
+        atmos.tmpl = [float(value)] * len(atmos.pl)
+
+    def _stratosphere_b(self, atmos, value):
+        self.calls.append('stratosphere')
+        atmos.tmp = [max(float(value), t) for t in atmos.tmp]
+        atmos.tmpl = [max(float(value), t) for t in atmos.tmpl]
+
+
+def _build_profile_config(ini_profile='isothermal'):
+    """Config carrying the fields read while the profile is updated."""
+    return SimpleNamespace(
+        atmos_clim=SimpleNamespace(
+            agni=SimpleNamespace(psurf_thresh=1.0e-3, ini_profile=ini_profile),
+        ),
+    )
+
+
+def _install_profile_fakes(monkeypatch, fake_agni):
+    """Point the module at the AGNI stand-in and a single-gas composition."""
+    fake_jl = SimpleNamespace(
+        AGNI=fake_agni,
+        Symbol=lambda name: name,
+        **{'setfield!': lambda obj, name, value: setattr(obj, name, value)},
+    )
+    monkeypatch.setattr(agni_mod, 'jl', fake_jl)
+    monkeypatch.setattr(agni_mod, '_construct_voldict', lambda *_a, **_k: {'H2O': 1.0})
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_check_stored_profile_accepts_a_physical_profile():
+    """A profile of positive pressures and temperatures is interpolable.
+
+    Physical scenario: the profile left by a converged solve, spanning seven
+    decades of pressure from the top of the atmosphere down to a hot surface.
+    """
+    p_centres = [1.0e-1, 1.0e2, 1.0e5, 1.0e7]
+    t_centres = [180.0, 400.0, 1200.0, 2400.0]
+
+    usable, reason = _check_stored_profile(p_centres, t_centres)
+    assert usable
+    assert reason == ''
+
+    # The pins above are only meaningful if this profile really does survive
+    # the interpolator the guard protects; a guard that passes something
+    # scipy rejects would be worthless.
+    PchipInterpolator(np.log10(p_centres), t_centres)
+
+    # Edge case: a single-cell profile carries no gradient but is still
+    # a valid structure to hold.
+    usable_one, reason_one = _check_stored_profile([5.0e6], [1900.0])
+    assert usable_one
+    assert reason_one == ''
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_check_stored_profile_rejects_non_finite_pressure():
+    """A NaN or infinite pressure cannot be turned into a log-pressure.
+
+    Physical scenario: the solver diverged and wrote NaN into the pressure
+    grid, which is what reaches the interpolator on the next iteration.
+    """
+    p_nan = [1.0e2, float('nan'), 1.0e6]
+    t_ok = [400.0, 900.0, 1800.0]
+
+    usable, reason = _check_stored_profile(p_nan, t_ok)
+    assert not usable
+    assert 'atmos.p' in reason
+    assert '1 non-finite' in reason
+
+    # Both non-finite kinds are caught, and the count reports every one.
+    usable_inf, reason_inf = _check_stored_profile([float('inf'), float('nan'), 1.0e6], t_ok)
+    assert not usable_inf
+    assert '2 non-finite' in reason_inf
+
+    # Discrimination: this is exactly the input scipy refuses, so a guard
+    # that let it through would return the run to the crash it replaces.
+    with pytest.raises(ValueError, match='finite'):
+        PchipInterpolator(np.log10(p_nan), t_ok)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_check_stored_profile_rejects_non_positive_pressure():
+    """Pressure must be positive for the profile to be interpolable.
+
+    Physical scenario: a collapsed grid holding zero or negative pressure.
+    Finiteness alone does not catch it, since the value only goes non-finite
+    once the logarithm is taken.
+    """
+    t_ok = [400.0, 900.0, 1800.0]
+
+    usable_zero, reason_zero = _check_stored_profile([1.0e2, 0.0, 1.0e6], t_ok)
+    assert not usable_zero
+    assert 'atmos.p' in reason_zero
+    assert '<= 0 Pa' in reason_zero
+
+    usable_neg, reason_neg = _check_stored_profile([1.0e2, -3.0e4, 1.0e6], t_ok)
+    assert not usable_neg
+    assert '<= 0 Pa' in reason_neg
+
+    # Discrimination against a finiteness-only guard: the offending values
+    # are finite, and only the logarithm of them is not.
+    assert np.all(np.isfinite([1.0e2, 0.0, 1.0e6]))
+    with np.errstate(divide='ignore'):
+        log_p = np.log10([1.0e2, 0.0, 1.0e6])
+    with pytest.raises(ValueError, match='finite'):
+        PchipInterpolator(log_p, t_ok)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_check_stored_profile_rejects_unphysical_temperature():
+    """Temperature must be finite and above absolute zero.
+
+    Physical scenario: the pressure grid survived the rejected solve but the
+    temperatures did not. Carrying them forward would seed the next solve
+    with a profile that is not a temperature.
+    """
+    p_ok = [1.0e2, 1.0e4, 1.0e6]
+
+    usable_nan, reason_nan = _check_stored_profile(p_ok, [400.0, float('nan'), 1800.0])
+    assert not usable_nan
+    assert 'atmos.tmp' in reason_nan
+    assert 'non-finite' in reason_nan
+
+    usable_zero, reason_zero = _check_stored_profile(p_ok, [400.0, 0.0, 1800.0])
+    assert not usable_zero
+    assert '<= 0 K' in reason_zero
+
+    usable_neg, _ = _check_stored_profile(p_ok, [400.0, -12.0, 1800.0])
+    assert not usable_neg
+
+    # The pressures here are the ones accepted above, so the rejection is
+    # attributable to the temperatures alone.
+    assert _check_stored_profile(p_ok, [400.0, 900.0, 1800.0])[0]
+
+
+@pytest.mark.unit
+def test_check_stored_profile_rejects_empty_and_ragged_input():
+    """A profile with no cells, or with mismatched arrays, is not a profile.
+
+    Contract clause: the guard runs before any array is indexed, so it has to
+    survive the degenerate shapes rather than raise on them.
+    """
+    usable_empty, reason_empty = _check_stored_profile([], [])
+    assert not usable_empty
+    assert 'empty' in reason_empty
+
+    usable_half, reason_half = _check_stored_profile([1.0e5], [])
+    assert not usable_half
+    assert 'empty' in reason_half
+
+    usable_ragged, reason_ragged = _check_stored_profile([1.0e2, 1.0e5], [300.0])
+    assert not usable_ragged
+    assert '2 pressures' in reason_ragged
+    assert '1 temperatures' in reason_ragged
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_update_agni_atmos_interpolates_a_usable_profile(monkeypatch):
+    """A usable profile is carried onto the new grid, not thrown away.
+
+    Physical scenario: an ordinary iteration after a converged solve, where
+    the surface pressure has grown by outgassing and the stored profile is
+    stretched onto the wider grid.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+
+    atmos = _ProfileAtmosphere([1.0e1, 1.0e3, 1.0e5, 1.0e7], [200.0, 500.0, 1100.0, 1900.0])
+    hf_row = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.1,
+        'T_surf': 1900.0,
+        'T_magma': 2000.0,
+        'P_surf': 200.0,  # bar
+    }
+
+    out = agni_mod.update_agni_atmos(
+        atmos, hf_row, {'output': '/tmp/run'}, _build_profile_config()
+    )
+
+    assert out is atmos
+    # No guess routine ran: the stored profile was used.
+    assert 'isothermal' not in fake_agni.calls
+    assert fake_agni.calls.count('generate_pgrid') == 1
+
+    # The new grid reaches the new surface pressure [bar -> Pa].
+    assert atmos.p_boa == pytest.approx(2.0e7, rel=1e-12)
+
+    # Boundedness: every temperature stays inside the range spanned by the
+    # stored profile and the magma clamp above it.
+    assert np.all(np.isfinite(atmos.tmp))
+    assert min(atmos.tmp) >= 200.0
+    assert max(atmos.tmp) <= max(1000.0, hf_row['T_magma'])
+
+    # Monotonicity: the stored profile grows with pressure, and a shape
+    # preserving interpolation of it must too.
+    assert np.all(np.diff(atmos.tmp) >= 0.0)
+
+    # Discrimination against a guess-profile regression: an isothermal
+    # rebuild would have left a single repeated value.
+    assert max(atmos.tmp) - min(atmos.tmp) > 100.0
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_update_agni_atmos_rebuilds_profile_left_non_finite(monkeypatch, caplog):
+    """A profile poisoned by a rejected solve is replaced, not interpolated.
+
+    Physical scenario: AGNI exhausted its attempts with NaN in the solution,
+    and the next iteration would otherwise take the logarithm of that grid.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+    no_interp = MagicMock(side_effect=AssertionError('interpolator must not be built'))
+    monkeypatch.setattr(agni_mod, 'PchipInterpolator', no_interp)
+    status = MagicMock()
+    monkeypatch.setattr(agni_mod, 'UpdateStatusfile', status)
+
+    atmos = _ProfileAtmosphere(
+        [1.0e1, float('nan'), 1.0e5, float('nan')],
+        [200.0, 500.0, float('nan'), 1900.0],
+    )
+    hf_row = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.1,
+        'T_surf': 2400.0,
+        'T_magma': 2400.0,
+        'P_surf': 260.0,  # bar
+    }
+
+    with caplog.at_level(logging.WARNING, logger='fwl.proteus.atmos_clim.agni'):
+        out = agni_mod.update_agni_atmos(
+            atmos, hf_row, {'output': '/tmp/run'}, _build_profile_config()
+        )
+
+    assert out is atmos
+    no_interp.assert_not_called()
+
+    # The run continues, so no failure status is written.
+    status.assert_not_called()
+
+    # The struct comes back on a finite, positive grid reaching the surface.
+    assert np.all(np.isfinite(atmos.p))
+    assert min(atmos.p) > 0.0
+    assert atmos.p_boa == pytest.approx(2.6e7, rel=1e-12)
+
+    # Positivity: the profile is the surface boundary condition, and the
+    # stratospheric floor sits below it so it is left alone.
+    assert np.all(np.isfinite(atmos.tmp))
+    assert atmos.tmp == pytest.approx([2400.0] * len(atmos.p))
+    assert np.all(np.isfinite(atmos.tmpl))
+    assert min(atmos.tmpl) > 0.0
+
+    # The log says which quantity went bad, so the cause is recoverable
+    # from the run's own output.
+    messages = ' '.join(rec.getMessage() for rec in caplog.records)
+    assert 'atmos.p' in messages
+    assert 'non-finite' in messages
+
+
+@pytest.mark.unit
+def test_update_agni_atmos_honours_the_configured_guess_on_rebuild(monkeypatch):
+    """The rebuild uses the initial guess the config asks for.
+
+    Contract clause: recovery reuses the same guess routine as the first
+    iteration, so a run does not silently switch profile shape mid-flight.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+
+    atmos = _ProfileAtmosphere([1.0e2, 1.0e5], [float('nan'), 1200.0])
+    hf_row = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.0,
+        'T_surf': 1500.0,
+        'T_magma': 1500.0,
+        'P_surf': 10.0,
+    }
+
+    agni_mod.update_agni_atmos(
+        atmos, hf_row, {'output': '/tmp/run'}, _build_profile_config('dry_adiabat')
+    )
+    assert 'dry_adiabat' in fake_agni.calls
+    assert 'isothermal' not in fake_agni.calls
+
+    # The floor is applied after the guess, in that order.
+    assert fake_agni.calls.index('stratosphere') > fake_agni.calls.index('dry_adiabat')
+
+    # Every guess the config offers is reachable from the rebuild, and the
+    # log-linear one is anchored on the surface temperature it is given.
+    for name in ('loglinear', 'analytic', 'isothermal'):
+        fresh = _ProfileAtmosphere([1.0e2, 1.0e5], [float('nan'), 1200.0])
+        agni_mod.update_agni_atmos(
+            fresh, hf_row, {'output': '/tmp/run'}, _build_profile_config(name)
+        )
+        assert fake_agni.calls[-2] == name
+        assert fake_agni.calls[-1] == 'stratosphere'
+        if name == 'loglinear':
+            assert fake_agni.guess_arg == pytest.approx(-750.0)
+
+    # An unknown guess is a configuration error, not an atmosphere one.
+    status = MagicMock()
+    monkeypatch.setattr(agni_mod, 'UpdateStatusfile', status)
+    bad = _ProfileAtmosphere([1.0e2, 1.0e5], [float('nan'), 1200.0])
+    with pytest.raises(ValueError, match='Invalid initial'):
+        agni_mod.update_agni_atmos(
+            bad, hf_row, {'output': '/tmp/run'}, _build_profile_config('parabolic')
+        )
+    status.assert_called_once_with({'output': '/tmp/run'}, 20)
+
+
+@pytest.mark.unit
+def test_update_agni_atmos_fails_as_atmosphere_error_without_a_usable_bc(monkeypatch):
+    """With no usable surface condition the run ends as an atmosphere failure.
+
+    Contract clause: there is nothing left to rebuild the profile from, so the
+    run stops with status 22 rather than the generic status a bare scipy
+    exception would leave behind.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+    status = MagicMock()
+    monkeypatch.setattr(agni_mod, 'UpdateStatusfile', status)
+    dirs = {'output': '/tmp/run'}
+    config = _build_profile_config()
+
+    hf_row = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.0,
+        'T_surf': float('nan'),
+        'T_magma': 2000.0,
+        'P_surf': 100.0,
+    }
+    atmos = _ProfileAtmosphere([1.0e2, 1.0e5], [float('nan'), 1200.0])
+    with pytest.raises(RuntimeError, match='T_surf'):
+        agni_mod.update_agni_atmos(atmos, hf_row, dirs, config)
+    status.assert_called_once_with(dirs, 22)
+
+    # Edge case: a surface pressure that is not a number sits above the
+    # transparent-mode threshold on every comparison, so it arrives here.
+    status.reset_mock()
+    hf_row_p = dict(hf_row, T_surf=1800.0, P_surf=float('nan'))
+    atmos_p = _ProfileAtmosphere([1.0e2, 1.0e5], [float('nan'), 1200.0])
+    with pytest.raises(RuntimeError, match='P_surf'):
+        agni_mod.update_agni_atmos(atmos_p, hf_row_p, dirs, config)
+    status.assert_called_once_with(dirs, 22)
+
+    # The same surface condition with a usable profile is not an error, so
+    # the failures above are attributable to the profile and the boundary
+    # condition together.
+    status.reset_mock()
+    atmos_ok = _ProfileAtmosphere([1.0e2, 1.0e5], [600.0, 1200.0])
+    agni_mod.update_agni_atmos(atmos_ok, dict(hf_row, T_surf=1800.0), dirs, config)
+    status.assert_not_called()

--- a/tests/atmos_clim/test_agni.py
+++ b/tests/atmos_clim/test_agni.py
@@ -1774,7 +1774,10 @@ class _ProfileAGNI:
     def __init__(self):
         self.calls = []
         self.guess_arg = None
-        self.atmosphere = SimpleNamespace(generate_pgrid_b=self._generate_pgrid_b)
+        self.atmosphere = SimpleNamespace(
+            generate_pgrid_b=self._generate_pgrid_b,
+            make_transparent_b=self._record('make_transparent'),
+        )
         self.setpt = SimpleNamespace(
             loglinear_b=self._record('loglinear'),
             isothermal_b=self._isothermal_b,
@@ -2199,6 +2202,7 @@ def test_update_agni_atmos_honours_the_configured_guess_on_rebuild(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_update_agni_atmos_fails_as_atmosphere_error_without_a_usable_bc(monkeypatch):
     """With no usable surface condition the run ends as an atmosphere failure.
 
@@ -2257,3 +2261,133 @@ def test_update_agni_atmos_fails_as_atmosphere_error_without_a_usable_bc(monkeyp
     # It fails before touching the struct, so the grid is never laid down.
     assert len(fake_agni.calls) == calls_before
     assert atmos_z.p_boa == pytest.approx(2.0e5)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_update_agni_atmos_rejects_a_bad_surface_state_behind_a_good_profile(monkeypatch):
+    """A surface state that is not finite and positive ends the run even when
+    the stored profile is perfectly usable.
+
+    Contract clause: temperature and pressure are positive quantities, and the
+    check on the stored profile cannot see the boundary condition carried
+    beside it. Edge case: a surface pressure of infinity, which sets the top of
+    the interpolation grid and raises inside scipy, and one of NaN, which is
+    invisible because every comparison against it is false.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+    status = MagicMock()
+    monkeypatch.setattr(agni_mod, 'UpdateStatusfile', status)
+    dirs = {'output': '/tmp/run'}
+    config = _build_profile_config()
+
+    healthy = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.0,
+        'T_surf': 1800.0,
+        'T_magma': 3000.0,
+        'P_surf': 260.0,
+    }
+
+    # The same profile with a usable surface state goes through, so each
+    # failure below is attributable to the boundary condition alone.
+    agni_mod.update_agni_atmos(
+        _ProfileAtmosphere([1.0e2, 1.0e5], [600.0, 1200.0]), dict(healthy), dirs, config
+    )
+    status.assert_not_called()
+
+    for field, value in (
+        ('P_surf', float('inf')),
+        ('P_surf', float('nan')),
+        ('P_surf', -1.0),
+        ('T_surf', float('nan')),
+        ('T_surf', 0.0),
+        ('T_magma', float('nan')),
+        ('T_magma', -1.0),
+    ):
+        status.reset_mock()
+        atmos = _ProfileAtmosphere([1.0e2, 1.0e5], [600.0, 1200.0])
+        with pytest.raises(RuntimeError, match=field):
+            agni_mod.update_agni_atmos(atmos, dict(healthy, **{field: value}), dirs, config)
+        status.assert_called_once_with(dirs, 22)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_surface_state_accepts_a_planet_that_has_lost_its_atmosphere():
+    """A surface pressure of zero is a planet with no atmosphere left, not a
+    spoiled boundary condition, so it must pass the surface-state check.
+
+    Contract clause: zero means different things either side of the boundary
+    condition. Desiccation sets ``P_surf`` to exactly zero deliberately and an
+    escape step that outpaces the column clamps it there, and transparent mode
+    handles that case without ever reading the value. A temperature of zero is
+    not a temperature and stays refused. Edge case: both boundaries at once.
+    """
+    from proteus.atmos_clim.agni import _validate_surface_state
+
+    healthy = {'T_surf': 1800.0, 'T_magma': 3000.0, 'P_surf': 260.0}
+
+    with patch('proteus.atmos_clim.agni.UpdateStatusfile') as status:
+        # The terminal state, and a pressure below the transparent threshold.
+        _validate_surface_state(dict(healthy, P_surf=0.0), {})
+        _validate_surface_state(dict(healthy, P_surf=1.0e-5), {})
+        status.assert_not_called()
+
+    # Discrimination: the neighbouring values on either side of that zero are
+    # still refused, so accepting it is not the check going slack.
+    for field, value in (('P_surf', -1.0e-30), ('T_surf', 0.0), ('T_magma', 0.0)):
+        with patch('proteus.atmos_clim.agni.UpdateStatusfile') as status:
+            with pytest.raises(RuntimeError, match=field):
+                _validate_surface_state(dict(healthy, **{field: value}), {})
+            status.assert_called_once_with({}, 22)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_a_lost_atmosphere_goes_to_transparent_mode_not_the_pressure_grid(monkeypatch):
+    """A planet with no atmosphere left must reach transparent mode, which is
+    what makes accepting a surface pressure of zero safe.
+
+    Contract clause: the surface-state check lets zero through because the
+    branch below it handles that case without reading the value. Laying a
+    log-spaced grid on a surface pressure of zero is what the routing avoids,
+    so the test pins the routing rather than the check. Edge case: exactly
+    zero, which desiccation produces, against a pressure that takes the grid.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+    status = MagicMock()
+    monkeypatch.setattr(agni_mod, 'UpdateStatusfile', status)
+    dirs = {'output': '/tmp/run'}
+    config = _build_profile_config()
+    healthy = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.0,
+        'T_surf': 1800.0,
+        'T_magma': 3000.0,
+        'P_surf': 260.0,
+    }
+
+    agni_mod.update_agni_atmos(
+        _ProfileAtmosphere([1.0e2, 1.0e5], [600.0, 1200.0]),
+        dict(healthy, P_surf=0.0),
+        dirs,
+        config,
+    )
+    status.assert_not_called()
+    assert 'make_transparent' in fake_agni.calls
+    assert 'isothermal' in fake_agni.calls
+    # The grid is what a surface pressure of zero must never reach.
+    assert 'generate_pgrid' not in fake_agni.calls
+
+    # Discrimination: a pressure that clears the threshold does take the grid,
+    # so the routing above is the branch and not simply what the fake does.
+    fake_agni.calls.clear()
+    agni_mod.update_agni_atmos(
+        _ProfileAtmosphere([1.0e2, 1.0e5], [600.0, 1200.0]), dict(healthy), dirs, config
+    )
+    assert 'generate_pgrid' in fake_agni.calls
+    assert 'make_transparent' not in fake_agni.calls
+    status.assert_not_called()

--- a/tests/atmos_clim/test_agni.py
+++ b/tests/atmos_clim/test_agni.py
@@ -5,7 +5,7 @@ This module tests the AGNI atmosphere interface including:
 - Aerosol discovery (_determine_aerosols)
 - Condensate species determination (_determine_condensates)
 - AGNI atmosphere initialization (init_agni_atmos)
-- Temperature-profile carry-over between iterations (_check_stored_profile,
+- Temperature-profile carry-over between iterations (_validate_stored_profile,
   update_agni_atmos), covering pressure and temperature positivity, profile
   monotonicity under interpolation, and the atmosphere-failure contract when
   the surface boundary condition cannot seed a new profile
@@ -27,9 +27,9 @@ from scipy.interpolate import PchipInterpolator
 
 import proteus.atmos_clim.agni as agni_mod
 from proteus.atmos_clim.agni import (
-    _check_stored_profile,
     _determine_aerosols,
     _determine_condensates,
+    _validate_stored_profile,
     init_agni_atmos,
     write_atmos_ncdf,
 )
@@ -1835,7 +1835,7 @@ def _install_profile_fakes(monkeypatch, fake_agni):
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
-def test_check_stored_profile_accepts_a_physical_profile():
+def test_validate_stored_profile_accepts_a_physical_profile():
     """A profile of positive pressures and temperatures is interpolable.
 
     Physical scenario: the profile left by a converged solve, spanning seven
@@ -1844,7 +1844,7 @@ def test_check_stored_profile_accepts_a_physical_profile():
     p_centres = [1.0e-1, 1.0e2, 1.0e5, 1.0e7]
     t_centres = [180.0, 400.0, 1200.0, 2400.0]
 
-    usable, reason = _check_stored_profile(p_centres, t_centres)
+    usable, reason = _validate_stored_profile(p_centres, t_centres)
     assert usable
     assert reason == ''
 
@@ -1855,14 +1855,14 @@ def test_check_stored_profile_accepts_a_physical_profile():
 
     # Edge case: a single-cell profile carries no gradient but is still
     # a valid structure to hold.
-    usable_one, reason_one = _check_stored_profile([5.0e6], [1900.0])
+    usable_one, reason_one = _validate_stored_profile([5.0e6], [1900.0])
     assert usable_one
     assert reason_one == ''
 
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
-def test_check_stored_profile_rejects_non_finite_pressure():
+def test_validate_stored_profile_rejects_non_finite_pressure():
     """A NaN or infinite pressure cannot be turned into a log-pressure.
 
     Physical scenario: the solver diverged and wrote NaN into the pressure
@@ -1871,13 +1871,13 @@ def test_check_stored_profile_rejects_non_finite_pressure():
     p_nan = [1.0e2, float('nan'), 1.0e6]
     t_ok = [400.0, 900.0, 1800.0]
 
-    usable, reason = _check_stored_profile(p_nan, t_ok)
+    usable, reason = _validate_stored_profile(p_nan, t_ok)
     assert not usable
     assert 'atmos.p' in reason
     assert '1 non-finite' in reason
 
     # Both non-finite kinds are caught, and the count reports every one.
-    usable_inf, reason_inf = _check_stored_profile([float('inf'), float('nan'), 1.0e6], t_ok)
+    usable_inf, reason_inf = _validate_stored_profile([float('inf'), float('nan'), 1.0e6], t_ok)
     assert not usable_inf
     assert '2 non-finite' in reason_inf
 
@@ -1889,7 +1889,7 @@ def test_check_stored_profile_rejects_non_finite_pressure():
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
-def test_check_stored_profile_rejects_non_positive_pressure():
+def test_validate_stored_profile_rejects_non_positive_pressure():
     """Pressure must be positive for the profile to be interpolable.
 
     Physical scenario: a collapsed grid holding zero or negative pressure.
@@ -1898,12 +1898,12 @@ def test_check_stored_profile_rejects_non_positive_pressure():
     """
     t_ok = [400.0, 900.0, 1800.0]
 
-    usable_zero, reason_zero = _check_stored_profile([1.0e2, 0.0, 1.0e6], t_ok)
+    usable_zero, reason_zero = _validate_stored_profile([1.0e2, 0.0, 1.0e6], t_ok)
     assert not usable_zero
     assert 'atmos.p' in reason_zero
     assert '<= 0 Pa' in reason_zero
 
-    usable_neg, reason_neg = _check_stored_profile([1.0e2, -3.0e4, 1.0e6], t_ok)
+    usable_neg, reason_neg = _validate_stored_profile([1.0e2, -3.0e4, 1.0e6], t_ok)
     assert not usable_neg
     assert '<= 0 Pa' in reason_neg
 
@@ -1918,7 +1918,37 @@ def test_check_stored_profile_rejects_non_positive_pressure():
 
 @pytest.mark.unit
 @pytest.mark.physics_invariant
-def test_check_stored_profile_rejects_unphysical_temperature():
+def test_validate_stored_profile_rejects_a_grid_that_stops_rising():
+    """Pressure must rise with depth for the profile to be interpolable.
+
+    Physical scenario: a grid that repeats a level or folds back on itself. It
+    is finite and positive everywhere, so only the ordering distinguishes it
+    from a usable column.
+    """
+    t_ok = [400.0, 900.0, 1800.0, 2200.0]
+
+    p_flat = [1.0e2, 1.0e5, 1.0e5, 1.0e7]
+    usable_flat, reason_flat = _validate_stored_profile(p_flat, t_ok)
+    assert not usable_flat
+    assert 'atmos.p' in reason_flat
+    assert '1 level(s)' in reason_flat
+
+    # A grid that folds back on itself is caught at the step that descends.
+    usable_back, reason_back = _validate_stored_profile([1.0e2, 1.0e6, 1.0e4, 1.0e7], t_ok)
+    assert not usable_back
+    assert '1 level(s)' in reason_back
+
+    # Discrimination against a finiteness-and-positivity guard: every value
+    # passes both of those, and only the ordering is wrong.
+    assert np.all(np.isfinite(p_flat))
+    assert min(p_flat) > 0.0
+    with pytest.raises(ValueError, match='strictly increasing'):
+        PchipInterpolator(np.log10(p_flat), t_ok)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_validate_stored_profile_rejects_unphysical_temperature():
     """Temperature must be finite and above absolute zero.
 
     Physical scenario: the pressure grid survived the rejected solve but the
@@ -1927,39 +1957,39 @@ def test_check_stored_profile_rejects_unphysical_temperature():
     """
     p_ok = [1.0e2, 1.0e4, 1.0e6]
 
-    usable_nan, reason_nan = _check_stored_profile(p_ok, [400.0, float('nan'), 1800.0])
+    usable_nan, reason_nan = _validate_stored_profile(p_ok, [400.0, float('nan'), 1800.0])
     assert not usable_nan
     assert 'atmos.tmp' in reason_nan
     assert 'non-finite' in reason_nan
 
-    usable_zero, reason_zero = _check_stored_profile(p_ok, [400.0, 0.0, 1800.0])
+    usable_zero, reason_zero = _validate_stored_profile(p_ok, [400.0, 0.0, 1800.0])
     assert not usable_zero
     assert '<= 0 K' in reason_zero
 
-    usable_neg, _ = _check_stored_profile(p_ok, [400.0, -12.0, 1800.0])
+    usable_neg, _ = _validate_stored_profile(p_ok, [400.0, -12.0, 1800.0])
     assert not usable_neg
 
     # The pressures here are the ones accepted above, so the rejection is
     # attributable to the temperatures alone.
-    assert _check_stored_profile(p_ok, [400.0, 900.0, 1800.0])[0]
+    assert _validate_stored_profile(p_ok, [400.0, 900.0, 1800.0])[0]
 
 
 @pytest.mark.unit
-def test_check_stored_profile_rejects_empty_and_ragged_input():
+def test_validate_stored_profile_rejects_empty_and_ragged_input():
     """A profile with no cells, or with mismatched arrays, is not a profile.
 
     Contract clause: the guard runs before any array is indexed, so it has to
     survive the degenerate shapes rather than raise on them.
     """
-    usable_empty, reason_empty = _check_stored_profile([], [])
+    usable_empty, reason_empty = _validate_stored_profile([], [])
     assert not usable_empty
     assert 'empty' in reason_empty
 
-    usable_half, reason_half = _check_stored_profile([1.0e5], [])
+    usable_half, reason_half = _validate_stored_profile([1.0e5], [])
     assert not usable_half
     assert 'empty' in reason_half
 
-    usable_ragged, reason_ragged = _check_stored_profile([1.0e2, 1.0e5], [300.0])
+    usable_ragged, reason_ragged = _validate_stored_profile([1.0e2, 1.0e5], [300.0])
     assert not usable_ragged
     assert '2 pressures' in reason_ragged
     assert '1 temperatures' in reason_ragged
@@ -2030,7 +2060,7 @@ def test_update_agni_atmos_rebuilds_profile_left_non_finite(monkeypatch, caplog)
 
     atmos = _ProfileAtmosphere(
         [1.0e1, float('nan'), 1.0e5, float('nan')],
-        [200.0, 500.0, float('nan'), 1900.0],
+        [200.0, 500.0, 1100.0, 1900.0],
     )
     hf_row = {
         'F_ins': 1361.0,
@@ -2064,10 +2094,57 @@ def test_update_agni_atmos_rebuilds_profile_left_non_finite(monkeypatch, caplog)
     assert min(atmos.tmpl) > 0.0
 
     # The log says which quantity went bad, so the cause is recoverable
-    # from the run's own output.
+    # from the run's own output. Only the pressures were poisoned here, so
+    # naming the temperatures would be wrong.
     messages = ' '.join(rec.getMessage() for rec in caplog.records)
-    assert 'atmos.p' in messages
-    assert 'non-finite' in messages
+    assert 'atmos.p holds 2 non-finite value(s)' in messages
+    assert 'atmos.tmp' not in messages
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_update_agni_atmos_rebuilds_when_only_temperatures_are_poisoned(monkeypatch, caplog):
+    """A NaN temperature on a clean grid is caught in its own right.
+
+    Physical scenario: the solver iterates on temperature, so a rejected solve
+    can leave the pressure grid intact and the profile unusable. The
+    interpolator refuses that too, and for a different reason.
+    """
+    fake_agni = _ProfileAGNI()
+    _install_profile_fakes(monkeypatch, fake_agni)
+    no_interp = MagicMock(side_effect=AssertionError('interpolator must not be built'))
+    monkeypatch.setattr(agni_mod, 'PchipInterpolator', no_interp)
+
+    p_clean = [1.0e1, 1.0e3, 1.0e5, 1.0e7]
+    atmos = _ProfileAtmosphere(p_clean, [200.0, float('nan'), 1100.0, 1900.0])
+    hf_row = {
+        'F_ins': 1361.0,
+        'albedo_pl': 0.1,
+        'T_surf': 2000.0,
+        'T_magma': 2000.0,
+        'P_surf': 50.0,
+    }
+
+    with caplog.at_level(logging.WARNING, logger='fwl.proteus.atmos_clim.agni'):
+        agni_mod.update_agni_atmos(
+            atmos, hf_row, {'output': '/tmp/run'}, _build_profile_config()
+        )
+
+    no_interp.assert_not_called()
+    assert 'isothermal' in fake_agni.calls
+
+    # Positivity: the profile that comes back is the surface condition.
+    assert np.all(np.isfinite(atmos.tmp))
+    assert atmos.tmp == pytest.approx([2000.0] * len(atmos.p))
+
+    # The offending quantity is named, and the clean pressures are not.
+    messages = ' '.join(rec.getMessage() for rec in caplog.records)
+    assert 'atmos.tmp holds 1 non-finite value(s)' in messages
+    assert 'atmos.p ' not in messages
+
+    # Discrimination: the pressures used here are the ones the interpolated
+    # path accepts, so the rebuild is attributable to the temperatures.
+    assert _validate_stored_profile(p_clean, [200.0, 600.0, 1100.0, 1900.0])[0]
 
 
 @pytest.mark.unit
@@ -2164,3 +2241,19 @@ def test_update_agni_atmos_fails_as_atmosphere_error_without_a_usable_bc(monkeyp
     atmos_ok = _ProfileAtmosphere([1.0e2, 1.0e5], [600.0, 1200.0])
     agni_mod.update_agni_atmos(atmos_ok, dict(hf_row, T_surf=1800.0), dirs, config)
     status.assert_not_called()
+
+    # A surface pressure of zero leaves no column to lay a grid over. In a run
+    # it is diverted to transparent mode upstream, so the rebuild is called
+    # directly to hold it to its own contract.
+    status.reset_mock()
+    atmos_z = _ProfileAtmosphere([1.0e2, 1.0e5], [float('nan'), 1200.0])
+    calls_before = len(fake_agni.calls)
+    with pytest.raises(RuntimeError, match='P_surf'):
+        agni_mod._rebuild_agni_profile(
+            atmos_z, dict(hf_row, T_surf=1800.0, P_surf=0.0), dirs, config, 'test reason'
+        )
+    status.assert_called_once_with(dirs, 22)
+
+    # It fails before touching the struct, so the grid is never laid down.
+    assert len(fake_agni.calls) == calls_before
+    assert atmos_z.p_boa == pytest.approx(2.0e5)

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -423,7 +423,9 @@ def test_check_atmosphere_deadlock_aborts_a_stalled_atmosphere(tmp_path):
 
     # One short of the cap the run continues, so the abort is on the
     # threshold rather than on any non-converged solve.
-    q = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=24, **moving)
+    q = _make_deadlock_proteus(
+        tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX - 1, **moving
+    )
     with patch('proteus.proteus.UpdateStatusfile') as mock_update:
         q._check_atmosphere_deadlock()
     mock_update.assert_not_called()

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -404,13 +404,15 @@ def test_check_atmosphere_deadlock_aborts_a_stalled_atmosphere(tmp_path):
     same input that resets the deadlock counter above, so an abort here is
     attributable to the stall count alone.
     """
+    from proteus.proteus import ATMOS_STALL_MAX
+
     moving = {
         'hf_all': pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3050.0, 'Phi_global': 1.0}]),
         'hf_row': {'F_atm': 140.0, 'T_magma': 3000.0, 'Phi_global': 0.9},
     }
-    p = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=25, **moving)
+    p = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX, **moving)
     with patch('proteus.proteus.UpdateStatusfile') as mock_update:
-        with pytest.raises(RuntimeError, match='25 consecutive solves'):
+        with pytest.raises(RuntimeError, match=f'{ATMOS_STALL_MAX} consecutive solves'):
             p._check_atmosphere_deadlock()
     mock_update.assert_called_once()
     args, _ = mock_update.call_args
@@ -436,10 +438,12 @@ def test_check_atmosphere_deadlock_stall_yields_to_a_converged_solve(tmp_path):
     coupled run. What is pinned here is the order of the two tests, so a
     count left on the struct can never kill a run whose atmosphere converged.
     """
+    from proteus.proteus import ATMOS_STALL_MAX
+
     p = _make_deadlock_proteus(
         tmp_path,
         converged=True,
-        stale_iters=99,
+        stale_iters=ATMOS_STALL_MAX + 1,
         hf_all=pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0}]),
         hf_row={'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0},
     )
@@ -454,12 +458,12 @@ def test_check_atmosphere_deadlock_stall_yields_to_a_converged_solve(tmp_path):
     q = _make_deadlock_proteus(
         tmp_path,
         converged=False,
-        stale_iters=99,
+        stale_iters=ATMOS_STALL_MAX + 1,
         hf_all=pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0}]),
         hf_row={'F_atm': 180.0, 'T_magma': 2900.0, 'Phi_global': 0.8},
     )
     with patch('proteus.proteus.UpdateStatusfile'):
-        with pytest.raises(RuntimeError, match='99 consecutive solves'):
+        with pytest.raises(RuntimeError, match=f'{ATMOS_STALL_MAX + 1} consecutive solves'):
             q._check_atmosphere_deadlock()
 
 
@@ -497,6 +501,7 @@ def test_check_atmosphere_deadlock_reads_the_count_the_wrapper_produces(tmp_path
     """
     from proteus.atmos_clim.common import Atmos_t
     from proteus.atmos_clim.wrapper import carry_converged_levels
+    from proteus.proteus import ATMOS_STALL_MAX
 
     atmos_o = Atmos_t()
     converged_row = {'R_xuv': 7.0e6, 'p_xuv': 1.0e2, 'T_xuv': 900.0, 'g_xuv': 9.5}
@@ -508,7 +513,7 @@ def test_check_atmosphere_deadlock_reads_the_count_the_wrapper_produces(tmp_path
 
     # Then the atmosphere stops resolving, once per iteration.
     atmos_o.converged = False
-    for expected in range(1, 26):
+    for expected in range(1, ATMOS_STALL_MAX + 1):
         carry_converged_levels(atmos_o, dict(converged_row))
         assert atmos_o.levels_stale_iters == expected
 
@@ -520,7 +525,7 @@ def test_check_atmosphere_deadlock_reads_the_count_the_wrapper_produces(tmp_path
     )
     p.atmos_o = atmos_o
     with patch('proteus.proteus.UpdateStatusfile') as mock_update:
-        with pytest.raises(RuntimeError, match='25 consecutive solves'):
+        with pytest.raises(RuntimeError, match=f'{ATMOS_STALL_MAX} consecutive solves'):
             p._check_atmosphere_deadlock()
     args, _ = mock_update.call_args
     assert args[1] == 22
@@ -571,7 +576,7 @@ def test_atmos_stall_max_is_the_value_the_run_actually_uses(tmp_path):
     from proteus.atmos_clim.wrapper import CARRIED_LEVELS_ALERT
     from proteus.proteus import AGNI_DEADLOCK_MAX, ATMOS_STALL_MAX
 
-    assert ATMOS_STALL_MAX == 25
+    assert ATMOS_STALL_MAX == 150
     assert ATMOS_STALL_MAX > CARRIED_LEVELS_ALERT
     assert ATMOS_STALL_MAX > AGNI_DEADLOCK_MAX
 

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -31,7 +31,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
 def _make_proteus_instance(tmp_path, *, struct_module='zalmoxis', interior_module='spider'):
     """Build a Proteus object with mocked config and directories."""
-    from proteus.proteus import Proteus
+    from proteus.proteus import ATMOS_STALL_MAX, Proteus
 
     config = MagicMock()
     config.interior_struct.module = struct_module
@@ -48,6 +48,10 @@ def _make_proteus_instance(tmp_path, *, struct_module='zalmoxis', interior_modul
     # against. Defaults mirror the schema.
     config.params.stop.solid.freeze_volatiles = False
     config.params.stop.solid.phi_crit = 0.01
+    # Same reason: an unset mock integer reads as 1, which would silently give
+    # the run a stall cap of one iteration instead of the schema default.
+    config.params.stop.stall.enabled = True
+    config.params.stop.stall.maximum = ATMOS_STALL_MAX
 
     directories = {
         'output': str(tmp_path),
@@ -1764,3 +1768,61 @@ def test_non_vapourising_run_keeps_strict_mass_conservation(tmp_path, caplog):
     # Discrimination: the breach is a factor of two, far outside the 1e-6
     # tolerance, so this is not passing on a rounding edge.
     assert rows[-1]['M_atm'] / rows[-1]['M_planet'] == pytest.approx(2.0, rel=1e-12)
+
+
+@pytest.mark.unit
+def test_stall_criterion_is_configurable_and_matches_its_constant(tmp_path):
+    """The stall abort reads its cap and its on/off state from the config, and
+    the schema default is the same number the module constant carries.
+
+    Contract clause: the cap is a termination criterion like the seven beside
+    it, so a run that stalls legitimately can raise it or switch it off without
+    editing source. The default is duplicated between the schema and the
+    constant, so it is pinned here: two records of one number are only safe
+    while something fails when they disagree.
+    """
+    from proteus.config._params import StopParams, StopStall
+    from proteus.proteus import ATMOS_STALL_MAX
+
+    assert StopStall().maximum == ATMOS_STALL_MAX
+    assert StopStall().enabled is True
+    assert StopParams().stall.maximum == ATMOS_STALL_MAX
+
+    # A non-positive cap is refused: it would abort before a run had a chance.
+    for bad in (0, -1):
+        with pytest.raises(ValueError):
+            StopStall(maximum=bad)
+
+    moving = {
+        'hf_all': pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3050.0, 'Phi_global': 1.0}]),
+        'hf_row': {'F_atm': 140.0, 'T_magma': 3000.0, 'Phi_global': 0.9},
+    }
+
+    # A raised cap moves the abort with it: the streak that ended the run at the
+    # default is now allowed to continue.
+    raised = _make_deadlock_proteus(
+        tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX, **moving
+    )
+    raised.atmos_stall_max = ATMOS_STALL_MAX * 2
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        raised._check_atmosphere_deadlock()
+    mock_update.assert_not_called()
+
+    # Switching the criterion off spares a streak far past any cap, which is
+    # the recourse a legitimately long-stalling run has.
+    off = _make_deadlock_proteus(
+        tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX * 10, **moving
+    )
+    off.atmos_stall_enabled = False
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        off._check_atmosphere_deadlock()
+    mock_update.assert_not_called()
+
+    # Discrimination: the same streak with the criterion on does abort, so the
+    # two results above are attributable to the switch and the cap.
+    on = _make_deadlock_proteus(
+        tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX * 10, **moving
+    )
+    with patch('proteus.proteus.UpdateStatusfile'):
+        with pytest.raises(RuntimeError, match='consecutive solves'):
+            on._check_atmosphere_deadlock()

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -248,14 +248,14 @@ def _make_deadlock_proteus(
     """
     from types import SimpleNamespace
 
-    from proteus.proteus import ATMOS_STALL_MAX
+    from proteus.proteus import AGNI_DEADLOCK_MAX, ATMOS_STALL_MAX
 
     p = _make_proteus_instance(tmp_path)
     p.atmos_o = SimpleNamespace(converged=bool(converged), levels_stale_iters=int(stale_iters))
     p.hf_all = hf_all
     p.hf_row = hf_row if hf_row is not None else {}
     p.agni_deadlock_count = 0
-    p.agni_deadlock_max = 3
+    p.agni_deadlock_max = AGNI_DEADLOCK_MAX
     p.atmos_stall_max = ATMOS_STALL_MAX
     return p
 
@@ -569,15 +569,17 @@ def test_atmos_stall_max_is_the_value_the_run_actually_uses(tmp_path):
     the earlier of the two.
     """
     from proteus.atmos_clim.wrapper import CARRIED_LEVELS_ALERT
-    from proteus.proteus import ATMOS_STALL_MAX
+    from proteus.proteus import AGNI_DEADLOCK_MAX, ATMOS_STALL_MAX
 
     assert ATMOS_STALL_MAX == 25
     assert ATMOS_STALL_MAX > CARRIED_LEVELS_ALERT
-    assert ATMOS_STALL_MAX > 3
+    assert ATMOS_STALL_MAX > AGNI_DEADLOCK_MAX
 
     # A constructed run carries the constant, so a literal reintroduced on
     # the instance would diverge from the pin above.
-    assert _make_proteus_instance(tmp_path).atmos_stall_max == ATMOS_STALL_MAX
+    built = _make_proteus_instance(tmp_path)
+    assert built.atmos_stall_max == ATMOS_STALL_MAX
+    assert built.agni_deadlock_max == AGNI_DEADLOCK_MAX
 
     moving = {
         'hf_all': pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3050.0, 'Phi_global': 1.0}]),

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -236,21 +236,25 @@ def test_proteus_resume_mesh_no_prev(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _make_deadlock_proteus(tmp_path, *, converged=False, hf_all=None, hf_row=None):
+def _make_deadlock_proteus(
+    tmp_path, *, converged=False, hf_all=None, hf_row=None, stale_iters=0
+):
     """Build a Proteus instance pre-positioned for the deadlock check.
 
-    All the fields the check reads (atmos_o.converged, hf_all, hf_row,
-    agni_deadlock_count, agni_deadlock_max, directories) are set
-    explicitly; everything else is left at its post-__init__ default.
+    All the fields the check reads (atmos_o.converged,
+    atmos_o.levels_stale_iters, hf_all, hf_row, agni_deadlock_count,
+    agni_deadlock_max, atmos_stall_max, directories) are set explicitly;
+    everything else is left at its post-__init__ default.
     """
     from types import SimpleNamespace
 
     p = _make_proteus_instance(tmp_path)
-    p.atmos_o = SimpleNamespace(converged=bool(converged))
+    p.atmos_o = SimpleNamespace(converged=bool(converged), levels_stale_iters=int(stale_iters))
     p.hf_all = hf_all
     p.hf_row = hf_row if hf_row is not None else {}
     p.agni_deadlock_count = 0
     p.agni_deadlock_max = 3
+    p.atmos_stall_max = 25
     return p
 
 
@@ -384,6 +388,197 @@ def test_check_atmosphere_deadlock_f_atm_tolerance_boundary(tmp_path):
     p.hf_row = {'F_atm': 200.0, 'T_magma': 3000.0, 'Phi_global': 1.0}
     p._check_atmosphere_deadlock()
     assert p.agni_deadlock_count == 0
+
+
+def test_check_atmosphere_deadlock_aborts_a_stalled_atmosphere(tmp_path):
+    """An atmosphere that never converges ends the run even while the
+    interior is still moving.
+
+    Physical scenario: the interior keeps cooling on levels carried from an
+    older solve, so the frozen-state test never fires and the run would
+    otherwise spend its whole budget on a structure it never resolved.
+
+    Discriminating: the interior moves by 50 K between the rows, which is the
+    same input that resets the deadlock counter above, so an abort here is
+    attributable to the stall count alone.
+    """
+    moving = {
+        'hf_all': pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3050.0, 'Phi_global': 1.0}]),
+        'hf_row': {'F_atm': 140.0, 'T_magma': 3000.0, 'Phi_global': 0.9},
+    }
+    p = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=25, **moving)
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        with pytest.raises(RuntimeError, match='25 consecutive solves'):
+            p._check_atmosphere_deadlock()
+    mock_update.assert_called_once()
+    args, _ = mock_update.call_args
+    assert args[1] == 22
+
+    # The frozen-interior counter is not what fired: it never left zero.
+    assert p.agni_deadlock_count == 0
+
+    # One short of the cap the run continues, so the abort is on the
+    # threshold rather than on any non-converged solve.
+    q = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=24, **moving)
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        q._check_atmosphere_deadlock()
+    mock_update.assert_not_called()
+    assert q.agni_deadlock_count == 0
+
+
+def test_check_atmosphere_deadlock_stall_yields_to_a_converged_solve(tmp_path):
+    """The convergence flag short-circuits the check before the count is read.
+
+    Contract clause only: the wrapper zeroes the count on a converged solve
+    before this method ever runs, so the pairing below cannot arise in a
+    coupled run. What is pinned here is the order of the two tests, so a
+    count left on the struct can never kill a run whose atmosphere converged.
+    """
+    p = _make_deadlock_proteus(
+        tmp_path,
+        converged=True,
+        stale_iters=99,
+        hf_all=pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0}]),
+        hf_row={'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0},
+    )
+    p.agni_deadlock_count = 2
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        p._check_atmosphere_deadlock()
+    mock_update.assert_not_called()
+    assert p.agni_deadlock_count == 0
+
+    # The same count with a failed solve does abort, so the convergence flag
+    # is what spared it.
+    q = _make_deadlock_proteus(
+        tmp_path,
+        converged=False,
+        stale_iters=99,
+        hf_all=pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0}]),
+        hf_row={'F_atm': 180.0, 'T_magma': 2900.0, 'Phi_global': 0.8},
+    )
+    with patch('proteus.proteus.UpdateStatusfile'):
+        with pytest.raises(RuntimeError, match='99 consecutive solves'):
+            q._check_atmosphere_deadlock()
+
+
+def test_check_atmosphere_deadlock_frozen_interior_still_aborts_first(tmp_path):
+    """A frozen interior keeps its own, much earlier abort.
+
+    Contract clause: the stall cap is a backstop for the case the frozen test
+    cannot see, so it must not delay the three-iteration abort that fires
+    when the interior has stopped moving as well.
+    """
+    frozen = {
+        'hf_all': pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0}]),
+        'hf_row': {'F_atm': 100.0, 'T_magma': 3000.0, 'Phi_global': 1.0},
+    }
+    p = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=3, **frozen)
+    p.agni_deadlock_count = 2
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        with pytest.raises(RuntimeError, match='consecutive AGNI failures'):
+            p._check_atmosphere_deadlock()
+    args, _ = mock_update.call_args
+    assert args[1] == 22
+
+    # Three frozen iterations is well inside the stall cap, so the two paths
+    # are not being confused for one another.
+    assert p.agni_deadlock_count == 3
+    assert p.agni_deadlock_count < p.atmos_stall_max
+
+
+def test_check_atmosphere_deadlock_reads_the_count_the_wrapper_produces(tmp_path):
+    """The count the abort reads is the one the atmosphere wrapper writes.
+
+    Contract clause: the two halves live in different modules, so this drives
+    the real producer, `carry_converged_levels`, rather than setting the
+    field by hand, and feeds the struct it leaves behind to the check.
+    """
+    from proteus.atmos_clim.common import Atmos_t
+    from proteus.atmos_clim.wrapper import carry_converged_levels
+
+    atmos_o = Atmos_t()
+    converged_row = {'R_xuv': 7.0e6, 'p_xuv': 1.0e2, 'T_xuv': 900.0, 'g_xuv': 9.5}
+
+    # One accepted solve gives the run something to fall back on.
+    atmos_o.converged = True
+    carry_converged_levels(atmos_o, dict(converged_row))
+    assert atmos_o.levels_stale_iters == 0
+
+    # Then the atmosphere stops resolving, once per iteration.
+    atmos_o.converged = False
+    for expected in range(1, 26):
+        carry_converged_levels(atmos_o, dict(converged_row))
+        assert atmos_o.levels_stale_iters == expected
+
+    p = _make_deadlock_proteus(
+        tmp_path,
+        converged=False,
+        hf_all=pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3050.0, 'Phi_global': 1.0}]),
+        hf_row={'F_atm': 140.0, 'T_magma': 3000.0, 'Phi_global': 0.9},
+    )
+    p.atmos_o = atmos_o
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        with pytest.raises(RuntimeError, match='25 consecutive solves'):
+            p._check_atmosphere_deadlock()
+    args, _ = mock_update.call_args
+    assert args[1] == 22
+
+    # A single accepted solve clears the count the wrapper keeps, so the run
+    # that recovers on its next iteration is not carrying a near-fatal state.
+    atmos_o.converged = True
+    carry_converged_levels(atmos_o, dict(converged_row))
+    assert atmos_o.levels_stale_iters == 0
+    p._check_atmosphere_deadlock()
+
+
+@pytest.mark.parametrize(
+    ('stored', 'expected'),
+    [(24.0, 24), (7.0, 7), (0.0, 0), (float('nan'), 0)],
+    ids=['one_short_of_the_cap', 'mid_streak', 'not_stalling', 'unreadable'],
+)
+def test_proteus_resume_restores_the_unresolved_atmosphere_count(tmp_path, stored, expected):
+    """A resume does not hand a stalling run a fresh allowance.
+
+    Contract clause: the count lives on a struct rebuilt at every start, and
+    the helpfile carries it, so a run killed part-way through a stall comes
+    back where it left off. Without this, any resume cadence shorter than the
+    cap defeats the abort entirely, which is the case a chronically stalling
+    run is most likely to be in.
+    """
+    p = _make_proteus_instance(tmp_path)
+    (tmp_path / 'data').mkdir(exist_ok=True)
+    df = _make_hf_df()
+    df['atm_levels_stale'] = [0.0, 0.0, 0.0, 0.0, stored]
+
+    _resume_with_patches(p, df)
+
+    assert p.atmos_o.levels_stale_iters == expected
+
+
+@pytest.mark.unit
+def test_proteus_resume_without_the_stale_column_starts_at_zero(tmp_path):
+    """A helpfile written before the column existed resumes as unstalled.
+
+    Contract clause: the restoration reads a column that older runs do not
+    carry, so its absence has to read as a run that has not stalled rather
+    than end the resume.
+    """
+    p = _make_proteus_instance(tmp_path)
+    (tmp_path / 'data').mkdir(exist_ok=True)
+    df = _make_hf_df()
+    assert 'atm_levels_stale' not in df.columns
+
+    _resume_with_patches(p, df)
+
+    assert p.atmos_o.levels_stale_iters == 0
+
+    # The same frame with the column present restores the stored value, so
+    # the zero above is the absent-column path and not a dropped read.
+    q = _make_proteus_instance(tmp_path)
+    df_with = _make_hf_df()
+    df_with['atm_levels_stale'] = [0.0, 0.0, 0.0, 0.0, 19.0]
+    _resume_with_patches(q, df_with)
+    assert q.atmos_o.levels_stale_iters == 19
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -248,13 +248,15 @@ def _make_deadlock_proteus(
     """
     from types import SimpleNamespace
 
+    from proteus.proteus import ATMOS_STALL_MAX
+
     p = _make_proteus_instance(tmp_path)
     p.atmos_o = SimpleNamespace(converged=bool(converged), levels_stale_iters=int(stale_iters))
     p.hf_all = hf_all
     p.hf_row = hf_row if hf_row is not None else {}
     p.agni_deadlock_count = 0
     p.agni_deadlock_max = 3
-    p.atmos_stall_max = 25
+    p.atmos_stall_max = ATMOS_STALL_MAX
     return p
 
 
@@ -553,6 +555,50 @@ def test_proteus_resume_restores_the_unresolved_atmosphere_count(tmp_path, store
     _resume_with_patches(p, df)
 
     assert p.atmos_o.levels_stale_iters == expected
+
+
+@pytest.mark.unit
+def test_atmos_stall_max_is_the_value_the_run_actually_uses(tmp_path):
+    """The stall cap is pinned, and the abort reads it rather than a literal.
+
+    Contract clause: the number decides when a run is given up on, so it must
+    not be changeable without a test noticing, and the check must not carry a
+    second copy of it. The ordering against the two neighbouring thresholds is
+    what has to hold whatever the number becomes: the wrapper reports a long
+    streak before anything aborts on it, and the frozen-interior abort stays
+    the earlier of the two.
+    """
+    from proteus.atmos_clim.wrapper import CARRIED_LEVELS_ALERT
+    from proteus.proteus import ATMOS_STALL_MAX
+
+    assert ATMOS_STALL_MAX == 25
+    assert ATMOS_STALL_MAX > CARRIED_LEVELS_ALERT
+    assert ATMOS_STALL_MAX > 3
+
+    # A constructed run carries the constant, so a literal reintroduced on
+    # the instance would diverge from the pin above.
+    assert _make_proteus_instance(tmp_path).atmos_stall_max == ATMOS_STALL_MAX
+
+    moving = {
+        'hf_all': pd.DataFrame([{'F_atm': 100.0, 'T_magma': 3050.0, 'Phi_global': 1.0}]),
+        'hf_row': {'F_atm': 140.0, 'T_magma': 3000.0, 'Phi_global': 0.9},
+    }
+
+    # The cap the check enforces is the one the constant carries, so moving
+    # the constant moves the abort with it.
+    p = _make_deadlock_proteus(tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX, **moving)
+    p.atmos_stall_max = ATMOS_STALL_MAX
+    with patch('proteus.proteus.UpdateStatusfile'):
+        with pytest.raises(RuntimeError, match=f'{ATMOS_STALL_MAX} consecutive solves'):
+            p._check_atmosphere_deadlock()
+
+    q = _make_deadlock_proteus(
+        tmp_path, converged=False, stale_iters=ATMOS_STALL_MAX - 1, **moving
+    )
+    q.atmos_stall_max = ATMOS_STALL_MAX
+    with patch('proteus.proteus.UpdateStatusfile') as mock_update:
+        q._check_atmosphere_deadlock()
+    mock_update.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/tools/test_migrate_config_v2_to_v3.py
+++ b/tests/tools/test_migrate_config_v2_to_v3.py
@@ -212,6 +212,10 @@ _REVIEWED_NEUTRAL = frozenset(
         'params.dt.mushy_maximum',
         'params.dt.mushy_upper',
         'params.dt.scale_decr',
+        # The unconverged-atmosphere criterion applies at its measured
+        # default, so a migrated config needs no explicit value for it.
+        'params.stop.stall.enabled',
+        'params.stop.stall.maximum',
         'params.dt.scale_incr',
         'params.dt.window',
         'params.out.dt_write_rel',


### PR DESCRIPTION
## Description

Closes #810.

A rejected AGNI solve still returns a structure, and the profile held on it can be one that cannot be interpolated onto the next pressure grid: pressures that are not finite, not positive, or not rising with depth abort the run inside scipy, and a temperature that is not finite is carried into the new profile and poisons the next solve. The stored profile is now checked before it is used and rebuilt from the surface boundary condition when it cannot be, and a boundary condition that is itself unusable ends the run as an atmosphere failure rather than as a bare exception from scipy.

Checking the stored profile is not enough on its own, so the surface state carried beside it is checked too, before any of it reaches the struct. A healthy profile with a spoiled surface state passed the profile check and was then used: the surface pressure sets the top of the interpolation grid, so an infinite one raises inside scipy exactly as an unusable profile did, and NaN is worse because the profile still looks healthy and every comparison against the value is false. Zero is treated differently either side of the boundary condition: a temperature of zero is not a temperature, but a surface pressure of zero is a planet that has lost its atmosphere, which desiccation produces deliberately and which transparent mode handles without reading the value, so pressure is held to being finite and non-negative and only the temperatures to being positive.

A run whose atmosphere never converges now ends rather than continuing indefinitely on rejected solves. The cap is 150 consecutive iterations. Measured across the 27 stalled cases from the GJ 9827 d campaign, the deepest stall a run recovered from is 126 consecutive rejected solves, after which it ran another 558 converged ones, and the deepest streak seen at all is 233 on a case that never recovered and was still unresolved when its job hit the walltime. The cap sits above the first with margin and below the second, and the comment carries both figures so the value reads as measurement rather than taste. It stays above the streak the atmosphere wrapper already reports at error level, and the frozen-interior deadlock keeps its own much earlier abort at three iterations.

## Validation of changes

macOS, Python 3.12, full local stack (AGNI, SOCRATES, Aragog, Zalmoxis, MORS).

- 2963 unit tests pass; ruff clean; `bash tools/validate_test_structure.sh` reports the structure complete.
- Every behavioural change is checked by reverting it and confirming a named test turns red: the cap back to 25 fails the pin, dropping the surface-state check fails the bypass test, and requiring a positive surface pressure fails both the boundary test and the transparent-mode routing test.
- The surface-state contract is exercised at each boundary it distinguishes: a surface pressure of zero and one below the transparent threshold pass, while a negative, infinite or NaN pressure and a zero or NaN temperature are refused with status 22.
- A surface pressure of zero is driven through `update_agni_atmos` and asserted to reach transparent mode without laying a pressure grid, since that routing is what makes accepting zero safe; a pressure above the threshold takes the grid instead, so the routing is a branch rather than the default.
- The tests no longer restate the cap: the streak they drive the check with, the message they match and the loop that counts up to the abort are all taken from the constant.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
