### PR TITLE
Record resolved step caps in the written coupler config

### DIFF
--- a/src/proteus/config/_config.py
+++ b/src/proteus/config/_config.py
@@ -371,12 +371,36 @@ class Config:
         cfg = dict_replace_none(cfg)
 
         # Apply any resolved-value overrides
-        for dotted_key, value in (overrides or {}).items():
-            *parents, leaf = dotted_key.split('.')
-            node = cfg
-            for key in parents:
-                node = node[key]
-            node[leaf] = value
+        if overrides:
+            # Imported here to avoid a module-level import cycle: orphans
+            # imports Config from this module.
+            from .orphans import UnknownConfigKeyError
+
+            for dotted_key, value in overrides.items():
+                segments = dotted_key.split('.')
+                *parents, leaf = segments
+                node = cfg
+                for depth, key in enumerate(parents):
+                    if not isinstance(node, dict) or key not in node:
+                        failing = '.'.join(segments[: depth + 1])
+                        raise UnknownConfigKeyError(
+                            f"Override key '{dotted_key}' does not match the schema: "
+                            f"no config section '{failing}'."
+                        )
+                    node = node[key]
+                if not isinstance(node, dict) or leaf not in node:
+                    raise UnknownConfigKeyError(
+                        f"Override key '{dotted_key}' does not match the schema: "
+                        f"no config field '{dotted_key}'."
+                    )
+                if isinstance(node[leaf], dict):
+                    raise UnknownConfigKeyError(
+                        f"Override key '{dotted_key}' targets a config section, "
+                        f"not a field; refusing to replace the whole section."
+                    )
+                # Route None through the same None -> "none" handling used above,
+                # so a None override does not reach tomlkit as a bare None.
+                node[leaf] = 'none' if value is None else value
 
         # Write to TOML file
         with open(out, 'w') as hdl:

--- a/src/proteus/config/_config.py
+++ b/src/proteus/config/_config.py
@@ -349,9 +349,19 @@ class Config:
         validator=(valid_config_version, check_module_dependencies),
     )
 
-    def write(self, out: str):
+    def write(self, out: str, overrides: dict | None = None):
         """
         Write configuration to a new TOML file.
+
+        Parameters
+        ----------
+        out
+            Output path for the TOML file.
+        overrides
+            Dotted-path values to substitute in the written file, e.g.
+            ``{'interior_energetics.aragog.phi_step_cap': 0.1}``. Lets a
+            caller record a resolved value (one a module derives from a
+            config default at runtime) without mutating this Config object.
         """
 
         # Convert to dictionary
@@ -359,6 +369,14 @@ class Config:
 
         # Replace None with "none"
         cfg = dict_replace_none(cfg)
+
+        # Apply any resolved-value overrides
+        for dotted_key, value in (overrides or {}).items():
+            *parents, leaf = dotted_key.split('.')
+            node = cfg
+            for key in parents:
+                node = node[key]
+            node[leaf] = value
 
         # Write to TOML file
         with open(out, 'w') as hdl:

--- a/src/proteus/config/_config.py
+++ b/src/proteus/config/_config.py
@@ -396,7 +396,7 @@ class Config:
                 if isinstance(node[leaf], dict):
                     raise UnknownConfigKeyError(
                         f"Override key '{dotted_key}' targets a config section, "
-                        f"not a field; refusing to replace the whole section."
+                        f'not a field; refusing to replace the whole section.'
                     )
                 # Route None through the same None -> "none" handling used above,
                 # so a None override does not reach tomlkit as a bare None.

--- a/src/proteus/interior_energetics/aragog.py
+++ b/src/proteus/interior_energetics/aragog.py
@@ -219,6 +219,28 @@ def _effective_entropy_step_cap(config: Config) -> float:
     return _resolve_step_cap(cap, _ZALMOXIS_DEFAULT_ENTROPY_STEP_CAP, is_zalmoxis)
 
 
