### PR TITLE
Fix the code style workflow link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Once your new data is uploaded on Zenodo, do not forget to also upload it on the
 Linting is a term for static code analysis to flag programming errors,
 bugs, stylistic errors and suspicious constructs [[ref]](https://en.wikipedia.org/wiki/Lint_(software)).
 
-PROTEUS uses [`ruff`](https://astral.sh/ruff) for linting. The linting [rules](https://docs.astral.sh/ruff/rules/) are defined in [`pyproject.toml`](https://github.com/FormingWorlds/PROTEUS/blob/main/pyproject.toml). This check are run automatically via a Github Action: [codestyle](https://github.com/FormingWorlds/PROTEUS/blob/main/.github/workflows/codestyle.yaml).
+PROTEUS uses [`ruff`](https://astral.sh/ruff) for linting. The linting [rules](https://docs.astral.sh/ruff/rules/) are defined in [`pyproject.toml`](https://github.com/FormingWorlds/PROTEUS/blob/main/pyproject.toml). This check are run automatically via a Github Action: [codestyle](https://github.com/FormingWorlds/PROTEUS/blob/main/.github/workflows/code-style.yaml).
 
 You can `ruff` on locally using one of these commands:
 


### PR DESCRIPTION
CONTRIBUTING.md links the workflow as `.github/workflows/codestyle.yaml`, but the file is named `code-style.yaml`, so the link 404s.

Checked that the corrected URL returns 200.