### PR TITLE
Give seventeen single-assertion tests something that discriminates

### DIFF
--- a/tests/config/test_star_validators.py
+++ b/tests/config/test_star_validators.py
@@ -55,9 +55,15 @@ def test_star_bol_scale_duration_rejects_negative():
 def test_star_bol_scale_duration_accepts_zero_boundary():
     """Exactly zero is the inclusive lower boundary of ``ge(0.0)`` and is
     also the default; it must be accepted, not rejected as a degenerate
-    (zero-width) window."""
+    (zero-width) window. What makes the boundary inclusive rather than the
+    field simply unchecked is that the value just below it is refused."""
     star = Star(bol_scale_duration=0.0)
     assert star.bol_scale_duration == pytest.approx(0.0, abs=1e-15)
+
+    # Discrimination: the bound is ge(0.0), so the first value under it fails.
+    # Without this, a field carrying no bound at all would pass the check above.
+    with pytest.raises(Exception, match='bol_scale_duration'):
+        Star(bol_scale_duration=-1.0e-9)
 
 
 @pytest.mark.unit

--- a/tests/data/test_manifest.py
+++ b/tests/data/test_manifest.py
@@ -163,10 +163,10 @@ def test_unknown_dataset_key_is_rejected():
     with pytest.raises(KeyError):
         _dataset('observe.not_a_declared_dataset')
 
-    # Discrimination: a key the manifest does declare resolves, so the raise
-    # above follows from the key being absent rather than from the lookup
-    # refusing everything it is asked for.
-    assert _dataset(MASS_RADIUS_ZENG_2019) is not None
+    # Discrimination: a key the manifest does declare resolves, and to that
+    # same dataset, so the raise above follows from the key being absent
+    # rather than from the lookup refusing or mis-resolving what it is asked.
+    assert _dataset(MASS_RADIUS_ZENG_2019).key == MASS_RADIUS_ZENG_2019
 
 
 def test_stale_fwl_io_is_named_as_the_stale_side(monkeypatch):
@@ -255,11 +255,10 @@ def test_declared_floor_matches_the_requirement():
         if spec.operator == '>='
     ]
 
-    assert bounds == [FWL_IO_FLOOR], f'pyproject floor {bounds} vs module floor {FWL_IO_FLOOR}'
-    # Discrimination: the requirement really does carry a lower bound. Were the
-    # `>=` dropped from pyproject, `bounds` would be empty and the comparison
-    # above would report a mismatch rather than the absence it actually is.
+    # Checked first so a dropped `>=` reports the absence it is, rather than
+    # reaching the comparison below and reading as a version mismatch.
     assert len(bounds) == 1, f'expected one lower bound on fwl-io, found {bounds}'
+    assert bounds == [FWL_IO_FLOOR], f'pyproject floor {bounds} vs module floor {FWL_IO_FLOOR}'
 
 
 def test_manifest_and_registries_are_declared_as_package_data():

--- a/tests/data/test_manifest.py
+++ b/tests/data/test_manifest.py
@@ -145,8 +145,13 @@ def test_dataset_dir_rejects_an_unversioned_resolution(tmp_path, monkeypatch):
 
     monkeypatch.setattr('proteus.data._fetcher', lambda *a, **k: _UnversionedFetcher())
 
-    with pytest.raises(RuntimeError, match='unversioned'):
+    with pytest.raises(RuntimeError, match='unversioned') as raised:
         dataset_dir(MASS_RADIUS_ZENG_2019, data_root=tmp_path)
+
+    # Discrimination: the guard names the path it refused, which is what sends
+    # the reader to the right directory. A message saying only that something
+    # was unversioned would satisfy the match above and tell them nothing.
+    assert 'zeng_2019' in str(raised.value)
 
 
 def test_unknown_dataset_key_is_rejected():
@@ -157,6 +162,11 @@ def test_unknown_dataset_key_is_rejected():
     """
     with pytest.raises(KeyError):
         _dataset('observe.not_a_declared_dataset')
