### PR TITLE
Key the SOCRATES and Julia CI caches to the runner image version

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -342,6 +342,9 @@ runs:
       run: |
         set -euo pipefail
         version="${ImageVersion:-unknown}"
+        if [ "$version" = "unknown" ]; then
+          echo "::warning::ImageVersion is not set on this runner; the SOCRATES and Julia depot cache keys fall back to a constant value and will not bust on an image bump"
+        fi
         echo "Runner ImageVersion: $version"
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -408,15 +411,20 @@ runs:
     # ------------------------------------------------------------------
     # 7. Julia depot cache (AGNI's Pkg.instantiate output)
     # ------------------------------------------------------------------
+    # The depot holds precompiled Julia packages and downloaded JLL binary
+    # artifacts, some of which dlopen/dlsym against native shared libraries
+    # (including libSOCRATES_C via AGNI's ccall bindings) the same way the
+    # SOCRATES build cache above does, so the key carries the same
+    # ImageVersion component to avoid serving artifacts across an image bump.
     - name: Cache Julia depot
       id: cache-julia
       uses: actions/cache@v5
       with:
         path: ~/.julia
-        key: julia-${{ runner.os }}-${{ runner.arch }}-${{ inputs.julia-version }}-${{ steps.pins.outputs.agni_ref }}-${{ hashFiles('AGNI/Project.toml','AGNI/Manifest.toml') }}
+        key: julia-${{ runner.os }}-${{ runner.arch }}-${{ inputs.julia-version }}-${{ steps.runner-image.outputs.version }}-${{ steps.pins.outputs.agni_ref }}-${{ hashFiles('AGNI/Project.toml','AGNI/Manifest.toml') }}
         restore-keys: |
-          julia-${{ runner.os }}-${{ runner.arch }}-${{ inputs.julia-version }}-${{ steps.pins.outputs.agni_ref }}-
-          julia-${{ runner.os }}-${{ runner.arch }}-${{ inputs.julia-version }}-
+          julia-${{ runner.os }}-${{ runner.arch }}-${{ inputs.julia-version }}-${{ steps.runner-image.outputs.version }}-${{ steps.pins.outputs.agni_ref }}-
+          julia-${{ runner.os }}-${{ runner.arch }}-${{ inputs.julia-version }}-${{ steps.runner-image.outputs.version }}-
 
     - name: Fetch AGNI spectral data (with retry)
       shell: bash

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -329,15 +329,28 @@ runs:
     # generations within the same OS/arch label. One cache per OS/arch is
     # therefore sufficient. The '-portable' key component separates these
     # caches from any tree built with the default performance flags.
+    # The key also carries the hosted runner's ImageVersion: a compiled
+    # shared library that resolves its symbols correctly on one runner
+    # image can fail to resolve them at runtime on a later image of the
+    # same OS/arch label, so the cache must not survive an image bump.
     # No restore-keys: a prefix-restored tree would be deleted and rebuilt
     # from scratch by get_socrates.sh anyway, so a partial restore is pure
     # download cost.
+    - name: Read runner image version
+      id: runner-image
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${ImageVersion:-unknown}"
+        echo "Runner ImageVersion: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Cache SOCRATES build
       id: cache-socrates
       uses: actions/cache@v5
       with:
         path: socrates/
-        key: socrates-${{ runner.os }}-${{ runner.arch }}-portable-${{ steps.pins.outputs.socrates_ref }}-${{ hashFiles('tools/get_socrates.sh') }}
+        key: socrates-${{ runner.os }}-${{ runner.arch }}-portable-${{ steps.runner-image.outputs.version }}-${{ steps.pins.outputs.socrates_ref }}-${{ hashFiles('tools/get_socrates.sh') }}
 
     - name: Build SOCRATES (cache miss)
       if: steps.cache-socrates.outputs.cache-hit != 'true'

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -411,11 +411,15 @@ runs:
     # ------------------------------------------------------------------
     # 7. Julia depot cache (AGNI's Pkg.instantiate output)
     # ------------------------------------------------------------------
-    # The depot holds precompiled Julia packages and downloaded JLL binary
-    # artifacts, some of which dlopen/dlsym against native shared libraries
-    # (including libSOCRATES_C via AGNI's ccall bindings) the same way the
-    # SOCRATES build cache above does, so the key carries the same
-    # ImageVersion component to avoid serving artifacts across an image bump.
+    # The depot holds Julia's own precompiled package cache and downloaded
+    # JLL binary artifacts, which dlopen/dlsym against native shared
+    # libraries the same way the SOCRATES build cache above does (the
+    # libSOCRATES_C ccall bindings AGNI compiles live in socrates/, under
+    # the separate cache above, not in this depot). The key carries the
+    # same ImageVersion component to avoid serving artifacts across an
+    # image bump. Both restore-key tiers below carry it too, so an image
+    # bump forces a full Pkg.instantiate() on the next run instead of a
+    # partial restore; that cost is accepted to keep the cache correct.
     - name: Cache Julia depot
       id: cache-julia
       uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Key the CI build caches for SOCRATES and the Julia depot to the runner image version, so a macOS image update forces a rebuild instead of reusing a binary built under a different OS release.

The nightly Integration tier on macos-latest started failing at AGNI precompile with `could not load symbol "PS_real_kind_bytes"` from `libSOCRATES_C`. Nothing in the pinned code had changed: the same aragog and SOCRATES refs were green the day before. The runner image had moved from macOS 26.5.2 to 26.6.2, and the SOCRATES build cache hit on both days, so the identical cached library was loaded under the new OS release and `dlsym` no longer resolved the symbol. A fresh compile of the pinned SOCRATES source on macOS 26 exports the symbol normally; the problem was cache reuse across images, not the toolchain.

## Changes

- `.github/actions/setup-proteus/action.yml`: the SOCRATES build cache key and the Julia depot cache key now include the runner `ImageVersion`, read from the runner environment with a debug echo of the resolved value. If the variable is absent the key falls back to a fixed string and a warning is emitted, so a silent cross-image reuse cannot recur unnoticed. Comments state what each cache holds and why the depot also needs the key.

No test, tier, or job is disabled or narrowed.

## Validation

Branch run 34027663894: Unit tier and Integration tier pass on both macOS and Ubuntu, 202 integration tests including every AGNI integration test that failed on main. The `ImageVersion` value resolved in the job log. That runner was still on the previous image, so the run exercised the new key producing a cache miss and a clean fresh build; the first nightly on an updated image will exercise the rebuild path the same way.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
