### PR TITLE
Refuse to resume a run whose helpfile predates schema columns

### DIFF
--- a/docs/How-to/troubleshooting.md
+++ b/docs/How-to/troubleshooting.md
@@ -10,6 +10,7 @@ step-by-step guide or the advice below,
 | Error / symptom | Section |
 |---|---|
 | `Aragog retry ladder exhausted` / T_core jumps >1500 K on coupled runs | [Numerically fragile coupled runs](#numerically-fragile-coupled-runs) |
+| `was written before N column(s) of the current output schema existed` | [Resuming an older run](#resuming-a-run-written-by-an-older-proteus) |
 | Simulation fails to converge (general) | [Stabilise a simulation](stabilise_run.md) |
 | `Permission denied (publickey)` | [SSH keys](#cannot-clone-module-or-permission-denied-publickey) |
 | `Out-of-date modules detected` | [Module updates](#out-of-date-modules-detected) |
@@ -43,6 +44,25 @@ The flag intercepts itself in `sys.argv` *before* any heavy imports, sets `JAX_E
 Do not enable by default; the flag has a small per-step cost. Use only when a config shows noise-floor divergence between launches.
 
 For broader convergence problems,see [stabilising simulations](stabilise_run.md).
+
+### Resuming a run written by an older PROTEUS {#resuming-a-run-written-by-an-older-proteus}
+
+`proteus start --resume` stops with a message naming columns the run's `runtime_helpfile.csv` does not carry:
+
+```text
+Helpfile 'output/<run>/runtime_helpfile.csv' was written before 3 column(s)
+of the current output schema existed: R_xuv, T_xuv, g_xuv.
+Run this configuration again from t=0, or read this run with the PROTEUS
+version that wrote it.
+```
+
+PROTEUS records one column per output quantity, and a resumed run reads its starting state from the last line of that file. A run paused before a quantity was added holds no value for it, so the run stops.
+
+Either run the configuration again from `t = 0`, or check out the PROTEUS version the run was launched with and read it under that version. There is deliberately no option to continue anyway. The absent columns cannot be filled with a placeholder, because several modules decide what to do by testing whether a quantity is present at all: CALLIOPE refuses a run whose oxygen budget is missing, the dummy and boundary interiors fall back to a configured core size, and the atmosphere lower boundary moves to the solvus only when a solvus radius exists. Supplying a placeholder satisfies each of those tests and passes the placeholder to the solver behind it, which produces a result that looks ordinary and is wrong.
+
+`proteus observe` and `proteus offchem` are held to a smaller set of columns, because reading a stored run to synthesise an observation or run offline chemistry touches only a small part of the schema. An archived run stays postprocessable after a schema addition it never used, and stops only when a column those commands actually read is absent. When that happens, the practical remedy for a run that is expensive or no longer possible to reproduce is the second one: check out the PROTEUS version the run was launched with and postprocess it under that version. Re-running from `t = 0` under current code does not reproduce the archived run, it produces a different one.
+
+To keep a long run resumable across an upgrade, note the PROTEUS version it was launched with and stay on it until the run finishes.
 
 ### Cannot clone module, or Permission denied (publickey) {#cannot-clone-module-or-permission-denied-publickey}
 

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -604,8 +604,17 @@ class Proteus:
             # Resuming from disk
             log.info('Resuming the simulation from the disk')
 
-            # Read helpfile from disk
-            self.hf_all = ReadHelpfileFromCSV(self.directories['output'])
+            # Read helpfile from disk. A run written before the output schema
+            # gained columns stops here, rather than continuing from a row that
+            # is missing those keys. A helpfile that cannot be loaded at all
+            # stops the same way: either leaves the run dead, and a run that
+            # dies without recording it reads as still running to anything
+            # polling the output directory.
+            try:
+                self.hf_all = ReadHelpfileFromCSV(self.directories['output'])
+            except Exception:
+                UpdateStatusfile(self.directories, 20)
+                raise
 
             # Check length
             if len(self.hf_all) <= self.loops['init_loops'] + 1:
@@ -1392,20 +1401,31 @@ class Proteus:
         archive.create(self.directories['output/data'], remove_files=True)
 
     def observe(self):
-        # Extract archived data
-        self.extract_archives()
+        # Load data from helpfile. Read it before unpacking the archive, so a
+        # run this cannot postprocess is left archived as it was found.
+        from proteus.utils.coupler import (
+            GetPostprocessingKeys,
+            HelpfileRow,
+            ReadHelpfileFromCSV,
+            helpfile_path,
+        )
 
-        # Load data from helpfile
-        from proteus.utils.coupler import ReadHelpfileFromCSV
-
-        hf_all = ReadHelpfileFromCSV(self.directories['output'])
+        hf_all = ReadHelpfileFromCSV(
+            self.directories['output'], required_columns=GetPostprocessingKeys()
+        )
 
         # Check length
         if len(hf_all) < 1:
             raise Exception('Simulation is too short to be postprocessed')
 
-        # Get last row
-        hf_row = hf_all.iloc[-1].to_dict()
+        # Extract archived data
+        self.extract_archives()
+
+        # Get last row. Wrapped so a column outside the postprocessing set,
+        # which the check above does not cover, still reports itself.
+        hf_row = HelpfileRow(
+            hf_all.iloc[-1].to_dict(), helpfile_path(self.directories['output'])
+        )
 
         # Run observations pipeline, typically invoked via CLI
         from proteus.observe.wrapper import run_observe
@@ -1413,20 +1433,31 @@ class Proteus:
         run_observe(hf_row, self.config, self.directories)
 
     def offline_chemistry(self):
-        # Extract archived data
-        self.extract_archives()
+        # Load data from helpfile. Read it before unpacking the archive, so a
+        # run this cannot postprocess is left archived as it was found.
+        from proteus.utils.coupler import (
+            GetPostprocessingKeys,
+            HelpfileRow,
+            ReadHelpfileFromCSV,
+            helpfile_path,
+        )
 
-        # Load data from helpfile
-        from proteus.utils.coupler import ReadHelpfileFromCSV
-
-        hf_all = ReadHelpfileFromCSV(self.directories['output'])
+        hf_all = ReadHelpfileFromCSV(
+            self.directories['output'], required_columns=GetPostprocessingKeys()
+        )
 
         # Check length
         if len(hf_all) < 1:
             raise Exception('Simulation is too short to be postprocessed')
 
-        # Get last row
-        hf_row = hf_all.iloc[-1].to_dict()
+        # Extract archived data
+        self.extract_archives()
+
+        # Get last row. Wrapped so a column outside the postprocessing set,
+        # which the check above does not cover, still reports itself.
+        hf_row = HelpfileRow(
+            hf_all.iloc[-1].to_dict(), helpfile_path(self.directories['output'])
+        )
 
         # Run offline chemistry, typically invoked via CLI
         from proteus.atmos_chem.wrapper import run_chemistry

--- a/src/proteus/utils/coupler.py
+++ b/src/proteus/utils/coupler.py
@@ -26,6 +26,7 @@ from proteus.utils.constants import (
     secs_per_hour,
     secs_per_minute,
     vol_gas_list,
+    vol_list,
 )
 from proteus.utils.helper import UpdateStatusfile, create_tmp_folder, get_proteus_dir, safe_rm
 from proteus.utils.plot import sample_times
@@ -1285,14 +1286,159 @@ def WriteHelpfileToCSV(output_dir: str, current_hf: pd.DataFrame):
     return fpath
 
 
-def ReadHelpfileFromCSV(output_dir: str):
+class HelpfileSchemaDriftError(Exception):
+    """A helpfile on disk lacks columns that the current output schema declares."""
+
+
+def helpfile_path(output_dir: str) -> str:
+    """Path to the helpfile of a run directory."""
+    return os.path.join(output_dir, 'runtime_helpfile.csv')
+
+
+class HelpfileRow(dict):
+    """One helpfile row that reports an absent column instead of a KeyError.
+
+    Postprocessing is held to `GetPostprocessingKeys()`, which is checked
+    before the run's archive is unpacked. That list is written by hand and
+    can fall behind the code, so this carries the same report to any column
+    outside it. Such a report necessarily arrives once a synthesis routine
+    reads the column, which is after the archive has been unpacked; only the
+    listed columns are caught early enough to leave a run untouched.
+
+    Membership tests and `get` with a default are untouched, so code that
+    already handles an absent column keeps working. `dict(row)`, `{**row}`
+    and `row.copy()` build a plain dict and lose the report, which is why
+    postprocessing passes the row itself around; `copy.copy` and pickling
+    keep it.
+    """
+
+    def __init__(self, row: dict, source: str):
+        super().__init__(row)
+        self.source = source
+
+    def __missing__(self, key):
+        raise HelpfileSchemaDriftError(
+            "Helpfile '%s' has no column '%s', which postprocessing this run "
+            'reads. It was written before that column existed. Run this '
+            'configuration again from t=0, or read this run with the PROTEUS '
+            'version that wrote it.' % (self.source, key)
+        )
+
+
+# Ceiling on how many column names a drift message spells out, so a very
+# old helpfile reports a readable summary instead of a wall of text.
+_DRIFT_REPORT_LIMIT = 12
+
+
+def _describe_missing_columns(missing: list[str]) -> str:
+    """Render missing column names for an error message."""
+    shown = ', '.join(missing[:_DRIFT_REPORT_LIMIT])
+    if len(missing) > _DRIFT_REPORT_LIMIT:
+        shown += ' (+%d more)' % (len(missing) - _DRIFT_REPORT_LIMIT)
+    return shown
+
+
+# Columns the observation and offline-chemistry pipelines index without a
+# fallback. Every other quantity they touch is read through `in` or `.get`
+# with a default, so its absence is already handled.
+_POSTPROCESSING_FIXED_KEYS = (
+    'Time',
+    'T_surf',
+    'P_surf',
+    'R_int',
+    'gravity',
+    'atm_kg_per_mol',
+    'R_star',
+    'T_star',
+    'separation',
+)
+
+
+def GetPostprocessingKeys():
+    """
+    Helpfile columns that postprocessing an existing run cannot do without.
+
+    Reading a stored run to synthesise an observation or run offline
+    chemistry touches a small part of the output schema, so those commands
+    are held to this set rather than to the whole of `GetHelpfileKeys()`.
+    An archived run stays readable after a schema addition it never used.
+
+    VULCAN indexes a per-element atmospheric mass and a per-gas volume
+    mixing ratio directly, so those expand from the element and volatile
+    lists. Both are fixed module constants, which keeps this set the same
+    for every run, as the full schema is.
+
+    Returns
+    -------
+    list of str
+        Column names, all of which are also in `GetHelpfileKeys()`.
+    """
+    keys = list(_POSTPROCESSING_FIXED_KEYS)
+    keys += [e + '_kg_atm' for e in element_list]
+    keys += [g + '_vmr' for g in vol_list]
+    return keys
+
+
+def ReadHelpfileFromCSV(output_dir: str, *, required_columns: list[str] | None = None):
     """
     Read helpfile from disk CSV file to DataFrame
+
+    A helpfile written before the output schema gained a column carries
+    neither that column nor any value for it. The entry points that turn a
+    stored run back into simulation state, resume and the two postprocessing
+    commands, all seed a working row from the last line of this table, so
+    the shortfall is caught here rather than in each of them. How much of
+    the schema a caller needs differs, which is what `required_columns` is
+    for. Readers that pull named columns straight out of the file, such as
+    the plotting and inference code, do not come through this function and
+    are not covered.
+
+    The shortfall is reported rather than filled. Seeding a value would make
+    the key present, and several modules decide what to do by testing whether
+    a key is there at all: CALLIOPE refuses a run whose oxygen budget is
+    absent, the dummy and boundary interiors fall back to a configured core
+    size, and the atmosphere lower boundary moves to the solvus only when a
+    solvus radius exists. A seeded zero turns each of those off and reaches
+    the solvers as a physical value no solver produced.
+
+    Parameters
+    ----------
+    output_dir : str
+        Directory holding ``runtime_helpfile.csv``.
+    required_columns : list of str, optional
+        Columns the caller cannot do without. Defaults to the whole of
+        ``GetHelpfileKeys()``, which is what resuming a run needs, since a
+        resumed row feeds every module. Postprocessing passes the smaller
+        ``GetPostprocessingKeys()`` so an archived run stays readable after
+        a schema addition it never used.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Helpfile contents as stored, carrying at least ``required_columns``.
+
+    Raises
+    ------
+    HelpfileSchemaDriftError
+        The file does not carry every required column.
     """
-    fpath = os.path.join(output_dir, 'runtime_helpfile.csv')
+    if required_columns is None:
+        required_columns = GetHelpfileKeys()
+
+    fpath = helpfile_path(output_dir)
     if not os.path.exists(fpath):
         raise Exception("Cannot find helpfile at '%s'" % fpath)
-    return pd.read_csv(fpath, sep=r'\s+')
+    hf_all = pd.read_csv(fpath, sep=r'\s+')
+
+    missing = sorted(set(required_columns) - set(hf_all.columns))
+    if missing:
+        raise HelpfileSchemaDriftError(
+            "Helpfile '%s' was written before %d column(s) of the current output "
+            'schema existed: %s. Run this configuration again from t=0, or read '
+            'this run with the PROTEUS version that wrote it.'
+            % (fpath, len(missing), _describe_missing_columns(missing))
+        )
+    return hf_all
 
 
 def _netcdf_readable(path: str) -> bool:

--- a/tests/test_proteus.py
+++ b/tests/test_proteus.py
@@ -230,6 +230,195 @@ def test_proteus_resume_mesh_no_prev(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Proteus.start(): refusing a helpfile that predates schema columns.
+# ---------------------------------------------------------------------------
+
+
+class _StopAfterHelpfileLoad(Exception):
+    """Sentinel exception to stop start() once the helpfile has been read."""
+
+
+def _resume_at_helpfile_load(p, *, read_effect=None):
+    """Drive start() as far as the helpfile load and stop there.
+
+    Returns the ReadHelpfileFromCSV and UpdateStatusfile mocks, which keep
+    their call history after the patches are lifted, plus the exception the
+    run ended on.
+    """
+    with ExitStack() as stack:
+        for target in _START_PATCHES:
+            stack.enter_context(patch(target))
+        stack.enter_context(
+            patch('proteus.interior_energetics.wrapper.get_nlevb', return_value=50)
+        )
+        mock_read = stack.enter_context(patch('proteus.utils.coupler.ReadHelpfileFromCSV'))
+        if read_effect is None:
+            mock_read.return_value = _make_hf_df()
+        else:
+            mock_read.side_effect = read_effect
+        # start() reads the helpfile, then hands it to snapshot selection.
+        # Stopping there keeps the test on the load and off the solver setup.
+        stack.enter_context(
+            patch(
+                'proteus.utils.coupler.select_resumable_snapshot',
+                side_effect=_StopAfterHelpfileLoad,
+            )
+        )
+        mock_status = stack.enter_context(patch('proteus.proteus.UpdateStatusfile'))
+
+        with pytest.raises(Exception) as excinfo:
+            p.start(resume=True, offline=True)
+
+    return mock_read, mock_status, excinfo.value
+
+
+@pytest.mark.unit
+def test_resume_records_an_error_status_on_helpfile_schema_drift(tmp_path):
+    """A refused resume writes the error status before it stops.
+
+    A run that died without updating its status file reads as still running
+    to every downstream tool that polls the output directory.
+    """
+    from proteus.utils.coupler import HelpfileSchemaDriftError
+
+    p = _make_proteus_instance(tmp_path)
+    drift = HelpfileSchemaDriftError('predates 2 column(s): M_atm, eccentricity')
+    mock_read, mock_status, ended_on = _resume_at_helpfile_load(p, read_effect=drift)
+
+    # The failure propagates rather than being swallowed into a partial run.
+    assert isinstance(ended_on, HelpfileSchemaDriftError)
+    assert 'M_atm' in str(ended_on)
+
+    statuses = [call.args[1] for call in mock_status.call_args_list]
+    assert 20 in statuses
+    # Discrimination: 0 is the start-of-run status written earlier, so the
+    # error status must be the last word and not merely present.
+    assert statuses[-1] == 20
+
+    # The resume asks for the shortfall to be reported and passes nothing
+    # that could soften it. A keyword here would mean an opt-out had been
+    # reintroduced, which is what makes a fabricated value reachable.
+    assert mock_read.call_args.kwargs == {}
+    assert mock_read.call_args.args == (p.directories['output'],)
+
+
+@pytest.mark.unit
+def test_resume_records_an_error_status_on_any_helpfile_load_failure(tmp_path):
+    """A resume that cannot read its helpfile at all records the same status.
+
+    Schema drift is one of several ways the load fails: the file may be
+    absent because the run died before its first write, or unparseable
+    because it was truncated. Each leaves the run just as dead, so each has
+    to leave the same mark on the status file.
+    """
+    p = _make_proteus_instance(tmp_path)
+
+    for label, effect in (
+        ('missing file', Exception("Cannot find helpfile at '/nowhere/runtime_helpfile.csv'")),
+        ('unparseable file', pd.errors.EmptyDataError('No columns to parse from file')),
+    ):
+        _, mock_status, ended_on = _resume_at_helpfile_load(p, read_effect=effect)
+
+        assert type(ended_on) is type(effect), label
+        statuses = [call.args[1] for call in mock_status.call_args_list]
+        assert statuses[-1] == 20, label
+        # Discrimination: 0 is written at the start of every run, so a status
+        # list of [0] alone is the untreated case this guards against.
+        assert statuses != [0], label
+
+
+@pytest.mark.unit
+def test_postprocessing_hands_the_physics_module_a_reporting_row(tmp_path):
+    """The row reaching the synthesis code reports a column it does not carry.
+
+    The required set is written by hand and can fall behind the code, so the
+    row itself has to say what is wrong for anything the set does not cover.
+    An ordinary dict would reach the same read as a bare KeyError.
+    """
+    from proteus.utils.coupler import (
+        GetPostprocessingKeys,
+        HelpfileRow,
+        HelpfileSchemaDriftError,
+    )
+
+    p = _make_proteus_instance(tmp_path)
+    p.config.atmos_chem.module = 'vulcan'
+
+    for method, wrapper in (
+        ('observe', 'proteus.observe.wrapper.run_observe'),
+        ('offline_chemistry', 'proteus.atmos_chem.wrapper.run_chemistry'),
+    ):
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(type(p), 'extract_archives'))
+            stack.enter_context(
+                patch('proteus.utils.coupler.ReadHelpfileFromCSV', return_value=_make_hf_df())
+            )
+            mock_wrapper = stack.enter_context(patch(wrapper))
+            getattr(p, method)()
+
+        # The two wrappers take the row in different positions, so select it
+        # by type. An unwrapped row yields no match, which is the regression
+        # this guards: it would reach the synthesis code as a bare dict.
+        handed = [a for a in mock_wrapper.call_args.args if isinstance(a, HelpfileRow)]
+        assert len(handed) == 1, method
+        row = handed[0]
+
+        # A column outside the required set reports itself on being read.
+        absent = 'struct_mass_desync_frac'
+        assert absent not in GetPostprocessingKeys()
+        with pytest.raises(HelpfileSchemaDriftError, match=absent):
+            row[absent]
+
+        # Discrimination: the columns the run does carry still read normally,
+        # so the wrapper reports a shortfall rather than blocking every read.
+        assert row['T_magma'] == pytest.approx(2200.0), method
+
+
+@pytest.mark.unit
+def test_postprocessing_refuses_a_helpfile_that_predates_schema_columns(tmp_path):
+    """observe() and offline_chemistry() stop on the same shortfall.
+
+    Both seed a working row from the last line of the same table and hand it
+    to a physics module, so neither may proceed on columns the run never
+    wrote.
+    """
+    from proteus.utils.coupler import HelpfileSchemaDriftError
+
+    p = _make_proteus_instance(tmp_path)
+    p.config.atmos_chem.module = 'vulcan'
+    drift = HelpfileSchemaDriftError('predates 1 column(s): R_xuv')
+
+    for method, wrapper in (
+        ('observe', 'proteus.observe.wrapper.run_observe'),
+        ('offline_chemistry', 'proteus.atmos_chem.wrapper.run_chemistry'),
+    ):
+        with ExitStack() as stack:
+            mock_extract = stack.enter_context(patch.object(type(p), 'extract_archives'))
+            mock_read = stack.enter_context(
+                patch('proteus.utils.coupler.ReadHelpfileFromCSV', side_effect=drift)
+            )
+            mock_wrapper = stack.enter_context(patch(wrapper))
+            with pytest.raises(HelpfileSchemaDriftError):
+                getattr(p, method)()
+
+        # Postprocessing is held to the columns it actually reads, not to the
+        # whole schema, so a run short of an unrelated diagnostic stays
+        # readable. Passing nothing here would restore the blanket check.
+        from proteus.utils.coupler import GetHelpfileKeys, GetPostprocessingKeys
+
+        required = mock_read.call_args.kwargs['required_columns']
+        assert set(required) == set(GetPostprocessingKeys()), method
+        assert set(required) < set(GetHelpfileKeys()), method
+
+        # Discrimination: the physics module is never reached, so no
+        # incomplete row can be handed to it.
+        assert mock_wrapper.call_count == 0, method
+        # The run is left archived as it was found. Unpacking first would
+        # delete the tar on the way to a refusal that was already certain.
+        assert mock_extract.call_count == 0, method
+
+
+# ---------------------------------------------------------------------------
 # Proteus._check_atmosphere_deadlock: AGNI-vs-interior deadlock detector.
 # Targets the previously-untested block at proteus.py:802-853 (now extracted
 # to a method on Proteus so it can be exercised in isolation).
@@ -471,7 +660,7 @@ def test_observe_raises_on_empty_helpfile(tmp_path):
     p = _make_proteus_instance(tmp_path)
     empty_df = pd.DataFrame()
     with (
-        patch.object(p, 'extract_archives'),
+        patch.object(p, 'extract_archives') as mock_extract,
         patch('proteus.utils.coupler.ReadHelpfileFromCSV', return_value=empty_df),
         patch('proteus.observe.wrapper.run_observe') as mock_run,
     ):
@@ -481,6 +670,9 @@ def test_observe_raises_on_empty_helpfile(tmp_path):
     # that swallowed the empty case and still dispatched would call
     # run_observe with an out-of-range index.
     assert mock_run.call_count == 0
+    # The run is left archived. Unpacking on the way to a refusal that was
+    # already certain deletes the tar for nothing.
+    assert mock_extract.call_count == 0
 
 
 def test_offline_chemistry_dispatches_to_run_chemistry_and_returns_result(tmp_path):
@@ -549,7 +741,7 @@ def test_offline_chemistry_raises_on_empty_helpfile(tmp_path):
     p = _make_proteus_instance(tmp_path)
     empty_df = pd.DataFrame()
     with (
-        patch.object(p, 'extract_archives'),
+        patch.object(p, 'extract_archives') as mock_extract,
         patch('proteus.utils.coupler.ReadHelpfileFromCSV', return_value=empty_df),
         patch('proteus.atmos_chem.wrapper.run_chemistry') as mock_chem,
     ):
@@ -557,10 +749,13 @@ def test_offline_chemistry_raises_on_empty_helpfile(tmp_path):
             p.offline_chemistry()
     assert mock_chem.call_count == 0
 
-
-# ---------------------------------------------------------------------------
-# Checkpoint restoration: spider_eos_dir + solidus/liquidus paths
-# ---------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
+    # Checkpoint restoration: spider_eos_dir + solidus/liquidus paths
+    # ---------------------------------------------------------------------------
+    # The run is left archived. offline_chemistry() takes the same order
+    # as observe(), so it needs the same guard against unpacking on the
+    # way to a refusal that was already certain.
+    assert mock_extract.call_count == 0
 
 
 def test_proteus_resume_restores_spider_eos_dir(tmp_path):

--- a/tests/utils/test_coupler.py
+++ b/tests/utils/test_coupler.py
@@ -37,17 +37,23 @@ import pandas as pd
 import pytest
 
 import proteus.utils.coupler as coupler_mod
-from proteus.utils.constants import element_list
+from proteus.utils.constants import element_list, vol_list
 from proteus.utils.coupler import (
+    _DRIFT_REPORT_LIMIT,
+    _POSTPROCESSING_FIXED_KEYS,
     CreateHelpfileFromDict,
     CreateLockFile,
     ExtendHelpfile,
     GetHelpfileKeys,
+    GetPostprocessingKeys,
+    HelpfileRow,
+    HelpfileSchemaDriftError,
     PrintCurrentState,
     ReadHelpfileFromCSV,
     WriteHelpfileToCSV,
     ZeroHelpfileRow,
     _atm_snapshot_names,
+    _describe_missing_columns,
     _get_current_time,
     _interior_snapshot_names,
     _netcdf_readable,
@@ -527,6 +533,384 @@ def test_write_helpfile_multiple_rows_roundtrip():
         assert len(hf_read) == 5
         assert hf_read['Time'].iloc[-1] == pytest.approx(4.0e7)
         assert hf_read['T_surf'].iloc[-1] == pytest.approx(340.0)
+
+
+# =============================================================================
+# Test: Helpfile Schema Drift
+# =============================================================================
+
+
+def _write_drifted_helpfile(tmpdir: str, dropped: list[str], n_rows: int = 3) -> None:
+    """Write a helpfile carrying every schema column except ``dropped``.
+
+    Stands in for a run whose CSV was written before those columns joined
+    the output schema. Every written column gets a distinct positive value,
+    so an assertion about what survived is not satisfied by zeros.
+    """
+    keys = [k for k in GetHelpfileKeys() if k not in set(dropped)]
+    row = {k: float(i + 1) for i, k in enumerate(keys)}
+    pd.DataFrame([row] * n_rows, columns=keys, dtype=float).to_csv(
+        os.path.join(tmpdir, 'runtime_helpfile.csv'),
+        index=False,
+        sep='\t',
+        float_format='%.10e',
+    )
+
+
+@pytest.mark.unit
+def test_read_helpfile_refuses_a_file_that_predates_schema_columns():
+    """A helpfile short of schema columns is refused, not completed.
+
+    An older run holds no value for a column added since. The refusal names
+    the columns and the file, which is what a user needs in order to decide
+    what to do with the run.
+    """
+    dropped = ['M_atm', 'eccentricity', 'solver_residual_J']
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_drifted_helpfile(tmpdir, dropped)
+
+        with pytest.raises(HelpfileSchemaDriftError) as excinfo:
+            ReadHelpfileFromCSV(tmpdir)
+
+        message = str(excinfo.value)
+        for col in dropped:
+            assert col in message
+        assert 'runtime_helpfile.csv' in message
+        assert 't=0' in message
+
+        # Discrimination: a column the file does carry must not be named, or
+        # the message is reciting the schema instead of the shortfall.
+        assert 'T_surf' not in message
+
+        # The refusal reads only. A regression that rewrote or truncated the
+        # file would cost the user the run it just declined to resume.
+        recovered = pd.read_csv(os.path.join(tmpdir, 'runtime_helpfile.csv'), sep=r'\s+')
+        assert len(recovered) == 3
+        assert not set(dropped) & set(recovered.columns)
+
+
+@pytest.mark.unit
+def test_absent_columns_are_never_seeded_into_the_returned_table():
+    """The loader hands back what the file holds, never a fabricated value.
+
+    Modules decide what to do by testing whether a key is present at all:
+    CALLIOPE refuses a run whose oxygen budget is absent, the dummy and
+    boundary interiors fall back to a configured core size, and the
+    atmosphere lower boundary moves to the solvus only when a solvus radius
+    exists. Seeding an absent column would satisfy every one of those tests
+    and pass a zero to the solver behind it.
+    """
+    guarded = ['O_kg_total', 'M_int', 'M_core', 'R_core', 'R_solvus', 'T_solvus', 'P_solvus']
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_drifted_helpfile(tmpdir, guarded)
+
+        # No table is returned at all, so no consumer can read a seeded key.
+        with pytest.raises(HelpfileSchemaDriftError):
+            ReadHelpfileFromCSV(tmpdir)
+
+        # Discrimination: with the same columns present the load succeeds and
+        # their values are exactly what the file holds, so the refusal above
+        # is caused by absence and not by the column names themselves.
+        _write_drifted_helpfile(tmpdir, [])
+        hf = ReadHelpfileFromCSV(tmpdir)
+        for col in guarded:
+            assert hf[col].iloc[-1] > 0.0
+        assert set(GetHelpfileKeys()) <= set(hf.columns)
+
+
+@pytest.mark.unit
+def test_describe_missing_columns_truncates_beyond_the_limit():
+    """Long column lists are truncated with the full count kept visible.
+
+    A run from many schema additions ago can be short hundreds of columns.
+    The summary stays readable while still reporting how many are absent, so
+    truncation never hides the scale of the drift.
+    """
+    names = ['col_%02d' % i for i in range(_DRIFT_REPORT_LIMIT + 8)]
+    rendered = _describe_missing_columns(names)
+
+    for col in names[:_DRIFT_REPORT_LIMIT]:
+        assert col in rendered
+    assert names[_DRIFT_REPORT_LIMIT] not in rendered
+    assert '(+8 more)' in rendered
+
+    # Edge case: a list exactly at the limit is shown whole, with no
+    # remainder marker claiming columns that are already listed.
+    exact = _describe_missing_columns(names[:_DRIFT_REPORT_LIMIT])
+    assert 'more)' not in exact
+    assert exact.count(', ') == _DRIFT_REPORT_LIMIT - 1
+
+    # Edge case: a single column renders as a bare name.
+    assert _describe_missing_columns(['only_one']) == 'only_one'
+
+
+@pytest.mark.unit
+def test_helpfile_drift_message_states_the_full_column_count():
+    """The refusal reports how many columns are absent, not just the listed ones."""
+    dropped = sorted(GetHelpfileKeys())[: _DRIFT_REPORT_LIMIT + 8]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_drifted_helpfile(tmpdir, dropped)
+
+        with pytest.raises(HelpfileSchemaDriftError) as excinfo:
+            ReadHelpfileFromCSV(tmpdir)
+
+        message = str(excinfo.value)
+        assert 'before %d column(s)' % len(dropped) in message
+        assert '(+8 more)' in message
+        # Discrimination: the count is the true shortfall, so a message that
+        # counted only the listed names would fail here.
+        assert str(_DRIFT_REPORT_LIMIT) + ' column(s)' not in message
+
+
+@pytest.mark.unit
+def test_refusal_precedes_the_key_gap_it_exists_to_prevent():
+    """The load stops before the row gap reaches the first completed iteration.
+
+    Resume seeds its working row from the last line of the table, so a file
+    predating a schema addition hands every later consumer a row short of
+    those keys. Catching it at the load turns a failure one iteration deep
+    into a refusal that names the cause.
+    """
+    dropped = ['M_atm', 'eccentricity', 'runtime']
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_drifted_helpfile(tmpdir, dropped)
+
+        with pytest.raises(HelpfileSchemaDriftError):
+            ReadHelpfileFromCSV(tmpdir)
+
+        # What the run would have hit instead, one iteration later: the same
+        # three columns, reported as a key gap with no cause attached.
+        raw = pd.read_csv(os.path.join(tmpdir, 'runtime_helpfile.csv'), sep=r'\s+')
+        with pytest.raises(Exception, match='missing expected keys') as excinfo:
+            ExtendHelpfile(raw, raw.iloc[-1].to_dict())
+        for col in dropped:
+            assert col in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_read_helpfile_with_the_current_schema_is_unchanged(caplog):
+    """A current-schema helpfile loads untouched and says nothing.
+
+    The check must be inert when there is nothing to report, so an ordinary
+    resume neither warns nor alters the table it read.
+    """
+    import logging
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        row = ZeroHelpfileRow()
+        row['Time'] = 3.0e6
+        row['T_surf'] = 1450.0
+        WriteHelpfileToCSV(tmpdir, CreateHelpfileFromDict(row))
+
+        with caplog.at_level(logging.WARNING, logger='fwl.proteus.utils.coupler'):
+            hf = ReadHelpfileFromCSV(tmpdir)
+
+        assert list(hf.columns) == list(GetHelpfileKeys())
+        assert hf['T_surf'].iloc[0] == pytest.approx(1450.0)
+        assert len(hf) == 1
+
+        joined = '\n'.join(r.getMessage() for r in caplog.records)
+        assert 'schema' not in joined
+
+
+# =============================================================================
+# Test: Postprocessing Column Requirement
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_helpfile_row_reports_an_absent_column_it_is_asked_for():
+    """A column outside the postprocessing set still reports itself when read.
+
+    The set of columns postprocessing needs is enumerated by hand, so it can
+    fall behind the code it describes. The row itself carries the report, so
+    a read the list did not anticipate says what is wrong instead of raising
+    a bare KeyError from inside a synthesis routine.
+    """
+    source = '/run/output/runtime_helpfile.csv'
+    row = HelpfileRow({'T_surf': 1450.0, 'R_int': 6.371e6}, source)
+
+    assert row['T_surf'] == pytest.approx(1450.0)
+
+    with pytest.raises(HelpfileSchemaDriftError) as excinfo:
+        row['R_xuv']
+    message = str(excinfo.value)
+    assert 'R_xuv' in message
+    assert source in message
+    # Discrimination: the report names the column asked for, not a column
+    # that happens to be present.
+    assert 'T_surf' not in message
+
+
+@pytest.mark.unit
+def test_helpfile_row_leaves_the_tolerant_reads_alone():
+    """Code that already handles an absent column keeps working unchanged.
+
+    Several postprocessing reads test membership or pass a default precisely
+    because a column may be absent. Reporting those as a shortfall would
+    turn a handled case into a refusal.
+    """
+    row = HelpfileRow({'H2O_vmr': 0.4}, '/run/output/runtime_helpfile.csv')
+
+    assert 'CO2_vmr' not in row
+    assert row.get('CO2_vmr', 0.0) == pytest.approx(0.0)
+    assert row.get('H2O_vmr', 0.0) == pytest.approx(0.4)
+    # Discrimination: membership is false rather than raising, which is what
+    # `if key in hf_row` in the synthesis code depends on.
+    assert 'H2O_vmr' in row
+
+
+@pytest.mark.unit
+def test_helpfile_row_survives_copying_but_not_rebuilding():
+    """Pin which ways of duplicating the row keep the report and which lose it.
+
+    The class docstring tells a reader that rebuilding the row as a plain
+    dict drops the report while copying it does not. That distinction is not
+    obvious from the code, so it is pinned here rather than left as a claim.
+    """
+    import copy
+
+    row = HelpfileRow({'T_surf': 1450.0}, '/run/output/runtime_helpfile.csv')
+
+    for label, kept in (
+        ('copy.copy', copy.copy(row)),
+        ('copy.deepcopy', copy.deepcopy(row)),
+    ):
+        assert isinstance(kept, HelpfileRow), label
+        assert kept.source == row.source, label
+        with pytest.raises(HelpfileSchemaDriftError, match='R_xuv'):
+            kept['R_xuv']
+
+    for label, rebuilt in (
+        ('dict()', dict(row)),
+        ('unpacking', {**row}),
+        ('dict.copy', row.copy()),
+    ):
+        assert not isinstance(rebuilt, HelpfileRow), label
+        # Discrimination: the values survive, so what is lost is the report
+        # and not the data. A plain KeyError is what a reader is warned about.
+        assert rebuilt['T_surf'] == pytest.approx(1450.0), label
+        with pytest.raises(KeyError):
+            rebuilt['R_xuv']
+
+
+@pytest.mark.unit
+def test_helpfile_row_reports_through_any_reference_to_it():
+    """The report follows the row, not the name it is read through.
+
+    A read reached after the row is assigned to a local, stored on an
+    object, or put in a container is the same object, so the column is
+    reported wherever the read happens.
+    """
+    source = '/run/output/runtime_helpfile.csv'
+    row = HelpfileRow({'T_surf': 1450.0}, source)
+
+    local = row
+    holder = types.SimpleNamespace(hf_row=row)
+    container = {'row': row}
+
+    for label, reference in (
+        ('local', local),
+        ('attribute', holder.hf_row),
+        ('container', container['row']),
+    ):
+        with pytest.raises(HelpfileSchemaDriftError, match='P_solvus'):
+            reference['P_solvus']
+        assert reference['T_surf'] == pytest.approx(1450.0), label
+
+
+@pytest.mark.unit
+def test_postprocessing_keys_are_a_strict_subset_of_the_schema():
+    """The postprocessing set is drawn from the schema and is smaller than it.
+
+    A key outside the schema could never be satisfied by any helpfile, and a
+    set equal to the schema would be the blanket check it exists to replace.
+    """
+    schema = set(GetHelpfileKeys())
+    keys = GetPostprocessingKeys()
+
+    assert set(keys) < schema
+    assert len(keys) == len(set(keys)), 'duplicate entries would over-report a shortfall'
+    # The set is fixed rather than config-derived, so two calls agree and no
+    # run can be refused for a requirement another run would not have had.
+    assert GetPostprocessingKeys() == keys
+
+
+@pytest.mark.unit
+def test_postprocessing_ignores_a_column_it_never_reads():
+    """A run short of a column postprocessing does not read still loads.
+
+    This is the whole point of the narrower set: a diagnostic added after an
+    archived run finished must not stop that run being postprocessed.
+    """
+    unread = 'struct_mass_desync_frac'
+    assert unread in GetHelpfileKeys()
+    assert unread not in GetPostprocessingKeys()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_drifted_helpfile(tmpdir, [unread])
+
+        hf = ReadHelpfileFromCSV(tmpdir, required_columns=GetPostprocessingKeys())
+        assert len(hf) == 3
+        assert set(GetPostprocessingKeys()) <= set(hf.columns)
+
+        # Discrimination: the same file is refused for a resume, so the two
+        # requirements are genuinely different and not both wide open.
+        with pytest.raises(HelpfileSchemaDriftError, match=unread):
+            ReadHelpfileFromCSV(tmpdir)
+
+
+@pytest.mark.unit
+def test_postprocessing_set_does_not_lose_a_key():
+    """No column drops out of the postprocessing requirement unnoticed.
+
+    The requirement is written by hand from the reads in ``observe/`` and
+    ``atmos_chem/``. Naming the members again here does not prove the list is
+    complete, since both are written by the same reading; it catches a member
+    being dropped, which would move that column's report from the load, which
+    happens before the run archive is unpacked, into a synthesis routine.
+    """
+    required = set(GetPostprocessingKeys())
+    named = {
+        'Time',
+        'T_surf',
+        'P_surf',
+        'R_int',
+        'gravity',
+        'atm_kg_per_mol',
+        'R_star',
+        'T_star',
+        'separation',
+    }
+    assert named <= required, 'dropped from the requirement: %s' % sorted(named - required)
+
+    # The two computed reads expand over fixed lists, so every member counts.
+    assert {e + '_kg_atm' for e in element_list} <= required
+    assert {g + '_vmr' for g in vol_list} <= required
+
+    # Discrimination: the requirement is not simply the whole schema, so the
+    # assertions above are not satisfied by a set that covers everything.
+    assert 'struct_mass_desync_frac' not in required
+
+
+@pytest.mark.unit
+def test_postprocessing_still_refuses_a_column_it_does_read():
+    """A run short of a column postprocessing indexes is refused.
+
+    The narrower requirement is not a way of proceeding regardless: a key
+    the synthesis code reads without a fallback still has to be there.
+    """
+    probes = list(_POSTPROCESSING_FIXED_KEYS) + ['H2O_vmr', 'O_kg_atm']
+    assert len(probes) == 11, 'expected every fixed key plus one of each expansion'
+    for needed in probes:
+        assert needed in GetPostprocessingKeys()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_drifted_helpfile(tmpdir, [needed])
+            with pytest.raises(HelpfileSchemaDriftError, match=needed) as excinfo:
+                ReadHelpfileFromCSV(tmpdir, required_columns=GetPostprocessingKeys())
+            # Discrimination: exactly the absent column is reported, not the
+            # whole requirement, so the count reflects the real shortfall.
+            assert 'before 1 column(s)' in str(excinfo.value)
 
 
 # =============================================================================
@@ -1965,7 +2349,7 @@ def test_assert_mass_conservation_accepts_noble_gas_inventory():
     Discriminating: the noble gases hold 5e16 kg against 1.1e19 kg of reactive
     volatiles, a 0.45 percent contribution.
     """
-    from proteus.utils.constants import noble_gases, vol_gas_list, vol_list
+    from proteus.utils.constants import noble_gases, vol_gas_list
     from proteus.utils.coupler import assert_mass_conservation
 
     hf_row = {'M_planet': 5.97e24}


### PR DESCRIPTION
## Description

Closes #811.

Resume reads its starting state from the last line of the run's `runtime_helpfile.csv`. A run paused before the output schema gained a column carries no value for it, so the resumed row is short those keys and `ExtendHelpfile` fails one iteration later with a message naming keys but not the cause. Every schema addition made all older runs non-resumable that way.

`ReadHelpfileFromCSV` now compares the file against the columns its caller needs and raises `HelpfileSchemaDriftError` naming the absent ones, the file, and the two ways forward: run the configuration again from `t = 0`, or read the run with the PROTEUS version that wrote it. The check sits at the read because that is where every entry point turning a stored run back into simulation state passes through. The resume path catches any failure to load the helpfile only to record the error status before re-raising, so a run that stops this way does not read as still running to anything polling the output directory.

The issue offered three designs. This is the first, refuse and explain, and the substantive decision is that absent columns are **not** filled with a placeholder. Several modules decide what to do by testing whether a quantity is present at all, so a placeholder is not inert:

| Site | Guard | With a placeholder |
|---|---|---|
| `outgas/calliope.py:353` | `if 'O_kg_total' not in hf_row: raise` | CALLIOPE receives an oxygen budget of exactly zero |
| `interior_energetics/dummy.py:62` | `if 'M_int' in hf_row and 'M_core' in hf_row` | `M_mantle = 0 - 0 = 0 kg`, skipping the density fallback |
| `interior_energetics/boundary.py:93` | `if 'R_core' in hf_row` | `core_radius = 0 m`, skipping the configured `core_frac` |
| `proteus.py` solvus override | `global_miscibility and 'R_solvus' in hf_row` | fires, sending `T_surf = 0 K`, `T_magma = 0 K`, `P_surf = 0 bar`, `R_int = 0 m` to the atmosphere solver |

The last is reachable precisely on the resume path, because a resumed run continues from its on-disk structure and so nothing overwrites the placeholder before the atmosphere solve reads it. Each was reproduced by executing the loader and inspecting what the guard sees. Stopping costs a re-run; continuing costs a result that looks ordinary and is wrong.

How much of the schema a caller needs differs. A resumed row feeds every module, so resume requires all 762 columns. `proteus observe` and `proteus offchem` index a few dozen without a fallback, so they are held to those and an archived run stays readable after a schema addition it never used; without this, postprocessing a run missing a column it never reads would have started failing where it previously worked. Both also read the helpfile, and check it is long enough, before unpacking the run archive, so a run they cannot postprocess is left archived as it was found.

That smaller set is written by hand and can fall behind the code it describes, so the row those two commands work from carries the report itself: a column outside the set says what is wrong when it is read, rather than surfacing as a bare `KeyError` from inside a synthesis routine. Being a runtime check it necessarily reports after extraction, so only the enumerated columns are caught early enough to leave a run untouched. Membership tests and reads with a default are unaffected, so the several places that already handle an absent column keep working.

The healthy path is untouched: with nothing absent the loader returns exactly what `pd.read_csv` produced, as before.

## Validation of changes

macOS 15 (Darwin 25.3.0, arm64), Python 3.12, all-dummy configuration.

- `pytest -m "unit and not skip and not slow and not integration" --ignore=tests/examples`: 2963 passed, 11 skipped. `ruff check` and `ruff format --check` clean; `bash tools/validate_test_structure.sh` passes.
- New tests in `tests/utils/test_coupler.py` and `tests/test_proteus.py`. I checked each behaviour by breaking its code path and confirming a covering test fails: never detecting the shortfall, detecting but not refusing, narrowing the default requirement, dropping the column names, file path or count from the message, removing the list truncation, always appending the truncation marker, dropping a fixed postprocessing key, dropping either computed expansion, widening the postprocessing set to the whole schema, the row report returning instead of raising, the row report omitting the column, dropping the status write, writing a success status instead, narrowing the status write back to one exception type, leaving the postprocessing row unwrapped, and unpacking the archive before either the schema or the length check. All were caught.
- Coupled runs, not just unit tests. A 21-iteration dummy run, then columns removed from its helpfile to stand in for an older schema. `proteus start -r` exits 1, writes status 20, and names the columns; `proteus observe` on a run missing only a column it never reads gets past the load; `proteus observe` on a run missing `T_star`, which it does read, stops; and restoring the intact helpfile, `proteus start -r` resumes at row 21 and runs to completion with status 12.
- Edge cases probed directly: a header-only file with the full schema loads as an empty frame, a header-only file one column short is refused, a file carrying a column the schema has since dropped loads unchanged, and a duplicated header column does not cause a false refusal. A completely empty file raises pandas' `EmptyDataError`, which is what it did before this change.
- `GetHelpfileKeys()` takes no arguments and returns the same 762 columns on every call, and `GetPostprocessingKeys()` expands from the same fixed element and volatile lists, so neither can fire on a healthy run whose config differs from the one that wrote the file.

Two notes for follow-up rather than for this PR. `_populate_energy_residual` carries a re-anchor for a helpfile missing `E_state_heat_cons_J`; the refusal makes that branch unreachable from the resume path and it is left as it is. Separately, `plot/`, `inference/`, `grid/` and `tools/` read `runtime_helpfile.csv` with their own `pd.read_csv` calls rather than through this loader; they are unaffected here because they read named columns and feed no solver, but they sit outside the guarantee this check provides.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