+
+    # Discrimination: a key the manifest does declare resolves, so the raise
+    # above follows from the key being absent rather than from the lookup
+    # refusing everything it is asked for.
+    assert _dataset(MASS_RADIUS_ZENG_2019) is not None
 
 
 def test_stale_fwl_io_is_named_as_the_stale_side(monkeypatch):
@@ -194,8 +204,13 @@ def test_manifest_error_under_a_current_fwl_io_propagates(monkeypatch):
     monkeypatch.setattr(fwl_io, 'load_manifest', _rejects)
     monkeypatch.setattr('proteus.data._fwl_io_derives_the_location', lambda: True)
 
-    with pytest.raises(ValueError, match='malformed'):
+    with pytest.raises(ValueError, match='malformed') as raised:
         _dataset(MASS_RADIUS_ZENG_2019)
+
+    # Discrimination: the message carries the manifest's own complaint and not
+    # an upgrade instruction, which is the whole point of separating a defect
+    # we ship from a dependency that is out of date.
+    assert 'fwl-io' not in str(raised.value).lower()
 
 
 def test_capability_check_reads_the_installed_fwl_io(monkeypatch):
@@ -241,6 +256,10 @@ def test_declared_floor_matches_the_requirement():
     ]
 
     assert bounds == [FWL_IO_FLOOR], f'pyproject floor {bounds} vs module floor {FWL_IO_FLOOR}'
+    # Discrimination: the requirement really does carry a lower bound. Were the
+    # `>=` dropped from pyproject, `bounds` would be empty and the comparison
+    # above would report a mismatch rather than the absence it actually is.
+    assert len(bounds) == 1, f'expected one lower bound on fwl-io, found {bounds}'
 
 
 def test_manifest_and_registries_are_declared_as_package_data():

--- a/tests/interior_energetics/test_timestep_bolscale_event.py
+++ b/tests/interior_energetics/test_timestep_bolscale_event.py
@@ -55,6 +55,12 @@ def test_estimate_bolscale_disabled_when_bol_scale_is_one():
     hf_all = _hf_all_with_age(age_star=0.7e9)  # inside the window, if it mattered
     assert _estimate_bolscale(hf_all, config) == np.inf
 
+    # Discrimination: the same window with a scaling that is not unity does
+    # constrain the step, so the sentinel above follows from bol_scale rather
+    # than from a window that reaches nothing at this age.
+    scaling = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    assert np.isfinite(_estimate_bolscale(hf_all, scaling))
+
 
 @pytest.mark.physics_invariant
 def test_estimate_bolscale_disabled_when_bol_scale_start_is_none():
@@ -63,6 +69,12 @@ def test_estimate_bolscale_disabled_when_bol_scale_start_is_none():
     config = _config_with_star(bol_scale=2.0, bol_scale_start=None, bol_scale_duration=0.0)
     hf_all = _hf_all_with_age(age_star=0.7e9)
     assert _estimate_bolscale(hf_all, config) == np.inf
+
+    # Discrimination: the same scaling with a window does constrain the step,
+    # so the sentinel above follows from the missing start rather than from the
+    # scaling being ignored.
+    windowed = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
+    assert np.isfinite(_estimate_bolscale(hf_all, windowed))
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +107,9 @@ def test_estimate_bolscale_inside_window_returns_time_until_end():
     hf_all = _hf_all_with_age(age_star=7.0e8)
     dt_bolscale = _estimate_bolscale(hf_all, config)
     assert dt_bolscale == pytest.approx(3.0e8, rel=1e-9)
+    # Discrimination: the window is 5.0e8 yr wide, so a branch returning the
+    # whole duration rather than what is left of it lands there instead.
+    assert abs(dt_bolscale - 5.0e8) > 1.0e7
 
 
 @pytest.mark.physics_invariant
@@ -104,6 +119,12 @@ def test_estimate_bolscale_after_window_returns_inf():
     config = _config_with_star(bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5)
     hf_all = _hf_all_with_age(age_star=1.1e9)
     assert _estimate_bolscale(hf_all, config) == np.inf