+_OPTIONAL_ENERGY_FIELDS = frozenset(
+    {
+        'temperature_step_cap',
+        'entropy_step_cap',
+        'phase_boundary_entropy_margin',
+    }
+)
+
+
+def _unsupported_energy_fields() -> set[str]:
+    """Return the optional energy fields the installed Aragog does not accept.
+
+    The temperature/entropy step caps and the phase-boundary entropy margin need
+    a paired Aragog. An older Aragog omits them from ``_EnergyParameters``, so
+    ``setup_solver`` drops them and the solver degrades to Aragog defaults. The
+    config snapshot calls this too, so it records a not-applied marker rather
+    than a resolved value the run never received.
+    """
+    accepted = set(inspect.signature(_EnergyParameters).parameters)
+    return set(_OPTIONAL_ENERGY_FIELDS) - accepted
+
+
 def _is_plausible_core_density(rho_core: float) -> bool:
     """Return True iff ``rho_core`` falls inside the physical-bounds bracket."""
     return _RHO_CORE_MIN <= float(rho_core) <= _RHO_CORE_MAX
@@ -726,12 +748,7 @@ class AragogRunner:
         # Aragog accepts them, so an older Aragog degrades gracefully (no caps,
         # its built-in 200 J/kg/K margin) with a clear warning instead of
         # crashing on an unexpected keyword.
