### PR TITLE
Forward separation_viscosity to the JAX interior solver

### DIFF
--- a/src/proteus/interior_energetics/aragog_jax.py
+++ b/src/proteus/interior_energetics/aragog_jax.py
@@ -107,6 +107,7 @@ class AragogJAXRunner:
             bottom_up_grav_sep=True,
             phase_smoothing=config.interior_energetics.aragog.phase_smoothing,
             phase_smoothing_width=0.01,
+            separation_viscosity=config.interior_energetics.aragog.separation_viscosity,
         )
 
         # Boundary conditions

--- a/tests/interior_energetics/test_aragog_jax.py
+++ b/tests/interior_energetics/test_aragog_jax.py
@@ -59,7 +59,8 @@ def _make_config(*, heat_radiogenic: bool = False, heat_tidal: bool = False):
     config.interior_energetics.eddy_diffusivity_chemical = 0.1
     config.interior_energetics.kappah_floor = 1e-6
     config.interior_energetics.spider.matprop_smooth_width = 0.02
-    config.interior_energetics.aragog.phase_smoothing = True
+    config.interior_energetics.aragog.phase_smoothing = 'tanh'
+    config.interior_energetics.aragog.separation_viscosity = 'mixture'
     config.interior_energetics.aragog.atol_temperature_equivalent = 1.0
     config.interior_energetics.rtol = 1e-4
     config.interior_energetics.heat_radiogenic = heat_radiogenic
@@ -133,6 +134,49 @@ def test_build_jax_components_raises_when_spider_eos_dir_missing(tmp_path):
         interior_o = _make_interior_o(spider_eos_dir=bad_eos_dir)
         with pytest.raises(FileNotFoundError, match=r'(?i)PALEOS|tables not found'):
             AragogJAXRunner(config, {'output': str(tmp_path)}, {}, None, interior_o)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ('separation_viscosity', 'expected_mixture_flag'),
+    [('mixture', 1.0), ('melt', 0.0)],
+)
+def test_build_jax_components_forwards_separation_viscosity(
+    tmp_path, separation_viscosity, expected_mixture_flag
+):
+    """``_build_jax_components`` forwards ``separation_viscosity`` from the
+    PROTEUS config to the JAX ``PhaseParams``.
+
+    Contract from ``aragog_jax.py`` (``_build_jax_components``): the
+    ``PhaseParams`` construction must pass ``separation_viscosity`` through
+    from ``config.interior_energetics.aragog.separation_viscosity``, so the
+    JAX solver honours the same setting as the numpy solver instead of
+    silently falling back to the aragog library default (``'melt'``, which
+    differs from the PROTEUS schema default ``'mixture'``).
+
+    Discrimination: a regression that drops the kwarg falls back to the
+    library default ``'melt'`` regardless of the config value, so the
+    ``'mixture'`` case (``expected_mixture_flag=1.0``) fails while the
+    ``'melt'`` case passes by coincidence. Parametrizing over both values
+    catches a dropped kwarg either way.
+    """
+    config = _make_config()
+    config.interior_energetics.aragog.separation_viscosity = separation_viscosity
+    interior_o = _make_interior_o(spider_eos_dir=str(tmp_path))
+
+    with (
+        patch('aragog.jax.eos.EntropyEOS_JAX', return_value=MagicMock()),
+        patch.object(AragogJAXRunner, '_build_mesh_arrays', return_value=MagicMock()),
+    ):
+        AragogJAXRunner(config, {'output': str(tmp_path)}, {}, None, interior_o)
+
+    assert interior_o._jax_params.separation_viscosity_mixture == pytest.approx(
+        expected_mixture_flag
+    ), (
+        f'separation_viscosity={separation_viscosity!r} produced '
+        f'separation_viscosity_mixture={interior_o._jax_params.separation_viscosity_mixture}, '
+        f'expected {expected_mixture_flag}'
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description

Makes the JAX interior solver honour the `separation_viscosity` config option, matching the numpy solver.

`_build_jax_components` built the JAX `PhaseParams` without `separation_viscosity`, so it silently fell back to the aragog library default (`melt`) instead of the value set in the PROTEUS config (schema default `mixture`). The numpy solver path already forwarded this field, so the two solvers disagreed on which viscosity blend to use for the gravitational-separation velocity whenever a run used the JAX path.

- Add `separation_viscosity=config.interior_energetics.aragog.separation_viscosity` to the `PhaseParams(...)` construction in `_build_jax_components`.
- Add a parametrized regression test covering both `mixture` and `melt`, so a dropped kwarg fails the test regardless of which value the config sets.
- Fix the shared test fixture (`phase_smoothing = True` is not a valid value; it now sets `'tanh'`) and add `separation_viscosity = 'mixture'` to match the schema default.

Related: item 5 of the follow-up list on FormingWorlds/aragog#36.

## Validation of changes

- `pytest tests/interior_energetics/test_aragog_jax.py -k separation_viscosity`: 2 passed
- `pytest tests/interior_energetics/test_aragog_jax.py`: 6 passed
- `pytest tests/interior_energetics/`: 489 passed, 7 skipped (pre-existing, unrelated)
- `pytest tests/ -m "unit" -q`: 3101 passed, 26 skipped (pre-existing, unrelated), 0 failed

macOS (Apple Silicon), Python 3.12, aragog 26.09.06. No docs change: `docs/Reference/config/interior.md` already documents the option without a solver-path restriction.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