+
+    # Discrimination: an age inside the same window is constrained, so the
+    # sentinel above follows from the window having closed rather than from
+    # this configuration never constraining anything.
+    inside = _hf_all_with_age(age_star=7.0e8)
+    assert np.isfinite(_estimate_bolscale(inside, config))
 
 
 def test_estimate_bolscale_boundary_at_exact_start_uses_during_branch():
@@ -116,6 +137,9 @@ def test_estimate_bolscale_boundary_at_exact_start_uses_during_branch():
     hf_all = _hf_all_with_age(age_star=5.0e8)  # == age_ini exactly
     dt_bolscale = _estimate_bolscale(hf_all, config)
     assert dt_bolscale == pytest.approx(5.0e8, rel=1e-9)  # age_end - age_now = 1e9 - 5e8
+    # Discrimination: the before branch would return age_ini - age_now, which
+    # is zero at this boundary and would stall the step rather than size it.
+    assert dt_bolscale > 1.0e7
 
 
 def test_estimate_bolscale_defaults_missing_age_star_column_to_zero():
@@ -128,6 +152,12 @@ def test_estimate_bolscale_defaults_missing_age_star_column_to_zero():
     hf_all = pd.DataFrame({'Time': [0.0, 1.0, 2.0]})  # no age_star column
     dt_bolscale = _estimate_bolscale(hf_all, config)
     assert dt_bolscale == pytest.approx(5.0e8, rel=1e-9)