-        _energy_fields = set(inspect.signature(_EnergyParameters).parameters)
-        _unsupported = {
-            'temperature_step_cap',
-            'entropy_step_cap',
-            'phase_boundary_entropy_margin',
-        } - _energy_fields
+        _unsupported = _unsupported_energy_fields()
         _caps_requested = temperature_step_cap > 0.0 or entropy_step_cap > 0.0
         _nondefault_margin_dropped = (
             'phase_boundary_entropy_margin' in _unsupported

--- a/src/proteus/interior_energetics/aragog.py
+++ b/src/proteus/interior_energetics/aragog.py
@@ -234,8 +234,11 @@ def _unsupported_energy_fields() -> set[str]:
     The temperature/entropy step caps and the phase-boundary entropy margin need
     a paired Aragog. An older Aragog omits them from ``_EnergyParameters``, so
     ``setup_solver`` drops them and the solver degrades to Aragog defaults. The
-    config snapshot calls this too, so it records a not-applied marker rather
-    than a resolved value the run never received.
+    config snapshot calls this too, so it records a not-applied marker for a
+    dropped step cap rather than a resolved value the run never received. The
+    margin has no such marker because its positive-only validator forbids the
+    sentinel, so a dropped non-default margin is reported through a solve-time
+    warning instead.
     """
     accepted = set(inspect.signature(_EnergyParameters).parameters)
     return set(_OPTIONAL_ENERGY_FIELDS) - accepted

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -500,21 +500,31 @@ class Proteus:
         # as the value Aragog actually used instead of the schema's 0.0.
         step_cap_overrides = {}
         if self.config.interior_energetics.module == 'aragog':
+            from proteus.config._interior import _STEP_CAP_OFF
             from proteus.interior_energetics.aragog import (
                 _effective_entropy_step_cap,
                 _effective_phi_step_cap,
                 _effective_temperature_step_cap,
+                _unsupported_energy_fields,
             )
 
+            # phi_step_cap is always accepted by Aragog, so record its resolved
+            # value. An older Aragog drops the temperature/entropy caps before
+            # they reach the solver; record the disabled sentinel for a dropped
+            # cap so the snapshot does not claim a cap the run never used.
+            unsupported = _unsupported_energy_fields()
             step_cap_overrides = {
                 'interior_energetics.aragog.phi_step_cap': _effective_phi_step_cap(self.config),
-                'interior_energetics.aragog.temperature_step_cap': (
-                    _effective_temperature_step_cap(self.config)
-                ),
-                'interior_energetics.aragog.entropy_step_cap': _effective_entropy_step_cap(
-                    self.config
-                ),
             }
+            for field, resolve in (
+                ('temperature_step_cap', _effective_temperature_step_cap),
+                ('entropy_step_cap', _effective_entropy_step_cap),
+            ):
+                key = f'interior_energetics.aragog.{field}'
+                if field in unsupported:
+                    step_cap_overrides[key] = _STEP_CAP_OFF
+                else:
+                    step_cap_overrides[key] = resolve(self.config)
         self.config.write(
             os.path.join(self.directories['output'], 'init_coupler.toml'),
             overrides=step_cap_overrides,

--- a/src/proteus/proteus.py
+++ b/src/proteus/proteus.py
@@ -495,8 +495,30 @@ class Proteus:
         self.init_stage = True
         self._baseline_structure_done = False
 
-        # Write config to output directory, for future reference
-        self.config.write(os.path.join(self.directories['output'], 'init_coupler.toml'))
+        # Write config to output directory, for future reference. Record the
+        # resolved (not raw) step caps, so a zalmoxis-armed default reads back
+        # as the value Aragog actually used instead of the schema's 0.0.
+        step_cap_overrides = {}
+        if self.config.interior_energetics.module == 'aragog':
+            from proteus.interior_energetics.aragog import (
+                _effective_entropy_step_cap,
+                _effective_phi_step_cap,
+                _effective_temperature_step_cap,
+            )
+
+            step_cap_overrides = {
+                'interior_energetics.aragog.phi_step_cap': _effective_phi_step_cap(self.config),
+                'interior_energetics.aragog.temperature_step_cap': (
+                    _effective_temperature_step_cap(self.config)
+                ),
+                'interior_energetics.aragog.entropy_step_cap': _effective_entropy_step_cap(
+                    self.config
+                ),
+            }
+        self.config.write(
+            os.path.join(self.directories['output'], 'init_coupler.toml'),
+            overrides=step_cap_overrides,
+        )
 
         # Create lockfile for keeping simulation running
         self.lockfile = CreateLockFile(self.directories['output'])

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -298,6 +298,32 @@ def test_factory_defaults_from_minimal_config():
 
 
 @pytest.mark.unit
+def test_write_overrides_a_dotted_key_without_touching_live_config(tmp_path):
+    """Config.write(overrides=...) patches the written file, not self."""
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    assert cfg.interior_energetics.aragog.phi_step_cap == 0.0
+
+    out = tmp_path / 'resolved.toml'
+    cfg.write(str(out), overrides={'interior_energetics.aragog.phi_step_cap': 0.1})
+
+    assert cfg.interior_energetics.aragog.phi_step_cap == 0.0
+    written = read_config(str(out))
+    assert written['interior_energetics']['aragog']['phi_step_cap'] == 0.1
+
+
+@pytest.mark.unit
+def test_write_without_overrides_matches_the_live_config(tmp_path):
+    """Config.write() with no overrides writes fields verbatim, as before."""
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+
+    out = tmp_path / 'plain.toml'
+    cfg.write(str(out))
+
+    written = read_config(str(out))
+    assert written['interior_energetics']['aragog']['phi_step_cap'] == 0.0
+
+
+@pytest.mark.unit
 def test_read_config_object_returns_config():
     """
     read_config_object returns a validated Config instance.

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -9,8 +9,10 @@ structure, speed, and physics validity.
 from __future__ import annotations
 
 import os
+from contextlib import ExitStack
 from itertools import chain
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import attrs
 import pytest
@@ -32,6 +34,7 @@ from proteus.config._interior import valid_aragog, valid_interiordummy, valid_sp
 from proteus.config._outgas import Calliope
 from proteus.config._params import max_bigger_than_min, valid_mod, valid_path
 from proteus.config._planet import GasPrs, Planet
+from tests.test_proteus import _START_PATCHES
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
@@ -323,18 +326,15 @@ def test_write_without_overrides_matches_the_live_config(tmp_path):
     assert written['interior_energetics']['aragog']['phi_step_cap'] == 0.0
 
 
-def _run_start_and_read_written_config(cfg, tmp_path, monkeypatch):
+def _run_start_and_read_written_config(cfg, tmp_path):
     """Run the real Proteus.start init-time step-cap write against a config, return the result.
 
     Drives the actual production code path (proteus.py's module=='aragog' guard
     and step_cap_overrides construction) rather than a hand-built copy of it, by
     calling the unbound Proteus.start method on a lightweight stand-in for self.
-    Only unrelated print/validation/lockfile side effects are stubbed out.
+    Reuses tests/test_proteus.py's _START_PATCHES for the lazy imports start()
+    needs stubbed, plus PrintHalfSeparator, which that list does not cover.
     """
-    import proteus.proteus as proteus_mod
-    import proteus.utils.coupler as coupler_mod
-    import proteus.utils.terminate as terminate_mod
-
     outdir = tmp_path / 'output'
     for sub in ('', 'data', 'observe', 'offchem', 'plots'):
         (outdir / sub).mkdir(parents=True, exist_ok=True)
@@ -358,18 +358,19 @@ def _run_start_and_read_written_config(cfg, tmp_path, monkeypatch):
     def _stop(*args, **kwargs):
         raise _StoppedAfterWrite
 
-    monkeypatch.setattr(coupler_mod, 'print_header', lambda *a, **k: None)
-    monkeypatch.setattr(coupler_mod, 'print_system_configuration', lambda *a, **k: None)
-    monkeypatch.setattr(coupler_mod, 'print_module_configuration', lambda *a, **k: None)
-    monkeypatch.setattr(coupler_mod, 'validate_module_versions', lambda *a, **k: None)
-    monkeypatch.setattr(terminate_mod, 'print_termination_criteria', lambda *a, **k: None)
-    monkeypatch.setattr(proteus_mod, 'PrintHalfSeparator', lambda *a, **k: None)
-    # CreateLockFile runs immediately after the config write under test, so
-    # stopping there is enough and avoids driving the rest of start().
-    monkeypatch.setattr(coupler_mod, 'CreateLockFile', _stop)
+    with ExitStack() as stack:
+        for target in _START_PATCHES:
+            # CreateLockFile runs immediately after the config write under
+            # test, so stopping there is enough and avoids driving the rest
+            # of start().
+            if target == 'proteus.utils.coupler.CreateLockFile':
+                stack.enter_context(patch(target, side_effect=_stop))
+            else:
+                stack.enter_context(patch(target))
+        stack.enter_context(patch('proteus.proteus.PrintHalfSeparator'))
 
-    with pytest.raises(_StoppedAfterWrite):
-        Proteus.start(proteus, resume=False, offline=True)
+        with pytest.raises(_StoppedAfterWrite):
+            Proteus.start(proteus, resume=False, offline=True)
 
     written = outdir / 'init_coupler.toml'
     assert written.is_file()
@@ -377,7 +378,7 @@ def _run_start_and_read_written_config(cfg, tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
-def test_start_writes_resolved_zalmoxis_step_caps_for_aragog(tmp_path, monkeypatch):
+def test_start_writes_resolved_zalmoxis_step_caps_for_aragog(tmp_path):
     """Proteus.start's aragog guard writes resolved, not raw, step caps to init_coupler.toml."""
     cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
     assert cfg.interior_energetics.module == 'aragog'
@@ -386,7 +387,7 @@ def test_start_writes_resolved_zalmoxis_step_caps_for_aragog(tmp_path, monkeypat
     assert cfg.interior_energetics.aragog.temperature_step_cap == 0.0
     assert cfg.interior_energetics.aragog.entropy_step_cap == 0.0
 
-    written = _run_start_and_read_written_config(cfg, tmp_path, monkeypatch)
+    written = _run_start_and_read_written_config(cfg, tmp_path)
 
     aragog = written.interior_energetics.aragog
     assert aragog.phi_step_cap == pytest.approx(0.1)
@@ -395,13 +396,30 @@ def test_start_writes_resolved_zalmoxis_step_caps_for_aragog(tmp_path, monkeypat
 
 
 @pytest.mark.unit
-def test_start_leaves_step_caps_raw_when_energetics_module_is_not_aragog(tmp_path, monkeypatch):
+def test_start_writes_verbatim_positive_step_caps_for_aragog(tmp_path):
+    """Distinct positive step caps pass through Proteus.start's aragog guard unswapped."""
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    assert cfg.interior_energetics.module == 'aragog'
+    cfg.interior_energetics.aragog.phi_step_cap = 2.0
+    cfg.interior_energetics.aragog.temperature_step_cap = 3.0
+    cfg.interior_energetics.aragog.entropy_step_cap = 7.0
+
+    written = _run_start_and_read_written_config(cfg, tmp_path)
+
+    aragog = written.interior_energetics.aragog
+    assert aragog.phi_step_cap == pytest.approx(2.0)
+    assert aragog.temperature_step_cap == pytest.approx(3.0)
+    assert aragog.entropy_step_cap == pytest.approx(7.0)
+
+
+@pytest.mark.unit
+def test_start_leaves_step_caps_raw_when_energetics_module_is_not_aragog(tmp_path):
     """The aragog guard must not fire, and must not promote caps, for a non-aragog module."""
     cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
     cfg.interior_energetics.module = 'dummy'
     assert cfg.interior_struct.module == 'zalmoxis'
 
-    written = _run_start_and_read_written_config(cfg, tmp_path, monkeypatch)
+    written = _run_start_and_read_written_config(cfg, tmp_path)
 
     aragog = written.interior_energetics.aragog
     assert aragog.phi_step_cap == 0.0

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -323,6 +323,92 @@ def test_write_without_overrides_matches_the_live_config(tmp_path):
     assert written['interior_energetics']['aragog']['phi_step_cap'] == 0.0
 
 
+def _run_start_and_read_written_config(cfg, tmp_path, monkeypatch):
+    """Run the real Proteus.start init-time step-cap write against a config, return the result.
+
+    Drives the actual production code path (proteus.py's module=='aragog' guard
+    and step_cap_overrides construction) rather than a hand-built copy of it, by
+    calling the unbound Proteus.start method on a lightweight stand-in for self.
+    Only unrelated print/validation/lockfile side effects are stubbed out.
+    """
+    import proteus.proteus as proteus_mod
+    import proteus.utils.coupler as coupler_mod
+    import proteus.utils.terminate as terminate_mod
+
+    outdir = tmp_path / 'output'
+    for sub in ('', 'data', 'observe', 'offchem', 'plots'):
+        (outdir / sub).mkdir(parents=True, exist_ok=True)
+
+    proteus = SimpleNamespace(
+        config=cfg,
+        config_path=str(PROTEUS_ROOT / 'input' / 'minimal.toml'),
+        directories={
+            'output': str(outdir),
+            'output/data': str(outdir / 'data'),
+            'output/observe': str(outdir / 'observe'),
+            'output/offchem': str(outdir / 'offchem'),
+            'output/plots': str(outdir / 'plots'),
+            'fwl': str(tmp_path),
+        },
+    )
+
+    class _StoppedAfterWrite(Exception):
+        pass
+
+    def _stop(*args, **kwargs):
+        raise _StoppedAfterWrite
+
+    monkeypatch.setattr(coupler_mod, 'print_header', lambda *a, **k: None)
+    monkeypatch.setattr(coupler_mod, 'print_system_configuration', lambda *a, **k: None)
+    monkeypatch.setattr(coupler_mod, 'print_module_configuration', lambda *a, **k: None)
+    monkeypatch.setattr(coupler_mod, 'validate_module_versions', lambda *a, **k: None)
+    monkeypatch.setattr(terminate_mod, 'print_termination_criteria', lambda *a, **k: None)
+    monkeypatch.setattr(proteus_mod, 'PrintHalfSeparator', lambda *a, **k: None)
+    # CreateLockFile runs immediately after the config write under test, so
+    # stopping there is enough and avoids driving the rest of start().
+    monkeypatch.setattr(coupler_mod, 'CreateLockFile', _stop)
+
+    with pytest.raises(_StoppedAfterWrite):
+        Proteus.start(proteus, resume=False, offline=True)
+
+    written = outdir / 'init_coupler.toml'
+    assert written.is_file()
+    return read_config_object(written)
+
+
+@pytest.mark.unit
+def test_start_writes_resolved_zalmoxis_step_caps_for_aragog(tmp_path, monkeypatch):
+    """Proteus.start's aragog guard writes resolved, not raw, step caps to init_coupler.toml."""
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    assert cfg.interior_energetics.module == 'aragog'
+    assert cfg.interior_struct.module == 'zalmoxis'
+    assert cfg.interior_energetics.aragog.phi_step_cap == 0.0
+    assert cfg.interior_energetics.aragog.temperature_step_cap == 0.0
+    assert cfg.interior_energetics.aragog.entropy_step_cap == 0.0
+
+    written = _run_start_and_read_written_config(cfg, tmp_path, monkeypatch)
+
+    aragog = written.interior_energetics.aragog
+    assert aragog.phi_step_cap == pytest.approx(0.1)
+    assert aragog.temperature_step_cap == pytest.approx(100.0)
+    assert aragog.entropy_step_cap == pytest.approx(100.0)
+
+
+@pytest.mark.unit
+def test_start_leaves_step_caps_raw_when_energetics_module_is_not_aragog(tmp_path, monkeypatch):
+    """The aragog guard must not fire, and must not promote caps, for a non-aragog module."""
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    cfg.interior_energetics.module = 'dummy'
+    assert cfg.interior_struct.module == 'zalmoxis'
+
+    written = _run_start_and_read_written_config(cfg, tmp_path, monkeypatch)
+
+    aragog = written.interior_energetics.aragog
+    assert aragog.phi_step_cap == 0.0
+    assert aragog.temperature_step_cap == 0.0
+    assert aragog.entropy_step_cap == 0.0
+
+
 @pytest.mark.unit
 def test_read_config_object_returns_config():
     """

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -345,7 +345,9 @@ def test_write_rejects_an_unknown_override_key(tmp_path):
     # A missing intermediate section is named too, not a bare KeyError. Anchor
     # the match to the trailing clause so it checks the reported failing segment,
     # not the dotted key echoed earlier in the same message.
-    with pytest.raises(UnknownConfigKeyError, match=r"no config section 'interior_energetics\.nope'"):
+    with pytest.raises(
+        UnknownConfigKeyError, match=r"no config section 'interior_energetics\.nope'"
+    ):
         cfg.write(str(out), overrides={'interior_energetics.nope.phi_step_cap': 0.1})
     # A key that resolves to a whole section, not a leaf field, is rejected too,
     # so an override cannot replace a section with a scalar.

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -311,7 +311,7 @@ def test_write_overrides_a_dotted_key_without_touching_live_config(tmp_path):
 
     assert cfg.interior_energetics.aragog.phi_step_cap == 0.0
     written = read_config(str(out))
-    assert written['interior_energetics']['aragog']['phi_step_cap'] == 0.1
+    assert written['interior_energetics']['aragog']['phi_step_cap'] == pytest.approx(0.1)
 
 
 @pytest.mark.unit
@@ -324,6 +324,48 @@ def test_write_without_overrides_matches_the_live_config(tmp_path):
 
     written = read_config(str(out))
     assert written['interior_energetics']['aragog']['phi_step_cap'] == 0.0
+    # Discriminating: a non-default field must round-trip verbatim too, so a
+    # plain write is not silently substituting or dropping fields.
+    assert written['interior_struct']['module'] == cfg.interior_struct.module == 'zalmoxis'
+
+
+@pytest.mark.unit
+def test_write_rejects_an_unknown_override_key(tmp_path):
+    """An override key outside the schema raises, so a typo cannot inject a stray key."""
+    from proteus.config.orphans import UnknownConfigKeyError
+
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    out = tmp_path / 'bad.toml'
+
+    # A typo in the leaf field is named and rejected, not silently inserted.
+    with pytest.raises(UnknownConfigKeyError, match='phi_step_kap'):
+        cfg.write(str(out), overrides={'interior_energetics.aragog.phi_step_kap': 0.1})
+    # The rejection happens before the write, so no partial file is emitted.
+    assert not out.exists()
+    # A missing intermediate section is named too, not a bare KeyError. Anchor
+    # the match to the trailing clause so it checks the reported failing segment,
+    # not the dotted key echoed earlier in the same message.
+    with pytest.raises(UnknownConfigKeyError, match=r"no config section 'interior_energetics\.nope'"):
+        cfg.write(str(out), overrides={'interior_energetics.nope.phi_step_cap': 0.1})
+    # A key that resolves to a whole section, not a leaf field, is rejected too,
+    # so an override cannot replace a section with a scalar.
+    with pytest.raises(UnknownConfigKeyError, match='targets a config section'):
+        cfg.write(str(out), overrides={'interior_energetics.aragog': 0.1})
+
+
+@pytest.mark.unit
+def test_write_accepts_a_none_override_without_crashing(tmp_path):
+    """A None override writes the 'none' sentinel, not a bare None that crashes tomlkit."""
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    out = tmp_path / 'noned.toml'
+
+    cfg.write(str(out), overrides={'atmos_chem.module': None})
+
+    written = read_config(str(out))
+    assert written['atmos_chem']['module'] == 'none'
+    # The written file parses back through the schema, so the None handling
+    # produced a valid config rather than a broken one.
+    assert read_config_object(out).atmos_chem.module is None
 
 
 def _run_start_and_read_written_config(cfg, tmp_path):
@@ -410,6 +452,35 @@ def test_start_writes_verbatim_positive_step_caps_for_aragog(tmp_path):
     assert aragog.phi_step_cap == pytest.approx(2.0)
     assert aragog.temperature_step_cap == pytest.approx(3.0)
     assert aragog.entropy_step_cap == pytest.approx(7.0)
+
+
+@pytest.mark.unit
+def test_start_records_not_applied_marker_when_aragog_lacks_step_caps(tmp_path):
+    """Under Aragog version skew the snapshot records the disabled sentinel, not a resolved cap."""
+    from proteus.config._interior import _STEP_CAP_OFF
+
+    cfg = read_config_object(PROTEUS_ROOT / 'input' / 'minimal.toml')
+    assert cfg.interior_energetics.module == 'aragog'
+    assert cfg.interior_struct.module == 'zalmoxis'
+
+    # Stand in for an older Aragog whose _EnergyParameters predates the
+    # temperature/entropy step caps, so setup_solver would drop them.
+    def _old_energy_parameters(conduction=None, convection=None, phi_step_cap=None):
+        raise NotImplementedError
+
+    with patch(
+        'proteus.interior_energetics.aragog._EnergyParameters',
+        _old_energy_parameters,
+    ):
+        written = _run_start_and_read_written_config(cfg, tmp_path)
+
+    aragog = written.interior_energetics.aragog
+    # phi is always supported, so it still records the zalmoxis-resolved value.
+    assert aragog.phi_step_cap == pytest.approx(0.1)
+    # The dropped caps record the disabled sentinel, not the resolved 100.0 the
+    # run never received.
+    assert aragog.temperature_step_cap == pytest.approx(_STEP_CAP_OFF)
+    assert aragog.entropy_step_cap == pytest.approx(_STEP_CAP_OFF)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description

When the interior energetics module is Aragog on a Zalmoxis structure, Aragog arms a step cap at runtime from a schema default of `0.0`. The `init_coupler.toml` snapshot written at initialisation recorded the raw `0.0` for `phi_step_cap`, `temperature_step_cap`, and `entropy_step_cap`, so the archived config did not show the value the run actually used.

`Config.write` now takes an optional `overrides` dict of dotted-path values. On init the Aragog path resolves the three effective step caps and passes them as overrides, so the written config records the resolved values. The override is applied to the serialised dict only; the live `Config` object is not mutated.

Closes #814.

## Validation of changes

I ran the full `tests/config/` suite: 295 passed. The new tests drive the real `Proteus.start` init path (the `step_cap_overrides` build and the `module == 'aragog'` guard), read the written `init_coupler.toml` back, and check the recorded caps:

- The promotion test confirms raw `0.0` caps on a Zalmoxis + Aragog config are written as the resolved `0.1` / `100.0` / `100.0`.
- The verbatim test sets three distinct positive caps and confirms each is written unchanged, so a temperature/entropy key swap in the override construction fails the test.
- A non-Aragog energetics module leaves the caps raw.

Test configuration: macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
