### PR TITLE
Keep the XUV level readable when its radius is not a number

### DIFF
--- a/src/proteus/atmos_clim/wrapper.py
+++ b/src/proteus/atmos_clim/wrapper.py
@@ -173,24 +173,27 @@ def carry_converged_levels(atmos_o: Atmos_t, hf_row: dict, previous_row: dict | 
             hf_row[key] = atmos_o.levels_converged[key]
 
 
-def realign_xuv_level(hf_row: dict, radius: float):
-    """Bring the XUV level onto a radius that has been moved on its own.
+def realign_xuv_gravity(hf_row: dict, radius: float):
+    """Place the XUV gravity at a radius that has been moved on its own.
 
     The level properties describe one height and are carried as a group, so
     moving the radius by itself leaves a pressure, temperature and gravity
-    belonging to a different one. Gravity is the one that can be recovered from
-    the radius alone, by the inverse-square form the dummy and JANUS modules use
-    to place it; AGNI instead reads gravity off the profile it solved, which is
-    not held once the solve is behind us, so the radius-only form is the closest
-    available estimate on every module. Pressure and temperature need that same
-    profile and have no such form, so they are marked unmeasured, in the sense
-    ``_finite_levels`` already reads, as is gravity where the planet is unknown.
+    belonging to a different one. Gravity is the only one recoverable from the
+    radius alone, by the inverse-square form the dummy and JANUS modules use to
+    place it, so it is the only one brought along. AGNI reads gravity off the
+    profile it solved, which is not held once the solve is behind us, so the
+    radius-only form is the closest available estimate on every module.
 
-    The composition at the level, in ``XUV_VMR_KEYS``, is read off the profile
-    at the same height and is left as it was. BOREAS builds the mean molecular
-    weight of the outflow from it and has no reading to fall back on, so marking
-    it unmeasured would replace a composition from a nearby height with none at
-    all. It is the one part of the level this does not bring along.
+    Pressure, temperature and the composition in ``XUV_VMR_KEYS`` keep the
+    values the last converged solve read, at the height it read them from. A
+    reading from a nearby height is worth more than none: ``p_xuv`` is what
+    AGNI and JANUS derive ``R_xuv`` from when ``xuv_defined_by_radius`` is off,
+    BOREAS builds the outflow mean molecular weight from the composition, and
+    every helpfile column is required to stay finite.
+
+    The gravity is left alone rather than invalidated where the planet is
+    unknown, for the same reason: a stale gravity is readable and a missing one
+    is not.
 
     Parameters
     ----------
@@ -199,16 +202,20 @@ def realign_xuv_level(hf_row: dict, radius: float):
         radius : float
             The radius the level now sits at [m].
     """
-    placeable = radius > 0.0 and 'gravity' in hf_row and 'R_int' in hf_row
-    if 'g_xuv' in hf_row:
-        hf_row['g_xuv'] = (
-            float(hf_row['gravity']) * (float(hf_row['R_int']) / radius) ** 2
-            if placeable
-            else np.nan
-        )
-    for key in ('p_xuv', 'T_xuv'):
-        if key in hf_row:
-            hf_row[key] = np.nan
+    if 'g_xuv' not in hf_row:
+        return
+
+    gravity = float(hf_row.get('gravity', np.nan))
+    r_int = float(hf_row.get('R_int', np.nan))
+    placeable = (
+        np.isfinite(radius)
+        and radius > 0.0
+        and np.isfinite(gravity)
+        and np.isfinite(r_int)
+        and r_int > 0.0
+    )
+    if placeable:
+        hf_row['g_xuv'] = gravity * (r_int / radius) ** 2
 
 
 def run_atmosphere(
@@ -405,15 +412,17 @@ def run_atmosphere(
 
     # A carried radius can come from a row written before the clip existed, or
     # under a different Hill radius, so bound it here as well. The rate escape
-    # computes goes as the cube of this radius, so the bound wins; the rest of
-    # the level is then brought onto the radius the bound left behind. The
-    # comparison is exact because an inapplicable clip returns what it was
-    # given, so a moved radius is the only thing that reaches the realignment.
+    # computes goes as the cube of this radius, so the bound wins; the gravity
+    # is then placed at the radius the bound left behind. The finiteness test is
+    # on the RESULT rather than on the carried value, because a radius of NaN
+    # compares unequal to everything: testing it there skips the placement in
+    # the one case where the bound does supply a real radius.
     if hasattr(config, 'escape') and 'R_xuv' in hf_row:
         carried = float(hf_row['R_xuv'])
-        hf_row['R_xuv'] = clip_radius_to_hill(config, hf_row, carried)
-        if hf_row['R_xuv'] != carried:
-            realign_xuv_level(hf_row, hf_row['R_xuv'])
+        clipped = clip_radius_to_hill(config, hf_row, carried)
+        hf_row['R_xuv'] = clipped
+        if np.isfinite(clipped) and clipped != carried:
+            realign_xuv_gravity(hf_row, clipped)
 
     # Persist the solve outcome, so a row whose levels were carried can be
     # identified from the output alone rather than from the log.

--- a/tests/atmos_clim/test_wrapper.py
+++ b/tests/atmos_clim/test_wrapper.py
@@ -1051,14 +1051,125 @@ def test_run_atmosphere_clips_a_carried_radius_from_an_unclipped_row():
     # The rest of the level still comes from the committed row.
     assert hf_row['H2O_vmr_xuv'] == pytest.approx(0.4, rel=1e-12)
 
-    # The bound moved the radius, so the level follows it: gravity is placed at
-    # the radius the row now carries, and the two quantities that would need the
-    # profile are marked unmeasured rather than left at the committed height.
+    # The bound moved the radius, so the gravity is placed at the radius the row
+    # now carries. The two quantities the profile would be needed to recompute
+    # keep the committed reading, which stays finite for the helpfile.
     assert hf_row['g_xuv'] == pytest.approx(
         hf_row['gravity'] * (hf_row['R_int'] / 1.0e8) ** 2, rel=1e-12
     )
-    assert math.isnan(hf_row['p_xuv'])
-    assert math.isnan(hf_row['T_xuv'])
+    committed = _levels(4.0e8, 5.0e8, 0.4)
+    assert hf_row['p_xuv'] == pytest.approx(committed['p_xuv'], rel=1e-12)
+    assert hf_row['T_xuv'] == pytest.approx(committed['T_xuv'], rel=1e-12)
+    assert math.isfinite(hf_row['p_xuv'])
+    assert math.isfinite(hf_row['T_xuv'])
+
+
+@pytest.mark.physics_invariant
+@pytest.mark.parametrize('hill_clamp', [False, True])
+def test_run_atmosphere_does_not_place_gravity_from_a_radius_that_is_not_a_number(
+    hill_clamp,
+):
+    """A radius that is not a number is answered by the bound, and the gravity
+    follows whatever radius the row ends up with.
+
+    The two arms are different states, not one state tested twice. With the
+    bound off the radius stays unmeasured and nothing is placed from it. With
+    the bound on the radius becomes the Hill limit, which is a real height, so
+    the gravity must be placed there: leaving it behind would pair a radius and
+    a gravity describing heights a factor apart.
+
+    This is the first solve of a run and it is rejected, so there is no earlier
+    level to fall back on and the rejected one is kept as it stands. That is the
+    one path on which a radius of NaN survives to the bound, since the fallback
+    otherwise drops a level it cannot read.
+    """
+    atmos_o = Atmos_t()
+    atmos_o._atm = object()
+
+    config = SimpleNamespace(
+        atmos_clim=SimpleNamespace(
+            module='agni',
+            albedo_pl=0.0,
+            rayleigh=False,
+            cloud_enabled=False,
+            surf_state='fixed',
+        ),
+        interior_energetics=SimpleNamespace(module='aragog'),
+        escape=SimpleNamespace(hill_clamp=hill_clamp, hill_clamp_frac=1.0),
+    )
+    hf_row = {
+        'T_magma': 1800.0,
+        'M_planet': 6.0e24,
+        'F_int': 120.0,
+        'F_atm': 100.0,
+        'axial_period': 86400.0,
+        'atm_kg_per_mol': 0.029,
+        'T_surf': 0.0,
+        'R_int': 6.371e6,
+        'gravity': 9.81,
+        'R_star': 6.96e8,
+        'F_olr': 200.0,
+        'F_sct': 100.0,
+        'F_ins': 1361.0,
+        'separation': 1.5e11,
+        'hill_radius': 1.0e8,
+        **{key: 0.0 for key in _levels(1.0, 1.0)},
+    }
+
+    # No committed row, so a rejected first solve has nothing to fall back on
+    # and its own level is what the bound then meets.
+    hf_all = None
+
+    # The rejected structure reports a radius it could not measure, alongside a
+    # pressure, temperature and gravity it did.
+    rejected = _levels(2.4e7, 2.88e7, 0.9)
+    rejected['R_xuv'] = float('nan')
+    out = dict(rejected)
+    out.update({'albedo': 0.2, 'F_atm': 100.0, 'agni_converged': False})
+    vmr = out.pop('H2O_vmr_xuv')
+
+    def _run_agni(atm, *args, **kwargs):
+        hf_row['H2O_vmr_xuv'] = vmr
+        return atm, out
+
+    with (
+        patch('proteus.atmos_clim.agni.update_agni_atmos', side_effect=lambda a, *_, **__: a),
+        patch('proteus.atmos_clim.agni.run_agni', side_effect=_run_agni),
+    ):
+        atmos_wrapper.run_atmosphere(
+            atmos_o,
+            config,
+            {'output': '/tmp/x'},
+            {'total': 5},
+            [1.0],
+            [1.0],
+            False,
+            hf_all,
+            hf_row,
+        )
+
+    # The pressure and temperature the solve did measure survive in both arms.
+    assert hf_row['p_xuv'] == pytest.approx(rejected['p_xuv'], rel=1e-12)
+    assert hf_row['T_xuv'] == pytest.approx(rejected['T_xuv'], rel=1e-12)
+    assert math.isfinite(hf_row['p_xuv'])
+    assert math.isfinite(hf_row['T_xuv'])
+
+    at_hill = 9.81 * (6.371e6 / 1.0e8) ** 2
+    if hill_clamp:
+        # The bound supplied a real radius, so the gravity is placed on it and
+        # the two describe the same height.
+        assert hf_row['R_xuv'] == pytest.approx(1.0e8, rel=1e-12)
+        assert hf_row['g_xuv'] == pytest.approx(at_hill, rel=1e-12)
+        # Keeping the rejected structure's gravity instead would be wrong by
+        # more than two orders of magnitude, so this pin separates the two.
+        assert hf_row['g_xuv'] != pytest.approx(rejected['g_xuv'], rel=1e-1)
+        assert rejected['g_xuv'] / hf_row['g_xuv'] > 100.0
+    else:
+        # Nothing bounded the radius, so it stays unmeasured and no height
+        # exists to place a gravity on.
+        assert math.isnan(hf_row['R_xuv'])
+        assert hf_row['g_xuv'] == pytest.approx(rejected['g_xuv'], rel=1e-12)
+        assert math.isfinite(hf_row['g_xuv'])
 
 
 def test_run_atmosphere_keeps_a_level_the_bound_does_not_move():
@@ -1139,13 +1250,14 @@ def test_run_atmosphere_keeps_a_level_the_bound_does_not_move():
 
 
 @pytest.mark.physics_invariant
-def test_realign_xuv_level_puts_gravity_at_the_moved_radius():
+@pytest.mark.reference_pinned
+def test_realign_xuv_gravity_puts_gravity_at_the_moved_radius():
     """A level whose radius has been moved takes the gravity of the height it
-    now sits at, and gives up the pressure and temperature of the one it left.
+    now sits at, and keeps the pressure and temperature of the one it left.
 
     Gravity falls as the inverse square of the radius, so the square is what
     discriminates: at twice the interior radius the surface value is quartered.
-    A realignment carrying the ratio rather than its square lands at half the
+    A placement carrying the ratio rather than its square lands at half the
     surface value, and one inverting the ratio lands at sixteen times it, both
     far outside the tolerance on a quarter.
     """
@@ -1157,43 +1269,63 @@ def test_realign_xuv_level_puts_gravity_at_the_moved_radius():
         'T_xuv': 400.0,
     }
 
-    atmos_wrapper.realign_xuv_level(hf_row, 1.2e7)
+    atmos_wrapper.realign_xuv_gravity(hf_row, 1.2e7)
 
     assert hf_row['g_xuv'] == pytest.approx(2.45, rel=1e-12)
-    # The two wrong forms this could take, each far enough from the right one
+    # The three wrong forms this could take, each far enough from the right one
     # that the pin above separates them rather than merely admitting them.
     unsquared = 9.8 * (6.0e6 / 1.2e7)
     inverted = 9.8 * (1.2e7 / 6.0e6) ** 2
+    cubed = 9.8 * (6.0e6 / 1.2e7) ** 3
     assert abs(hf_row['g_xuv'] - unsquared) > 2.0
     assert abs(hf_row['g_xuv'] - inverted) > 2.0
-    # Neither of these can be recomputed without the profile the solve held.
-    assert math.isnan(hf_row['p_xuv'])
-    assert math.isnan(hf_row['T_xuv'])
+    assert abs(hf_row['g_xuv'] - cubed) > 1.0
+    # Reading these off a nearby height beats having no reading at all, and the
+    # helpfile requires them to stay finite.
+    assert hf_row['p_xuv'] == pytest.approx(1.0e-6, rel=1e-12)
+    assert hf_row['T_xuv'] == pytest.approx(400.0, rel=1e-12)
 
 
-def test_realign_xuv_level_marks_gravity_unmeasured_where_it_cannot_be_placed():
-    """A radius of zero places no level, and a row without the interior radius
-    or the surface gravity gives nothing to place one from. Neither leaves the
-    gravity of the height the radius came away from.
+@pytest.mark.physics_invariant
+def test_realign_xuv_gravity_leaves_the_level_alone_where_it_cannot_be_placed():
+    """A radius of zero places no gravity, and a row without the interior radius
+    or the surface gravity gives nothing to place one from. A degenerate value
+    that is merely present counts as absent, since a zero interior radius would
+    otherwise yield a gravity of zero that reads as a measurement.
 
-    A stale value here is worse than none, since it reads as a measurement of a
-    level the row no longer describes, which is the pairing this realignment
-    exists to prevent.
+    Nothing is invalidated in these cases. A stale gravity is readable and a
+    missing one is not, and every helpfile column is required to stay finite.
     """
     at_zero = {'gravity': 9.8, 'R_int': 6.0e6, 'g_xuv': 6.8, 'p_xuv': 1.0e-6, 'T_xuv': 400.0}
-    atmos_wrapper.realign_xuv_level(at_zero, 0.0)
-    assert math.isnan(at_zero['g_xuv'])
-    assert math.isnan(at_zero['p_xuv'])
-    assert math.isnan(at_zero['T_xuv'])
+    atmos_wrapper.realign_xuv_gravity(at_zero, 0.0)
+    assert at_zero['g_xuv'] == pytest.approx(6.8, rel=1e-12)
+    assert at_zero['p_xuv'] == pytest.approx(1.0e-6, rel=1e-12)
+    assert at_zero['T_xuv'] == pytest.approx(400.0, rel=1e-12)
 
     without_planet = {'g_xuv': 6.8, 'p_xuv': 1.0e-6, 'T_xuv': 400.0}
-    atmos_wrapper.realign_xuv_level(without_planet, 1.2e7)
-    assert math.isnan(without_planet['g_xuv'])
-    assert math.isnan(without_planet['p_xuv'])
+    atmos_wrapper.realign_xuv_gravity(without_planet, 1.2e7)
+    assert without_planet['g_xuv'] == pytest.approx(6.8, rel=1e-12)
+    assert without_planet['T_xuv'] == pytest.approx(400.0, rel=1e-12)
+
+    # A present but degenerate planet is not a planet: a zero interior radius
+    # would place the gravity at exactly zero, and a non-finite surface gravity
+    # would carry its own non-finiteness into the level.
+    no_body = {'gravity': 9.8, 'R_int': 0.0, 'g_xuv': 6.8}
+    atmos_wrapper.realign_xuv_gravity(no_body, 1.2e7)
+    assert no_body['g_xuv'] == pytest.approx(6.8, rel=1e-12)
+
+    no_gravity = {'gravity': float('nan'), 'R_int': 6.0e6, 'g_xuv': 6.8}
+    atmos_wrapper.realign_xuv_gravity(no_gravity, 1.2e7)
+    assert no_gravity['g_xuv'] == pytest.approx(6.8, rel=1e-12)
+
+    # An unbounded radius is not a height either, and would place gravity at zero.
+    unbounded = {'gravity': 9.8, 'R_int': 6.0e6, 'g_xuv': 6.8}
+    atmos_wrapper.realign_xuv_gravity(unbounded, float('inf'))
+    assert unbounded['g_xuv'] == pytest.approx(6.8, rel=1e-12)
 
     # A row carrying no XUV level at all is left as it is rather than given one.
     empty: dict = {'gravity': 9.8, 'R_int': 6.0e6}
-    atmos_wrapper.realign_xuv_level(empty, 1.2e7)
+    atmos_wrapper.realign_xuv_gravity(empty, 1.2e7)
     assert 'g_xuv' not in empty
     assert 'p_xuv' not in empty
     assert 'T_xuv' not in empty


### PR DESCRIPTION
## Description

Three defects in the XUV level realignment that #824 introduced, plus the comment that made the first one look correct.

**The realignment fired on a radius that never moved.** The guard was `if hf_row['R_xuv'] != carried`. A radius of NaN compares unequal to every value including itself, so when `clip_radius_to_hill` was inapplicable and handed the radius straight back, the guard still answered yes and the level was rebuilt around a height nothing had measured. Finite `p_xuv`, `T_xuv` and `g_xuv` were all overwritten with NaN.

The finiteness test now sits on the bound's **result**, not on the carried value. Testing the carried value looks like the fix and is not: it skips the placement in the one case where the bound does supply a real radius, leaving the row with a radius at the Hill limit and a gravity still describing a height a factor away. Guarding the input leaves `g_xuv` wrong by 170x in that case; guarding the result gives a ratio of exactly 1 against the self-consistent value.

**A NaN temperature reached the helpfile.** `T_xuv` is written only in the atmosphere modules (`janus.py:379`, `agni.py:1460`, `dummy.py:170`), all of which run before the realignment, and nothing rewrites it afterwards. `p_xuv` is rescued by escape at `escape/wrapper.py:152` and `:223`; `T_xuv` is not. Both now keep the values the last converged solve read.

**The placement accepted a planet that was not there.** `placeable` tested key presence, so an interior radius of `0.0` produced `g_xuv = 0.0`, a finite unphysical gravity that reads as a measurement. It now requires finite and positive values.

The function is renamed `realign_xuv_gravity`, because gravity is the only quantity it places.

### The pressure compromise, stated rather than buried

Keeping a stale `p_xuv` is not free, and the numbers argue against it. Measured on the recorded atmosphere profiles of the GJ 9827 d cases, over the top third of the column where the XUV level sits:

| case | R_top / R_int | dlnp/dlnr | dlnT/dlnr | pressure error at F=1.2 | at F=2 |
|---|---|---|---|---|---|
| 005 | 20.3 | -4.6 | -0.35 | 2.3x | 24x |
| 011 | 22.9 | -5.6 | -0.27 | 2.8x | 48x |
| 013 | 2.1 | -34.7 | -0.08 | 556x | 2.7e10x |
| 008 | 1.8 | -37.2 | -3.07 | 880x | 1.6e11x |
| 010 | 1.6 | -45.7 | -0.08 | 4.2e3x | 5.7e13x |

Pressure is exponential in height and temperature is nearly flat over the same span. A bound that moves the radius by a fifth leaves the carried temperature good to a few percent and the carried pressure wrong by anything from 2 to 4000 times. Carrying both is therefore right for temperature and a **known compromise for pressure**.

How often that compromise is actually paid is narrow, and worth stating precisely because the gradient numbers above look alarming on their own. The realignment runs only when the wrapper's re-clip *moves* a carried radius. `clip_radius_to_hill` is exactly idempotent, so a carried radius that the atmosphere module already bounded comes back unchanged and the guard evaluates false. In the recorded runs `hill_radius` is constant to within a part in 10000 and never decreases, so a carried radius is never left above a bound that has since tightened, and the realignment does not fire in them at all. Its live path is a resume against a helpfile written before the clip existed, or a run in which the Hill radius does contract. The frequent event in those runs, the bound binding on 53 of 53 and 83 of 91 iterations, happens inside the atmosphere module while the profile is still in hand and `p_xuv` is looked up again at the bounded radius; that is a different event from this one and carries no stale pressure.

It is taken because the alternative sentinel is worse, not because it is good. NaN is read three different ways by the code that consumes it: `_finite_levels` (`wrapper.py:54-56`) treats it as "not measured" and skips it, `assert_no_nan_inf` treats any NaN as a bug with no carve-out, and `find_nearest` maps a NaN target to index 0 and silently returns the top of the profile. A sentinel with three readings is not a sentinel. The honest third option, re-deriving `p_xuv` at the clipped radius from the profile, is not attempted here and is worth a separate issue.

Two further points this does not address, both pre-existing and out of scope: `clip_radius_to_hill` turns a NaN radius into the Hill limit because `NaN <= r_limit` is False, and with the bound off a NaN `R_xuv` still reaches the helpfile.

## Validation of changes

macOS, Python 3.12, conda env proteus-dev-1.

Each fix was verified by mutation, applying the defect back one at a time against a file copy and confirming the test written for it goes red:

| mutation | change | result |
|---|---|---|
| M1 | drop the call-site finiteness check | green, so that check is defensive; `realign_xuv_gravity` owns the decision |
| M2 | guard the carried value instead of the result | red on the clamped arm |
| M3 | reinstate the NaN marking of pressure and temperature | red on 4 tests |
| M4 | `placeable` back to key presence | red on 1 test |

The tree restores to 33 passing after each.

Idempotency of `clip_radius_to_hill` was checked by execution rather than by reading: clipping 5.0e8 against a 1.0e8 bound gives 1.0e8, and clipping that result again returns it bit-identically, so the wrapper guard is false on any radius the module already bounded.

Unit tier: 2976 passed, 11 skipped, 0 failed, against 2974 passed, 11 skipped, 0 failed on the base commit. The two extra are the arms of the new parametrised test. `ruff check` and `ruff format --check` clean. `tools/validate_test_structure.sh` clean.

The gravity placement itself was checked against the model's own gravity profile: the inverse-square form agrees with the solved gravity at the top of the column to a ratio of 1.0001, so ignoring the mass of the atmosphere between the two heights costs 0.01%.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