+    # Discrimination: a frame carrying the column at zero gives the same
+    # answer, so the missing column is read as zero rather than skipping the
+    # age comparison altogether.
+    assert dt_bolscale == pytest.approx(
+        _estimate_bolscale(_hf_all_with_age(age_star=0.0), config), rel=1e-9
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +246,15 @@ def test_next_step_does_not_clip_when_window_is_far_away():
 
     dt = next_step(config, {}, hf_row, hf_all, step_sf=1.0)
     assert dt == pytest.approx(1.0e5, rel=1e-9)
+    # Discrimination: the same controller with the window close at hand does
+    # clip, so the value above is the ceiling passing through rather than a
+    # step the clip never reaches on any configuration.
+    near = _next_step_config(
+        dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
+    )
+    # 1.0e3 yr short of the window, well inside the 1.0e5 yr ceiling.
+    close = _next_step_hf_all(age_star=4.99999e8)
+    assert next_step(near, {}, hf_row, close, step_sf=1.0) < 1.0e5
 
 
 def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
@@ -232,6 +271,11 @@ def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
     # Static time-step branch returns exactly 1.0 yr
     dt = next_step(config, {}, hf_row, None, step_sf=1.0)
     assert dt == pytest.approx(1.0)
+    # Discrimination: handing the same call a history rather than None leaves
+    # the static branch answering the same way, so what is pinned above is the
+    # gate holding rather than the history being what produced the value.
+    with_history = next_step(config, {}, hf_row, _next_step_hf_all(age_star=7.0e8), step_sf=1.0)
+    assert with_history == pytest.approx(1.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interior_energetics/test_timestep_bolscale_event.py
+++ b/tests/interior_energetics/test_timestep_bolscale_event.py
@@ -127,6 +127,7 @@ def test_estimate_bolscale_after_window_returns_inf():
     assert np.isfinite(_estimate_bolscale(inside, config))
 
 
+@pytest.mark.physics_invariant
 def test_estimate_bolscale_boundary_at_exact_start_uses_during_branch():
     """age_now exactly equal to age_ini fails the strict `age_now <
     age_ini` "before" check and falls into the `elif age_now < age_end`
@@ -142,6 +143,7 @@ def test_estimate_bolscale_boundary_at_exact_start_uses_during_branch():
     assert dt_bolscale > 1.0e7
 
 
+@pytest.mark.physics_invariant
 def test_estimate_bolscale_defaults_missing_age_star_column_to_zero():
     """hf_all without an 'age_star' column must not raise: the source
     reads it via ``.get('age_star', 0.0)``. This is the error-contract
@@ -152,12 +154,12 @@ def test_estimate_bolscale_defaults_missing_age_star_column_to_zero():
     hf_all = pd.DataFrame({'Time': [0.0, 1.0, 2.0]})  # no age_star column
     dt_bolscale = _estimate_bolscale(hf_all, config)
     assert dt_bolscale == pytest.approx(5.0e8, rel=1e-9)
-    # Discrimination: a frame carrying the column at zero gives the same
-    # answer, so the missing column is read as zero rather than skipping the
-    # age comparison altogether.
-    assert dt_bolscale == pytest.approx(
-        _estimate_bolscale(_hf_all_with_age(age_star=0.0), config), rel=1e-9
-    )
+    # Discrimination: an age inside the window takes the other branch and
+    # returns the time to its end, so the value above is the default of zero
+    # driving the before-the-window formula rather than a figure this
+    # configuration returns for any frame it is handed.
+    during = _estimate_bolscale(_hf_all_with_age(age_star=7.0e8), config)
+    assert during == pytest.approx(3.0e8, rel=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -257,11 +259,12 @@ def test_next_step_does_not_clip_when_window_is_far_away():
     assert next_step(near, {}, hf_row, close, step_sf=1.0) < 1.0e5
 
 
+@pytest.mark.physics_invariant
 def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
-    """On the very first call (no history yet), hf_all is None; the
-    ``if hf_all is not None`` gate must skip `_estimate_bolscale` entirely
-    rather than crashing on ``None.iloc[-1]``. Force the static branch
-    (Time < 2 yr) so no other part of next_step needs hf_all either.
+    """On the very first call there is no history yet, so hf_all is None and
+    ``if hf_all is not None`` must skip `_estimate_bolscale` rather than
+    crashing on ``None.iloc[-1]``. Force the static branch (Time < 2 yr) so
+    no other part of next_step needs hf_all either.
     """
     config = _next_step_config(
         dt_maximum=1.0e5, bol_scale=2.0, bol_scale_start=0.5, bol_scale_duration=0.5
@@ -271,11 +274,15 @@ def test_next_step_skips_bolscale_clip_when_hf_all_is_none():
     # Static time-step branch returns exactly 1.0 yr
     dt = next_step(config, {}, hf_row, None, step_sf=1.0)
     assert dt == pytest.approx(1.0)
-    # Discrimination: handing the same call a history rather than None leaves
-    # the static branch answering the same way, so what is pinned above is the
-    # gate holding rather than the history being what produced the value.
-    with_history = next_step(config, {}, hf_row, _next_step_hf_all(age_star=7.0e8), step_sf=1.0)
-    assert with_history == pytest.approx(1.0)
+
+    # Discrimination: the same call given a history whose window opens a
+    # quarter of a year out clips the static step to that remaining time, so
+    # the value above is the clamp being skipped rather than a step no window
+    # could shorten. The window opens at 5.0e8 yr.
+    near_edge = _next_step_hf_all(age_star=5.0e8 - 0.25)
+    assert next_step(config, {}, hf_row, near_edge, step_sf=1.0) == pytest.approx(
+        0.25, rel=1e-9
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -660,6 +660,12 @@ class TestGetScriptForPackage:
         mixed-case name still resolves (dist names are normally lowercase, but
         the helper must not depend on that)."""
         assert _get_script_for_package('FWL-Zalmoxis') == 'tools/get_zalmoxis.sh'
+        # Discrimination: the lowercase spelling reaches the same script. A
+        # helper that did not fold case would resolve one of the two and not
+        # the other, so agreement is what says the folding happened.
+        assert _get_script_for_package('FWL-Zalmoxis') == _get_script_for_package(
+            'fwl-zalmoxis'
+        )
 
     def test_name_without_fwl_prefix_is_used_verbatim(self):
         """The fwl- strip is conditional: a name lacking the prefix is looked up

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -660,12 +660,12 @@ class TestGetScriptForPackage:
         mixed-case name still resolves (dist names are normally lowercase, but
         the helper must not depend on that)."""
         assert _get_script_for_package('FWL-Zalmoxis') == 'tools/get_zalmoxis.sh'
-        # Discrimination: the lowercase spelling reaches the same script. A
-        # helper that did not fold case would resolve one of the two and not
-        # the other, so agreement is what says the folding happened.
-        assert _get_script_for_package('FWL-Zalmoxis') == _get_script_for_package(
-            'fwl-zalmoxis'
-        )
+        # A fully upper-case spelling of a second package folds too, so the
+        # line above is not one spelling happening to work.
+        assert _get_script_for_package('FWL-ARAGOG') == 'tools/get_aragog.sh'
+        # Folding must not invent a script either: a mixed-case package with
+        # none still takes the git-pull path.
+        assert _get_script_for_package('FWL-Calliope') is None
 
     def test_name_without_fwl_prefix_is_used_verbatim(self):
         """The fwl- strip is conditional: a name lacking the prefix is looked up

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -677,10 +677,13 @@ class TestBootstrapLogger:
             if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
         ]
         assert len(stdout_handlers) == 1
-        # Discrimination: the file handler setup_logger adds is present too, so
-        # the count above comes from the bootstrap console handler being
-        # cleared rather than from setup_logger having added nothing at all.
-        assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
+        # Discrimination: exactly one file handler, on the path asked for. The
+        # stdout count above says nothing about file output, so a setup_logger
+        # that dropped, duplicated or misdirected the file handler would leave
+        # it unchanged.
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+        assert file_handlers[0].baseFilename == os.path.abspath(logpath)
 
     @pytest.mark.unit
     def test_info_record_reaches_handler(self):

--- a/tests/utils/test_logs.py
+++ b/tests/utils/test_logs.py
@@ -677,6 +677,10 @@ class TestBootstrapLogger:
             if type(h) is logging.StreamHandler and getattr(h, 'stream', None) is sys.stdout
         ]
         assert len(stdout_handlers) == 1
+        # Discrimination: the file handler setup_logger adds is present too, so
+        # the count above comes from the bootstrap console handler being
+        # cleared rather than from setup_logger having added nothing at all.
+        assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
 
     @pytest.mark.unit
     def test_info_record_reaches_handler(self):
@@ -695,6 +699,14 @@ class TestBootstrapLogger:
         logging.getLogger('fwl.proteus.utils.coupler').info('Temporary-file working dir: /x')
         assert 'Temporary-file working dir: /x' in buf.getvalue()
 
+        # Discrimination: a record below the configured level is not emitted,
+        # so the line above arrived through the level filter rather than
+        # through a handler passing everything it is given.
+        buf.truncate(0)
+        buf.seek(0)
+        logging.getLogger('fwl.proteus.utils.coupler').debug('Not at this level')
+        assert 'Not at this level' not in buf.getvalue()
+
     @pytest.mark.unit
     def test_invalid_level_raises(self):
         """An unrecognised level must raise rather than silently default.
@@ -704,6 +716,12 @@ class TestBootstrapLogger:
         """
         with pytest.raises(ValueError, match='Invalid log level'):
             bootstrap_logger(level='INVALID')
+
+        # Discrimination: a level that is recognised is accepted, so the raise
+        # above comes from the level being unknown rather than from the call
+        # refusing every level it is handed.
+        bootstrap_logger(level='DEBUG')
+        assert logging.getLogger('fwl').level == logging.DEBUG
 
 
 class TestGetCurrentLogfileIndex:


### PR DESCRIPTION
## Description

Seventeen tests across five files rested on a single assertion each. A test like that does not separate the behaviour it names from a version of the code that does nothing: `test_star_bol_scale_duration_accepts_zero_boundary` accepts a duration of exactly zero under a bound of `ge(0.0)` and never asks what happens just below it, so a field carrying no bound at all passes it unchanged. Each now carries a second assertion that fails when the behaviour is absent.

The shapes are the ones `proteus-tests.md` asks for. Lookups gain their opposite case, so a raise says the input was refused rather than that everything is. The two manifest error paths gain a claim about what the message carries, since naming the offending path, and not blaming a dependency for a defect we ship, is the reason those guards exist. The logging tests gain a level that must not appear and the file handler that must, so a handler passing everything and a setup adding nothing are both separated from the behaviour wanted. The window arithmetic gains its neighbouring wrong answer: inside the window, the whole duration rather than what is left of it; at the exact start, the zero the before branch would return.

This matters more than a tidy-up right now, because `main` is failing that check today. `python tools/check_test_quality.py --check` on `75a4f7bd` reports `single_assert 20` against a recorded baseline of 11, a REGRESSION. The first commit here brings it back to 11, the second takes it to 3. The check is reported rather than blocking in PR CI, which is how the drift accumulated without anyone seeing it.

`tools/test_quality_baseline.json` is deliberately untouched at `{"single_assert": 11}`, so the improvement is a real reduction rather than a blessed one. Regenerating it to 3 is worth doing, but it belongs in its own commit rather than hidden inside this one.

Every addition is an assertion. Nothing about what these tests already covered changed, and no source file is touched.

## Validation of changes

macOS with Python 3.12, against `main` at `75a4f7bd`.

- `tools/check_test_quality.py --check`: `main` reports 20 against baseline 11 (REGRESSION), this branch reports 3 (OK). The 17 it clears are exactly the offenders in the five files it touches; the three that remain are `tests/helpers/test_trajectory.py::test_read_reference_refuses_a_corrupted_file` and two in `tests/integration/test_integration_observe_wrapper.py`.
- Full unit tier green: `pytest -m "unit and not skip and not slow and not integration" --ignore=tests/examples` gives 2918 passed, 28 skipped. One further failure, `test_manifest_is_discovered_via_entry_point`, reproduces identically on `main` in the same environment and comes from my local editable install's entry-point metadata, so it is not attributable to this branch.
- `ruff check tests/` and `ruff format --check tests/` both clean.
- I mutated the source behind each addition to check it actually goes red when the behaviour it names is absent, rather than reading it and assuming. Five could not fail at all, and a sixth carried a comment describing a case that does not exist. All six are replaced in the third commit, and each replacement was re-checked the same way.
- The one that mattered: `test_next_step_skips_bolscale_clip_when_hf_all_is_none` passed with the clamp deleted outright, because the static branch's one-year step swallows any Gyr-scale window value under `min`. Its second call now takes a history whose window opens a quarter of a year out, so the step is clipped to that remaining time. Deleting the clamp now fails it, and removing only the None check still fails it, so the original coverage is intact.
- The other four that could not fail: `test_unknown_dataset_key_is_rejected` asserted `is not None` where `_dataset` raises or returns a `Dataset` and never returns `None`, so it now compares the resolved key; `test_case_insensitive_prefix_strip` compared two spellings both already pinned elsewhere in the file, so it now folds a second package and one with no script at all; `test_estimate_bolscale_defaults_missing_age_star_column_to_zero` was subsumed by the pinned value above it, so it now contrasts the default against an age that takes the other branch; and `test_declared_floor_matches_the_requirement` had its length check after the equality that already caught the same case, so the order is swapped and a dropped `>=` now reports the absence it is.
- `test_setup_logger_after_bootstrap_has_no_duplicate_stdout` was the sixth, and my first reading of it was wrong: removing `setup_logger`'s file-handler line does fail that assertion, so it was never inert. The defect was its comment, which named a case that cannot occur. The comment is corrected and the assertion now pins exactly one file handler on the path requested, which also catches a duplicated or misdirected one.
- Two estimator tests pin a value alongside a guard against the wrong formula, the same shape as their marked neighbours, so they carry `physics_invariant` now, as does the rewritten `hf_all`-is-None test.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required


