### PR TITLE
Bound the apt-get retry in CI setup with a timeout

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -108,8 +108,40 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends \
+        # apt-get talks to the Ubuntu archive mirrors, which occasionally stop
+        # responding mid-transfer instead of failing outright; an unbounded
+        # call once consumed the whole job waiting on a stalled connection.
+        # Bound each call with a timeout and retry with backoff, in the same
+        # spirit as the AGNI spectral data fetch below (a separate step, so
+        # the loop is duplicated here rather than shared). One retry keeps
+        # the worst case for this whole step to a few minutes, which matters
+        # because the surrounding job's own timeout is only 30 minutes.
+        delays=(45)
+        attempts=$(( ${#delays[@]} + 1 ))
+        apt_retry() {
+          local desc="$1"; shift
+          local n=1
+          while true; do
+            # A prior attempt killed by the timeout below can leave dpkg
+            # mid-unpack; repair that before retrying so the next attempt
+            # isn't rejected for an unrelated "packages not configured" error.
+            sudo dpkg --configure -a >/dev/null 2>&1 || true
+            if sudo timeout --kill-after=10 150 apt-get "$@"; then
+              echo "$desc succeeded on attempt $n"
+              return 0
+            fi
+            if [ "$n" -ge "$attempts" ]; then
+              echo "$desc failed after $attempts attempts" >&2
+              return 1
+            fi
+            local delay="${delays[$((n - 1))]}"
+            echo "$desc attempt $n failed or timed out; retrying in ${delay}s" >&2
+            sleep "$delay"
+            n=$((n + 1))
+          done
+        }
+        apt_retry "apt-get update" update -qq
+        apt_retry "apt-get install" install -y --no-install-recommends \
           gfortran \
           libnetcdff-dev \
           netcdf-bin \

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -108,14 +108,11 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # apt-get talks to the Ubuntu archive mirrors, which occasionally stop
-        # responding mid-transfer instead of failing outright; an unbounded
-        # call once consumed the whole job waiting on a stalled connection.
-        # Bound each call with a timeout and retry with backoff, in the same
-        # spirit as the AGNI spectral data fetch below (a separate step, so
-        # the loop is duplicated here rather than shared). One retry keeps
-        # the worst case for this whole step to a few minutes, which matters
-        # because the surrounding job's own timeout is only 30 minutes.
+        # apt-get can stall mid-transfer against the Ubuntu mirrors; an
+        # unbounded call once consumed the whole job. Bound each call with a
+        # timeout and retry with backoff, similar to the AGNI fetch below
+        # (duplicated here since it's a separate step). One retry keeps this
+        # step's worst case to a few minutes, well inside the job's own 30.
         delays=(45)
         attempts=$(( ${#delays[@]} + 1 ))
         apt_retry() {

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -101,6 +101,45 @@ runs:
       run: rm -f "$HOME/.bash_logout"
 
     # ------------------------------------------------------------------
+    # 1a0. Apt mirror reachability (Linux)
+    # ------------------------------------------------------------------
+    # A genuinely down mirror fails every apt-get attempt the same way, so
+    # retrying the full call burns the retry budget below on something that
+    # cannot succeed. Probe the mirror hosts actually configured on this
+    # runner (not a hardcoded default: GH-hosted Ubuntu runners point at a
+    # regional Azure mirror, not archive.ubuntu.com) and fail fast with a
+    # clear message if none answer. This only excludes classic #-commented
+    # lines; a deb822 .sources stanza disabled via "Enabled: no" without a
+    # leading # still counts as configured here.
+    - name: Check apt mirror reachability (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mirrors="$(grep -rhvE '^[[:space:]]*#' \
+          /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources \
+          2>/dev/null | grep -oE 'https?://[^ "]+' \
+          | sed -E 's#(https?://[^/]+).*#\1#' | sort -u || true)"
+        if [ -z "$mirrors" ]; then
+          echo "No apt mirror URIs found in the sources config; skipping the reachability check."
+          exit 0
+        fi
+        reachable=""
+        while IFS= read -r mirror; do
+          code="$(curl -sS --max-time 10 -o /dev/null -w '%{http_code}' "$mirror" 2>/dev/null)" || code="000"
+          if [ "$code" != "000" ]; then
+            echo "Reachable ($code): $mirror"
+            reachable=1
+            break
+          fi
+          echo "Unreachable: $mirror"
+        done <<< "$mirrors"
+        if [ -z "$reachable" ]; then
+          echo "::error::No configured apt mirror answered; failing fast instead of retrying apt-get against a mirror that cannot succeed." >&2
+          exit 1
+        fi
+
+    # ------------------------------------------------------------------
     # 1a. System packages (Linux)
     # ------------------------------------------------------------------
     - name: Install system packages (Linux)
@@ -108,56 +147,44 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        source "${{ github.action_path }}/retry-with-timeout.sh"
         # apt-get can stall mid-transfer against the Ubuntu mirrors; an
-        # unbounded call once consumed the whole job. Bound each call with a
-        # timeout and retry with backoff, similar to the AGNI fetch below
-        # (duplicated here since it's a separate step). Worst case is both
-        # calls timing out on every attempt, about 17 minutes total; check
-        # this step's caller has a job-level timeout above that.
-        delays=(45)
-        attempts=$(( ${#delays[@]} + 1 ))
-        apt_retry() {
-          local desc="$1"; shift
-          local n=1
-          while true; do
-            # A prior attempt killed by the timeout below can leave dpkg
-            # mid-unpack; repair that before retrying so the next attempt
-            # isn't rejected for an unrelated "packages not configured" error.
-            # Bounded for the same reason as the apt-get call itself: a wedged
-            # dpkg lock must not be able to hang the job indefinitely.
-            sudo timeout --kill-after=10 60 dpkg --configure -a >/dev/null 2>&1 || true
-            if sudo timeout --kill-after=10 150 apt-get "$@"; then
-              echo "$desc succeeded on attempt $n"
-              return 0
-            fi
-            if [ "$n" -ge "$attempts" ]; then
-              echo "$desc failed after $attempts attempts" >&2
-              return 1
-            fi
-            local delay="${delays[$((n - 1))]}"
-            echo "$desc attempt $n failed or timed out; retrying in ${delay}s" >&2
-            sleep "$delay"
-            n=$((n + 1))
-          done
+        # unbounded call once consumed the whole job. Bound each call with
+        # the shared retry_with_timeout helper (also used by the macOS step
+        # below). Worst case is both calls timing out on every attempt,
+        # about 17 minutes total; check this step's caller has a job-level
+        # timeout above that.
+        dpkg_repair() {
+          # A prior attempt killed by the timeout below can leave dpkg
+          # mid-unpack; repair that before retrying so the next attempt
+          # isn't rejected for an unrelated "packages not configured" error.
+          # Bounded for the same reason as the apt-get call itself: a wedged
+          # dpkg lock must not be able to hang the job indefinitely.
+          sudo timeout --kill-after=10 60 dpkg --configure -a >/dev/null 2>&1 || true
         }
-        apt_retry "apt-get update" update -qq
-        apt_retry "apt-get install" install -y --no-install-recommends \
-          gfortran \
-          libnetcdff-dev \
-          netcdf-bin \
-          libssl-dev \
-          curl
+        retry_with_timeout "apt-get update" 150 10 dpkg_repair \
+          sudo apt-get update -qq
+        retry_with_timeout "apt-get install" 150 10 dpkg_repair \
+          sudo apt-get install -y --no-install-recommends \
+            gfortran \
+            libnetcdff-dev \
+            netcdf-bin \
+            libssl-dev \
+            curl
 
     # ------------------------------------------------------------------
     # 1b. System packages (macOS)
     # ------------------------------------------------------------------
     # gcc provides the Fortran toolchain; netcdf-fortran provides
-    # nf-config for the SOCRATES build. The brew exit code needs
-    # special handling: on the macos-latest Sequoia images,
-    # ``brew install`` can exit 1 with all packages successfully
-    # poured when a post-install step emits the "did not complete
-    # successfully" warning. The packages themselves are functional,
-    # so verify each is on the prefix list before accepting the
+    # nf-config for the SOCRATES build. brew install can stall against a
+    # mirror the same way apt-get can, so it gets the same bounded
+    # timeout-and-retry pattern; recent CI runs finish this in ~20-25s, so
+    # the timeout below leaves large headroom while still capping a stall.
+    # The brew exit code needs special handling on top of that: on the
+    # macos-latest Sequoia images, ``brew install`` can exit 1 with all
+    # packages successfully poured when a post-install step emits the "did
+    # not complete successfully" warning. The packages themselves are
+    # functional, so verify each is on the prefix list before accepting the
     # failure.
     #
     # Calling workflows must leave USER at the runner default and must
@@ -171,17 +198,17 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        set +e
-        brew install --quiet gcc netcdf netcdf-fortran openssl@3
-        brew_rc=$?
-        set -e
+        source "${{ github.action_path }}/retry-with-timeout.sh"
+        brew_rc=0
+        retry_with_timeout "brew install" 240 10 "" \
+          brew install --quiet gcc netcdf netcdf-fortran openssl@3 || brew_rc=$?
         missing=()
         for pkg in gcc netcdf netcdf-fortran openssl@3; do
           brew list "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
         done
         if [ ${#missing[@]} -gt 0 ]; then
           echo "ERROR: brew install rc=$brew_rc and missing packages: ${missing[*]}" >&2
-          exit "${brew_rc:-1}"
+          exit "$brew_rc"
         fi
         if [ "$brew_rc" -ne 0 ]; then
           echo "brew install exited $brew_rc but all packages present; continuing"

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -111,8 +111,9 @@ runs:
         # apt-get can stall mid-transfer against the Ubuntu mirrors; an
         # unbounded call once consumed the whole job. Bound each call with a
         # timeout and retry with backoff, similar to the AGNI fetch below
-        # (duplicated here since it's a separate step). One retry keeps this
-        # step's worst case to a few minutes, well inside the job's own 30.
+        # (duplicated here since it's a separate step). Worst case is both
+        # calls timing out on every attempt, about 17 minutes total; check
+        # this step's caller has a job-level timeout above that.
         delays=(45)
         attempts=$(( ${#delays[@]} + 1 ))
         apt_retry() {
@@ -122,7 +123,9 @@ runs:
             # A prior attempt killed by the timeout below can leave dpkg
             # mid-unpack; repair that before retrying so the next attempt
             # isn't rejected for an unrelated "packages not configured" error.
-            sudo dpkg --configure -a >/dev/null 2>&1 || true
+            # Bounded for the same reason as the apt-get call itself: a wedged
+            # dpkg lock must not be able to hang the job indefinitely.
+            sudo timeout --kill-after=10 60 dpkg --configure -a >/dev/null 2>&1 || true
             if sudo timeout --kill-after=10 150 apt-get "$@"; then
               echo "$desc succeeded on attempt $n"
               return 0

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -103,14 +103,10 @@ runs:
     # ------------------------------------------------------------------
     # 1a0. Apt mirror reachability (Linux)
     # ------------------------------------------------------------------
-    # A genuinely down mirror fails every apt-get attempt the same way, so
-    # retrying the full call burns the retry budget below on something that
-    # cannot succeed. Probe the mirror hosts actually configured on this
-    # runner (not a hardcoded default: GH-hosted Ubuntu runners point at a
-    # regional Azure mirror, not archive.ubuntu.com) and fail fast with a
-    # clear message if none answer. This only excludes classic #-commented
-    # lines; a deb822 .sources stanza disabled via "Enabled: no" without a
-    # leading # still counts as configured here.
+    # A down mirror fails every apt-get attempt the same way, so probe the
+    # mirrors actually configured on this runner and fail fast if none
+    # answer, instead of retrying against one that cannot succeed. Doesn't
+    # recognize a deb822 stanza disabled only via "Enabled: no" (no leading #).
     - name: Check apt mirror reachability (Linux)
       if: runner.os == 'Linux'
       shell: bash
@@ -148,12 +144,10 @@ runs:
       run: |
         set -euo pipefail
         source "${{ github.action_path }}/retry-with-timeout.sh"
-        # apt-get can stall mid-transfer against the Ubuntu mirrors; an
-        # unbounded call once consumed the whole job. Bound each call with
-        # the shared retry_with_timeout helper (also used by the macOS step
-        # below). Worst case is both calls timing out on every attempt,
-        # about 17 minutes total; check this step's caller has a job-level
-        # timeout above that.
+        # apt-get can stall mid-transfer against the Ubuntu mirrors, so
+        # bound each call with the shared retry_with_timeout helper.
+        # Worst case is ~17 minutes if both calls time out on every
+        # attempt; the caller's job-level timeout must exceed that.
         dpkg_repair() {
           # A prior attempt killed by the timeout below can leave dpkg
           # mid-unpack; repair that before retrying so the next attempt
@@ -176,23 +170,16 @@ runs:
     # 1b. System packages (macOS)
     # ------------------------------------------------------------------
     # gcc provides the Fortran toolchain; netcdf-fortran provides
-    # nf-config for the SOCRATES build. brew install can stall against a
-    # mirror the same way apt-get can, so it gets the same bounded
-    # timeout-and-retry pattern; recent CI runs finish this in ~20-25s, so
-    # the timeout below leaves large headroom while still capping a stall.
-    # The brew exit code needs special handling on top of that: on the
-    # macos-latest Sequoia images, ``brew install`` can exit 1 with all
-    # packages successfully poured when a post-install step emits the "did
-    # not complete successfully" warning. The packages themselves are
-    # functional, so verify each is on the prefix list before accepting the
-    # failure.
+    # nf-config for the SOCRATES build. brew install can stall like
+    # apt-get, so it gets the same bounded retry pattern.
     #
-    # Calling workflows must leave USER at the runner default and must
-    # not set it in any env block. ``brew install`` runs a preinstall
-    # check that looks the active account up by name in the passwd
-    # database, so a USER naming an account that does not exist aborts
-    # this step with "user <name> doesn't exist" before any package is
-    # installed. ``tests/tools/test_install_scripts.py`` enforces this.
+    # brew install can exit 1 with all packages poured on macos-latest
+    # Sequoia (a post-install warning, not a real failure); verify each
+    # package is present before treating a nonzero exit as real.
+    #
+    # Calling workflows must leave USER at the runner default; brew's
+    # preinstall check looks it up in the passwd database and aborts early
+    # if it names a nonexistent account. test_install_scripts.py enforces this.
     - name: Install system packages (macOS)
       if: runner.os == 'macOS'
       shell: bash

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -169,17 +169,11 @@ runs:
     # ------------------------------------------------------------------
     # 1b. System packages (macOS)
     # ------------------------------------------------------------------
-    # gcc provides the Fortran toolchain; netcdf-fortran provides
-    # nf-config for the SOCRATES build. brew install can stall like
-    # apt-get, so it gets the same bounded retry pattern.
-    #
-    # brew install can exit 1 with all packages poured on macos-latest
-    # Sequoia (a post-install warning, not a real failure); verify each
-    # package is present before treating a nonzero exit as real.
-    #
-    # Calling workflows must leave USER at the runner default; brew's
-    # preinstall check looks it up in the passwd database and aborts early
-    # if it names a nonexistent account. test_install_scripts.py enforces this.
+    # gcc/netcdf-fortran give the Fortran toolchain and nf-config for SOCRATES. brew
+    # install shares apt-get's bounded retry pattern; a nonzero exit can still mean
+    # every package poured (a Sequoia post-install warning), so verify presence before
+    # trusting it. USER must stay at the runner default: brew's preinstall passwd lookup
+    # aborts on a nonexistent account (test_install_scripts.py enforces this).
     - name: Install system packages (macOS)
       if: runner.os == 'macOS'
       shell: bash

--- a/.github/actions/setup-proteus/retry-with-timeout.sh
+++ b/.github/actions/setup-proteus/retry-with-timeout.sh
@@ -1,0 +1,87 @@
+# Shared retry-with-timeout helper for the package-manager install steps in
+# this action. Source it, then call retry_with_timeout to run a command
+# under a bounded timeout, retrying once with backoff if it fails or times
+# out.
+#
+# Usage: retry_with_timeout <description> <timeout-secs> <kill-after-secs> <pre-attempt-hook-or-empty> <command...>
+# The pre-attempt hook, if non-empty, is called before every attempt and is
+# not itself subject to the timeout; give it its own bound if it needs one.
+# A non-zero return from the hook does not abort the caller; a hook that
+# calls `exit` directly bypasses that and ends the whole script.
+# A command beginning with `sudo` runs as `sudo <timeout-bin> ... <rest>`
+# rather than `<timeout-bin> ... sudo <rest>`, so a kill-after signal reaches
+# the privileged process directly instead of only reaching the sudo wrapper
+# around it, which sudo would not relay.
+
+# GNU coreutils' `timeout` ships on Linux runners but not on macOS; Homebrew
+# installs the same binary as `gtimeout` if asked. Resolve which name is on
+# PATH once per sourcing shell, installing coreutils only when neither exists.
+# Neither timeout binary is available yet at this point, so the install
+# itself is bounded by hand with a background watchdog. `set -m` gives the
+# install its own process group so the watchdog can kill the whole group
+# (`-$_rwt_brew_pid`, not just that one PID): brew forks child processes of
+# its own, and killing only the top PID would leave those running.
+if command -v timeout >/dev/null 2>&1; then
+  _RWT_TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  _RWT_TIMEOUT_BIN="gtimeout"
+else
+  ( set -m
+    brew install coreutils >/dev/null 2>&1 &
+    _rwt_brew_pid=$!
+    ( sleep 90; kill -9 -- "-$_rwt_brew_pid" ) >/dev/null 2>&1 &
+    _rwt_watch_pid=$!
+    wait "$_rwt_brew_pid" 2>/dev/null
+    kill -9 -- "-$_rwt_watch_pid" >/dev/null 2>&1
+    wait "$_rwt_watch_pid" 2>/dev/null
+  ) || true
+  if command -v gtimeout >/dev/null 2>&1; then
+    _RWT_TIMEOUT_BIN="gtimeout"
+  else
+    _RWT_TIMEOUT_BIN="timeout"
+  fi
+fi
+
+retry_with_timeout() {
+  local desc="$1" timeout_secs="$2" kill_after="$3" pre_hook="$4"
+  shift 4
+  local delays=(45)
+  local attempts=$(( ${#delays[@]} + 1 ))
+  local n=1 rc
+  local use_sudo=""
+  if [ "$1" = "sudo" ]; then
+    use_sudo=1
+    shift
+  fi
+
+  while true; do
+    if [ -n "$pre_hook" ]; then
+      "$pre_hook" || true
+    fi
+    if [ -n "$use_sudo" ]; then
+      if sudo "$_RWT_TIMEOUT_BIN" --kill-after="$kill_after" "$timeout_secs" "$@"; then
+        rc=0
+      else
+        rc=$?
+      fi
+    else
+      if "$_RWT_TIMEOUT_BIN" --kill-after="$kill_after" "$timeout_secs" "$@"; then
+        rc=0
+      else
+        rc=$?
+      fi
+    fi
+    if [ "$rc" -eq 0 ]; then
+      echo "$desc succeeded on attempt $n"
+      return 0
+    fi
+    if [ "$n" -ge "$attempts" ]; then
+      echo "$desc failed after $attempts attempts (exit $rc)" >&2
+      return "$rc"
+    fi
+    local delay="${delays[$((n - 1))]}"
+    echo "$desc attempt $n failed or timed out (exit $rc); retrying in ${delay}s" >&2
+    sleep "$delay"
+    n=$((n + 1))
+  done
+}

--- a/.github/actions/setup-proteus/retry-with-timeout.sh
+++ b/.github/actions/setup-proteus/retry-with-timeout.sh
@@ -1,26 +1,11 @@
-# Shared retry-with-timeout helper for the package-manager install steps in
-# this action. Source it, then call retry_with_timeout to run a command
-# under a bounded timeout, retrying once with backoff if it fails or times
-# out.
-#
 # Usage: retry_with_timeout <description> <timeout-secs> <kill-after-secs> <pre-attempt-hook-or-empty> <command...>
-# The pre-attempt hook, if non-empty, is called before every attempt and is
-# not itself subject to the timeout; give it its own bound if it needs one.
-# A non-zero return from the hook does not abort the caller; a hook that
-# calls `exit` directly bypasses that and ends the whole script.
-# A command beginning with `sudo` runs as `sudo <timeout-bin> ... <rest>`
-# rather than `<timeout-bin> ... sudo <rest>`, so a kill-after signal reaches
-# the privileged process directly instead of only reaching the sudo wrapper
-# around it, which sudo would not relay.
+# Source this, then call retry_with_timeout to run a command under a
+# bounded timeout, retrying once with backoff.
 
-# GNU coreutils' `timeout` ships on Linux runners but not on macOS; Homebrew
-# installs the same binary as `gtimeout` if asked. Resolve which name is on
-# PATH once per sourcing shell, installing coreutils only when neither exists.
-# Neither timeout binary is available yet at this point, so the install
-# itself is bounded by hand with a background watchdog. `set -m` gives the
-# install its own process group so the watchdog can kill the whole group
-# (`-$_rwt_brew_pid`, not just that one PID): brew forks child processes of
-# its own, and killing only the top PID would leave those running.
+# GNU coreutils' `timeout` ships on Linux but not macOS; resolve gtimeout
+# from Homebrew instead, installing coreutils only if neither is already
+# on PATH. That install is bounded by a background watchdog that kills
+# the whole process group, since brew forks children of its own.
 if command -v timeout >/dev/null 2>&1; then
   _RWT_TIMEOUT_BIN="timeout"
 elif command -v gtimeout >/dev/null 2>&1; then

--- a/.github/actions/setup-proteus/retry-with-timeout.sh
+++ b/.github/actions/setup-proteus/retry-with-timeout.sh
@@ -37,8 +37,11 @@ else
   ) || true
   if command -v gtimeout >/dev/null 2>&1; then
     _RWT_TIMEOUT_BIN="gtimeout"
-  else
+  elif command -v timeout >/dev/null 2>&1; then
     _RWT_TIMEOUT_BIN="timeout"
+  else
+    echo "retry-with-timeout.sh: neither timeout nor gtimeout is on PATH after installing coreutils; cannot bound package-manager calls, stopping here" >&2
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## Description
`apt-get update`/`apt-get install` in the Linux setup action can stall mid-transfer against the Ubuntu mirrors, and an unbounded call once consumed an entire nightly job. This wraps both calls in a timeout with one retry and backoff, and repairs any dpkg state a killed attempt leaves behind before retrying.

## Validation of changes
I traced the retry loop by hand and confirmed its bash syntax with `bash -n` on the extracted script block. I also bounded the `dpkg --configure -a` repair call with its own timeout, since it originally had none and could hang the job indefinitely on a wedged dpkg lock, defeating the point of the surrounding retry wrapper; and I corrected a comment that claimed the worst case stayed well inside a 30-minute job budget, which does not hold for every job that calls this action.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
