### PR TITLE
Drop the arithmetic from the golden-run column floor

### DIFF
--- a/tests/integration/test_integration_golden_run.py
+++ b/tests/integration/test_integration_golden_run.py
@@ -72,17 +72,11 @@ pytestmark = [pytest.mark.integration, pytest.mark.timeout(300)]
 CONFIG = PROTEUS_ROOT / 'tests' / 'integration' / 'golden_run.toml'
 REFERENCE = PROTEUS_ROOT / 'tests' / 'integration' / 'golden_run.tsv'
 
-# Floor on how much of the helpfile the comparison has to cover. The
-# configuration writes about 761 columns; a filter or a schema change that
-# started dropping most of them would otherwise leave the comparison passing
-# over almost nothing, since a reference recorded from the same narrowed run
-# would agree with it.
-#
-# Set to about 85% of what the configuration writes, so the floor still
-# catches a collapse while leaving room for a schema change that retires a
-# handful of columns. It has to be raised whenever the helpfile grows
-# substantially, or it stops discriminating: at 400 it would accept losing
-# nearly half of the columns written today.
+# Floor on how much of the helpfile the comparison has to cover. A filter or a
+# schema change that started dropping most of the columns would otherwise leave
+# the comparison passing over almost nothing, since a reference recorded from
+# the same narrowed run would agree with it. Raise it as the helpfile grows, or
+# it stops discriminating.
 MIN_COLUMNS_COMPARED = 650
 
 # Column perturbed to show the comparison can fail on this data, and by how
@@ -146,9 +140,8 @@ def test_fixed_run_reproduces_the_recorded_trajectory(tmp_path, request):
         '--record-golden in the same commit, so the diff shows what moved.'
     )
     assert len(check.comparison.compared) >= MIN_COLUMNS_COMPARED, (
-        f'only {len(check.comparison.compared)} columns were compared, below the '
-        f'{MIN_COLUMNS_COMPARED} this configuration writes; the comparison is no '
-        'longer covering the helpfile'
+        f'only {len(check.comparison.compared)} columns were compared, below the floor '
+        f'of {MIN_COLUMNS_COMPARED}; the comparison is no longer covering the helpfile'
     )
 
     # The comparison has to be able to fail on this data, not only on


### PR DESCRIPTION
## Description

The comment on the golden-run column floor carried the column count, the percentage the floor was set at, and an example of a value that would be too low. All three drift as the helpfile grows, and none of them is needed to understand what the floor is for. The schema check that landed alongside this test derives its coverage from `GetHelpfileKeys()`, so the numbers restated in the comment were a second copy that could go stale on its own. The floor itself and the reason for it stay.

The assertion beneath it described the floor as what the configuration writes. It is not: it is the floor, and the configuration writes more than it. The message now says which of the two it is reporting.

This is the follow-up promised on #812 rather than an optional tidy-up.

## Validation of changes

macOS with Python 3.12, on `main` at e60f5799.

- `tests/integration/test_integration_golden_run.py` passes; the floor and the constant it reads are untouched, so the comparison behaves exactly as before.
- `ruff check` and `ruff format --check` clean on the file.
- No code changed, only the comment above the constant and the text of one assertion message.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
