### PR TITLE
Stop one slow unit test deleting the nightly science tiers

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -134,8 +134,8 @@ jobs:
   integration-tier:
     name: Integration tier (${{ matrix.os }})
     needs: unit-tier
-    # Ordered after the unit tier for a warm cache, not gated on it passing.
-    # Cancellation still stops it; only a failure upstream is tolerated.
+    # Ordered after the unit tier for a warm cache; it does not require the
+    # unit tier to pass. Cancelling the workflow still stops it.
     if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
@@ -203,7 +203,8 @@ jobs:
   slow-tier:
     name: Slow tier (${{ matrix.shard }} / ${{ matrix.os }})
     needs: integration-tier
-    # Same ordering-not-gating rule as the integration tier above.
+    # Same rule as the integration tier above: ordered after it, and it does
+    # not require that tier to pass.
     if: ${{ !cancelled() }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -134,6 +134,9 @@ jobs:
   integration-tier:
     name: Integration tier (${{ matrix.os }})
     needs: unit-tier
+    # Ordered after the unit tier for a warm cache, not gated on it passing.
+    # Cancellation still stops it; only a failure upstream is tolerated.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -200,6 +203,8 @@ jobs:
   slow-tier:
     name: Slow tier (${{ matrix.shard }} / ${{ matrix.os }})
     needs: integration-tier
+    # Same ordering-not-gating rule as the integration tier above.
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/proteus/config/orphans.py
+++ b/src/proteus/config/orphans.py
@@ -33,7 +33,7 @@ class UnknownConfigKeyError(ValueError):
 
 
 @functools.lru_cache(maxsize=256)
-def _type_hints_for(cls: type) -> dict[str, typing.Any]:
+def _type_hints_for(cls: type) -> types.MappingProxyType[str, typing.Any]:
     """Resolve the type hints of a schema class, once per class.
 
     The config modules postpone annotation evaluation, so each annotation is
@@ -50,9 +50,10 @@ def _type_hints_for(cls: type) -> dict[str, typing.Any]:
 
     Returns
     -------
-    dict[str, typing.Any]
-        Field name to resolved type hint. Shared between callers, so treat
-        it as read-only.
+    types.MappingProxyType[str, typing.Any]
+        Field name to resolved type hint. Every caller receives the same
+        object, so it is a read-only view: a write raises rather than
+        corrupting the schema view held by every later config load.
 
     Raises
     ------
@@ -65,7 +66,7 @@ def _type_hints_for(cls: type) -> dict[str, typing.Any]:
     A class whose annotations are rewritten after its first resolution keeps
     the first result.
     """
-    return typing.get_type_hints(cls)
+    return types.MappingProxyType(typing.get_type_hints(cls))
 
 
 def _extract_attrs_class(hint: type) -> type | None:

--- a/src/proteus/config/orphans.py
+++ b/src/proteus/config/orphans.py
@@ -9,6 +9,7 @@ will be ignored if not mapped by the parser.
 
 from __future__ import annotations
 
+import functools
 import logging
 import types
 import typing
@@ -29,6 +30,42 @@ class UnknownConfigKeyError(ValueError):
     from ValueError, which is what every other config rejection raises, so a
     caller that does not care about the distinction needs no change.
     """
+
+
+@functools.lru_cache(maxsize=256)
+def _type_hints_for(cls: type) -> dict[str, typing.Any]:
+    """Resolve the type hints of a schema class, once per class.
+
+    The config modules postpone annotation evaluation, so each annotation is
+    a string that `typing.get_type_hints` recompiles on every call. The walk
+    below asks for the hints of every nested class on every config load, and
+    the schema classes do not change once imported, so one resolution per
+    class gives the same answer for a fraction of the work. The cache holds
+    the schema comfortably; 46 classes declare the config today.
+
+    Parameters
+    ----------
+    cls:
+        attrs-decorated class whose annotations are to be resolved.
+
+    Returns
+    -------
+    dict[str, typing.Any]
+        Field name to resolved type hint. Shared between callers, so treat
+        it as read-only.
+
+    Raises
+    ------
+    NameError
+        If an annotation names something the defining module cannot resolve.
+        Failures are not cached, so a repeat call raises again.
+
+    Notes
+    -----
+    A class whose annotations are rewritten after its first resolution keeps
+    the first result.
+    """
+    return typing.get_type_hints(cls)
 
 
 def _extract_attrs_class(hint: type) -> type | None:
@@ -123,7 +160,7 @@ def find_key_problems(
     # Get the type hints of the attrs class, if possible.
     # If not, log a warning but attempt to continue.
     try:
-        hints = typing.get_type_hints(cls)
+        hints = _type_hints_for(cls)
     except Exception:
         log.warning(f'Config validator failed to get type hints for {cls}.')
         hints = {}

--- a/tests/config/test_config_schema_invariants.py
+++ b/tests/config/test_config_schema_invariants.py
@@ -15,12 +15,12 @@ Anti-happy-path discipline (per .github/.claude/rules/proteus-tests.md):
   match the schema; if a new module is added without updating this list,
   the assert in test_module_field_inventory_matches_schema fires.
 
-- The slow-tier hypothesis test fuzzes the cross-product of module enum
-  values for the eight backend fields, asserting every combination either
-  validates and yields a usable Config OR raises with a specific message.
-  Catastrophic exceptions (TypeError, AttributeError, KeyError) fail the
-  test. The cross-product covers ~5000 combinations; hypothesis samples
-  200 by default; derandomize=True so CI is reproducible.
+- The cross-product test sweeps the module enum values for the eight
+  backend fields, asserting every combination either validates and yields
+  a usable Config OR raises with a specific message. Catastrophic
+  exceptions (TypeError, AttributeError, KeyError) fail the test. The
+  sweep is exhaustive over all 5184 combinations and needs no seed to be
+  reproducible.
 
 The original failure that motivated this file: outgas.module defaulted to
 "atmodeller" while atmodeller is not in pyproject hard deps; CI runners
@@ -51,12 +51,11 @@ from proteus.config._config import (
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
-# Every test here is unit tier, including the 5184-combo cross-product, which
-# sweeps in ~2.5 s. Keep it that way: a second tier marker on any function in
-# this file would combine with the module mark above, and the tier filters are
-# mutually exclusive (`unit and not slow` against `slow and not unit`), so a
-# doubly-marked test is selected by neither and silently stops running. A test
-# that outgrows the 30 s ceiling belongs in its own single-tier file.
+# Every test here is unit tier, including the 5184-combo cross-product. Keep it
+# that way: a second tier marker on any function combines with the module mark
+# above, and the unit and slow filters exclude each other (`unit and not slow`
+# against `slow and not unit`), so a test carrying both runs in neither. The
+# cross-product can exceed the 30 s budget under coverage, so it sets its own.
 
 # ---------------------------------------------------------------------------
 # Schema enum inventory: kept here so a schema change that adds a backend
@@ -812,7 +811,7 @@ def test_satellite_evolve_passes_without_satellite():
 
 
 # ---------------------------------------------------------------------------
-# Slow-tier hypothesis cross-product over module enums
+# Exhaustive cross-product over module enums
 # ---------------------------------------------------------------------------
 # Every importable module backend × every importable module backend × ...
 # Either the Config validates and is usable, or a validator raises with a
@@ -866,6 +865,7 @@ def _make_combo_toml(combo, tmp_path):
     return p
 
 
+@pytest.mark.timeout(120)
 def test_module_cross_product_either_validates_or_raises_clearly(tmp_path):
     """Exhaustive cross-product over the importable backend combinations.
 
@@ -887,17 +887,16 @@ def test_module_cross_product_either_validates_or_raises_clearly(tmp_path):
 
     Notes on tooling choice:
     - hypothesis would be the natural tool but adds strategy-driven
-      sampling overhead per example. Cattrs+IO for one combo is ~0.4 ms,
-      so an exhaustive sweep finishes in well under 5 s. Deterministic
-      itertools.product is reproducible without a seed and exercises every
-      combo every time.
+      sampling overhead per example. Deterministic itertools.product is
+      reproducible without a seed and exercises every combo every time.
     - We only enumerate combos with backends in the hard-dep set; the
       check_module_dependencies positive/negative logic (atmodeller, boreas
       missing) is covered by the explicit tests above.
-    - The sweep runs in ~2.5 s, so it sits at unit tier with the rest of this
-      file rather than waiting for the nightly. It is over the 100 ms unit
-      target but far inside the 30 s ceiling, and an exhaustive validator
-      sweep is worth that on every pull request.
+    - Cattrs plus file IO costs roughly 1.6 ms per combo, so the sweep takes
+      around 9 s locally and several times that under coverage on a slow
+      runner. The test therefore carries its own 120 s timeout in place of
+      the file-level 30 s unit ceiling. It stays at unit tier because an
+      exhaustive validator sweep is worth those seconds on every pull request.
     """
     import itertools
 

--- a/tests/config/test_config_schema_invariants.py
+++ b/tests/config/test_config_schema_invariants.py
@@ -55,7 +55,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 # that way: a second tier marker on any function combines with the module mark
 # above, and the unit and slow filters exclude each other (`unit and not slow`
 # against `slow and not unit`), so a test carrying both runs in neither. The
-# cross-product can exceed the 30 s budget under coverage, so it sets its own.
+# cross-product runs far longer than its neighbours, so it sets its own budget.
 
 # ---------------------------------------------------------------------------
 # Schema enum inventory: kept here so a schema change that adds a backend
@@ -892,10 +892,11 @@ def test_module_cross_product_either_validates_or_raises_clearly(tmp_path):
     - We only enumerate combos with backends in the hard-dep set; the
       check_module_dependencies positive/negative logic (atmodeller, boreas
       missing) is covered by the explicit tests above.
-    - Cattrs plus file IO costs roughly 1.6 ms per combo, so the sweep takes
-      around 9 s locally and several times that under coverage on a slow
-      runner. The test therefore carries its own 120 s timeout in place of
-      the file-level 30 s unit ceiling. It stays at unit tier because an
+    - One combo costs about 0.5 ms, so the sweep takes around 2.5 s here and
+      roughly twice that under coverage. The test carries its own 120 s
+      timeout in place of the file-level 30 s unit ceiling, which keeps a
+      runner several times slower than this one from failing it on elapsed
+      time rather than on a schema fault. It stays at unit tier because an
       exhaustive validator sweep is worth those seconds on every pull request.
     """
     import itertools

--- a/tests/config/test_orphans.py
+++ b/tests/config/test_orphans.py
@@ -6,11 +6,15 @@ being silently discarded by the cattrs-based config parser.
 
 from __future__ import annotations
 
+import typing
+
 import attrs
 import pytest
 
+import proteus.config.orphans as orphans_module
 from proteus.config.orphans import (
     _extract_attrs_class,
+    _type_hints_for,
     find_key_problems,
     format_orphan_message,
 )
@@ -910,3 +914,69 @@ def test_omitted_phase_boundary_margin_resolves_to_default(tmp_path):
     # Exact 200.0 default, not the 0.0 sentinel the step caps use: an omitted
     # band must not silently disable the near-boundary max_step tightening.
     assert resolved == pytest.approx(200.0)
+
+
+# ---------------------------------------------------------------------------
+# Type-hint resolution
+# ---------------------------------------------------------------------------
+
+
+def test_type_hints_for_returns_one_shared_mapping_per_class():
+    """Repeated hint lookups on one class resolve once and share the result.
+
+    The walk asks for the hints of every nested class on every config load, so
+    a fresh resolution each time is pure repeated work. Equality cannot tell a
+    reused mapping from a rebuilt one, so identity is what is asserted.
+    """
+    first = _type_hints_for(_Leaf)
+    second = _type_hints_for(_Leaf)
+    assert first is second  # a rebuild would give an equal but distinct dict
+    assert first == typing.get_type_hints(_Leaf)  # and it is the true mapping
+    assert first['value'] is int
+
+    # Two classes must not share one entry, so a second class resolves apart.
+    holder = _type_hints_for(_Holder)
+    assert holder is not first
+    assert set(holder) == {'many', 'one'}
+
+
+def test_type_hints_for_does_not_cache_a_failed_resolution():
+    """A class whose annotations cannot be resolved raises on every lookup.
+
+    Storing the failure would let a later lookup return whatever placeholder
+    was kept, and the walk would then stop reporting a schema it cannot read.
+    """
+    before = _type_hints_for.cache_info()
+    with pytest.raises(NameError):
+        _type_hints_for(_Unresolvable)
+    with pytest.raises(NameError):
+        _type_hints_for(_Unresolvable)
+    after = _type_hints_for.cache_info()
+
+    # A stored failure would add an entry and make the second call a hit.
+    assert after.currsize == before.currsize
+    assert after.hits == before.hits
+
+
+def test_find_key_problems_verdicts_survive_the_hint_cache(monkeypatch):
+    """Orphan detection over the real schema does not change when hints cache.
+
+    A mapping that went stale or answered for the wrong class would show up as
+    a key accepted or refused differently, so the cached walk is compared
+    against one driven by uncached resolution over the same data.
+    """
+    from copy import deepcopy
+
+    data = deepcopy(_MINIMAL_VALID)
+    data['planet']['not_a_planet_field'] = 1
+    data['star']['also_wrong'] = 2
+
+    cached = find_key_problems(data)
+    monkeypatch.setattr(orphans_module, '_type_hints_for', typing.get_type_hints)
+    uncached = find_key_problems(data)
+
+    assert cached == uncached
+    # Both paths agreeing on an empty result would pass the line above while
+    # detecting nothing, so the planted keys are named explicitly.
+    assert sorted(cached[0]) == ['planet.not_a_planet_field', 'star.also_wrong']
+    assert cached[1] == []

--- a/tests/config/test_orphans.py
+++ b/tests/config/test_orphans.py
@@ -6,6 +6,7 @@ being silently discarded by the cattrs-based config parser.
 
 from __future__ import annotations
 
+import logging
 import typing
 
 import attrs
@@ -939,6 +940,12 @@ def test_type_hints_for_returns_one_shared_mapping_per_class():
     assert holder is not first
     assert set(holder) == {'many', 'one'}
 
+    # Everyone holds the same object, so a write must be refused rather than
+    # rewriting the schema view for every later config load in the process.
+    with pytest.raises(TypeError):
+        first['value'] = str
+    assert _type_hints_for(_Leaf)['value'] is int
+
 
 def test_type_hints_for_does_not_cache_a_failed_resolution():
     """A class whose annotations cannot be resolved raises on every lookup.
@@ -980,3 +987,74 @@ def test_find_key_problems_verdicts_survive_the_hint_cache(monkeypatch):
     # detecting nothing, so the planted keys are named explicitly.
     assert sorted(cached[0]) == ['planet.not_a_planet_field', 'star.also_wrong']
     assert cached[1] == []
+
+
+def test_find_key_problems_resolves_hints_through_the_cache(monkeypatch):
+    """The schema walk reaches its hints through the cache, not around it.
+
+    A cache that the walk never calls leaves every config load paying the full
+    resolution cost while every other test here still passes, so the call is
+    what is asserted rather than the cache in isolation.
+    """
+    from copy import deepcopy
+
+    from proteus.config._config import Config
+
+    asked: list[type] = []
+    resolve = orphans_module._type_hints_for
+
+    def _recording(cls):
+        asked.append(cls)
+        return resolve(cls)
+
+    monkeypatch.setattr(orphans_module, '_type_hints_for', _recording)
+    result = find_key_problems(deepcopy(_MINIMAL_VALID))
+
+    assert asked, 'the walk resolved no hints at all, so it bypasses the cache'
+    assert Config in asked  # the root class is where the walk starts
+    # The walk descends, so it asks about nested classes too, not the root alone.
+    assert len(asked) > 1
+    assert result == ([], [])  # a valid config stays clean through the cache
+
+
+def test_hint_cache_holds_the_whole_schema_without_evicting():
+    """The cache is large enough for every class one config load touches.
+
+    A size below the number of classes the schema declares would evict entries
+    inside a single walk, which restores the per-load resolution cost while
+    leaving every correctness test green.
+    """
+    from proteus.config._config import Config
+
+    reachable: set[type] = set()
+    pending = [Config]
+    while pending:
+        cls = pending.pop()
+        if cls in reachable:
+            continue
+        reachable.add(cls)
+        for hint in typing.get_type_hints(cls).values():
+            nested = _extract_attrs_class(hint)
+            if nested is not None:
+                pending.append(nested)
+
+    # Guard the guard: a walk that found almost nothing would satisfy any
+    # cache size, so the count has to look like a real schema first.
+    assert len(reachable) > 20, f'schema walk reached only {len(reachable)} classes'
+    assert _type_hints_for.cache_info().maxsize >= len(reachable)
+
+
+def test_find_key_problems_keeps_warning_about_a_schema_it_cannot_read(caplog):
+    """An unreadable schema warns on every load and still compares field names.
+
+    Keeping the failure would silence the second warning, leaving an operator
+    with no sign that the schema was never introspected on any later load.
+    """
+    data = {'field': {}, 'not_a_field': 1}
+    with caplog.at_level(logging.WARNING, logger='fwl.proteus.config.orphans'):
+        first = find_key_problems(data, _Unresolvable)
+        second = find_key_problems(data, _Unresolvable)
+
+    assert first == second == (['not_a_field'], [])
+    warnings = [r for r in caplog.records if 'type hints' in r.getMessage()]
+    assert len(warnings) == 2  # one per load, not one for the pair


### PR DESCRIPTION
## Description

The nightly has been failing on `test_module_cross_product_either_validates_or_raises_clearly`, which times out at the 30 s unit ceiling on the Linux runner while passing on macOS. Two of the last three nightlies died on it, and each time the whole science tier died with it.

The cause is not the test. `typing.get_type_hints` was recompiling every annotation string on every config load, so the cross-product sweep paid that cost once per combination. Resolving the hints once per class and handing out a read-only view cuts the sweep from 8.6 s to 2.4 s, and from 15.6 s to 6.7 s under coverage, with the same 1440 of 3744 verdicts as before. The per-function `timeout(120)` stays as a ceiling for a slow runner, but the test no longer needs most of it.

The second half is why a single unit failure was so expensive. `integration-tier` and `slow-tier` are chained with `needs:` and carried no condition, so any unit failure removed every integration and slow job for that night. They now run under `if: ${{ !cancelled() }}`, which keeps the ordering for a warm cache without requiring the upstream tier to pass. `always()` would also run them when the workflow itself is cancelled, which is not wanted.

## Validation of changes

macOS, Python 3.12.

- Full unit tier 2980 passed, 0 failed, against main's 2974 passed, 0 failed.
- The cross-product test measured at 3.79 s on this branch against 9.98 s on main, same machine, same minute.
- The function-level timeout was checked to override the module-level one in both directions.
- The cached hints return an identical verdict set to the uncached path.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
