### PR TITLE
Pin macOS CI conda BLAS to Accelerate to fix unit-tier SIGABRT

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -254,12 +254,51 @@ runs:
     # Install the conda-side dependencies that need native libraries
     # (SUNDIALS for CVODE, scikits.odes for the Python bindings). The
     # rest of PROTEUS installs via pip into the same env in step 8.
-    - name: Install conda dependencies
+    - name: Install conda dependencies (Linux)
+      if: runner.os == 'Linux'
       shell: bash -el {0}
       run: |
         set -euo pipefail
         mamba install -n proteus -c conda-forge -y sundials 'scikits.odes>=3.0.0'
+
+    # Pin BLAS/LAPACK to the Accelerate build variant in the same
+    # solve. The openblas variant drags in llvm-openmp, which loads a
+    # second libomp.dylib into the same process as torch's bundled
+    # copy and aborts the process at import time.
+    - name: Install conda dependencies (macOS)
+      if: runner.os == 'macOS'
+      shell: bash -el {0}
+      run: |
+        set -euo pipefail
+        mamba install -n proteus -c conda-forge -y sundials 'scikits.odes>=3.0.0' \
+          'libblas=*=*accelerate*' 'liblapack=*=*accelerate*'
+
+    - name: Verify conda dependencies
+      shell: bash -el {0}
+      run: |
+        set -euo pipefail
         python -c "import scikits.odes; print('scikits.odes OK, version', scikits.odes.__version__)"
+
+    # Verify the install landed on the intended variant so a channel
+    # or solver drift back to openblas fails loudly here instead of
+    # resurfacing as an unrelated-looking pytest collection abort.
+    - name: Verify BLAS/LAPACK build (macOS)
+      if: runner.os == 'macOS'
+      shell: bash -el {0}
+      run: |
+        set -euo pipefail
+        blas_info="$(mamba list -n proteus '^libblas$')"
+        lapack_info="$(mamba list -n proteus '^liblapack$')"
+        echo "$blas_info"
+        echo "$lapack_info"
+        if ! grep -q accelerate <<< "$blas_info"; then
+          echo "::error::libblas did not resolve to an Accelerate build; this reintroduces the duplicate libomp.dylib SIGABRT." >&2
+          exit 1
+        fi
+        if ! grep -q accelerate <<< "$lapack_info"; then
+          echo "::error::liblapack did not resolve to an Accelerate build; this reintroduces the duplicate libomp.dylib SIGABRT." >&2
+          exit 1
+        fi
 
     # ------------------------------------------------------------------
     # 3. Julia


### PR DESCRIPTION
## Description

The macOS Unit and Slow tiers abort at pytest startup with `Abort trap: 6` (exit code 134), before any test runs. Importing torch loads its bundled `libomp.dylib`, and the conda openblas BLAS variant pulls a second `libomp.dylib` (llvm-openmp) into the same process during the `sundials` / `scikits.odes` install. The duplicate OpenMP runtime aborts the process.

This pins the macOS conda `libblas` and `liblapack` to the Accelerate build variant, so llvm-openmp is never installed and only one `libomp.dylib` loads. The conda install step is split into a Linux step, whose install command is unchanged, and a macOS step that adds the Accelerate pins. A macOS verify step fails the build if the variant drifts back to openblas, so a future channel or solver change surfaces here instead of resurfacing as an unrelated-looking pytest collection abort.

The nightly runs that show the abort: 33730197851 and 33850245873, both on `main`, macOS only, on the same commit that passes on Linux.

## Validation of changes

I reproduced the abort on macOS arm64 in a CI-faithful environment: a DYLD trace showed two `libomp.dylib` loads, torch's bundled copy and conda's llvm-openmp, the latter pulled in by numpy's openblas variant during the conda install. With the Accelerate pins the DYLD trace shows a single `libomp.dylib` load, and a `scikits.odes` / CVODE smoke case gives byte-identical results across the two BLAS variants. The Linux install command is unchanged, so the ubuntu leg is untouched by construction. CI on this PR is the final confirmation.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
