### PR TITLE
Build aragog phase parameters through one shared builder

### DIFF
--- a/src/proteus/interior_energetics/aragog.py
+++ b/src/proteus/interior_energetics/aragog.py
@@ -25,10 +25,13 @@ from aragog.parser import (
     _EnergyParameters,
     _InitialConditionParameters,
     _MeshParameters,
-    _PhaseMixedParameters,
     _PhaseParameters,
     _Radionuclide,
     _SolverParameters,
+)
+from proteus.interior_energetics.aragog_phase import (
+    build_jax_phase_params,
+    build_mixed_phase_params,
 )
 from proteus.interior_energetics.common import Interior_t
 from proteus.utils.constants import FEI2021_LIQUIDUS_P_CALIB_PA
@@ -1056,26 +1059,7 @@ class AragogRunner:
             entropy=entropy_solid_arg,
         )
 
-        phase_mixed = _PhaseMixedParameters(
-            latent_heat_of_fusion=float(config.interior_energetics.latent_heat_of_fusion),
-            rheological_transition_melt_fraction=config.interior_energetics.rfront_loc,
-            rheological_transition_width=config.interior_energetics.rfront_wid,
-            solidus=solidus_path,
-            liquidus=liquidus_path,
-            phase='mixed',
-            phase_transition_width=float(config.interior_energetics.phase_transition_width),
-            grain_size=config.interior_energetics.grain_size,
-            separation_viscosity=config.interior_energetics.aragog.separation_viscosity,
-            matprop_smooth_width=float(config.interior_energetics.spider.matprop_smooth_width),
-            const_properties=bool(config.interior_energetics.const_properties),
-            const_rho=float(config.interior_energetics.const_rho),
-            const_Cp=float(config.interior_energetics.const_Cp),
-            const_alpha=float(config.interior_energetics.const_alpha),
-            const_cond=float(config.interior_energetics.const_cond),
-            const_log10visc=float(config.interior_energetics.const_log10visc),
-            const_T_ref=float(config.interior_energetics.const_T_ref),
-            const_S_ref=float(config.interior_energetics.const_S_ref),
-        )
+        phase_mixed = build_mixed_phase_params(config, solidus_path, liquidus_path)
 
         radionuclides = []
         if config.interior_energetics.heat_radiogenic:
@@ -1194,7 +1178,7 @@ class AragogRunner:
 
         try:
             import jax.numpy as jnp
-            from aragog.jax.phase import MeshArrays, PhaseParams
+            from aragog.jax.phase import MeshArrays
             from aragog.jax.solver import BoundaryParams
             from aragog.solver.cvode_jax import build_jax_rhs_and_jacobian
             # EntropyEOS_JAX is imported lazily by _cached_entropy_eos_jax.
@@ -1219,31 +1203,7 @@ class AragogRunner:
                     _t_post_jax_eos - _t_pre_jax_eos,
                 )
 
-            ie = config.interior_energetics
-            params_jax = PhaseParams(
-                phi_rheo=ie.rfront_loc,
-                phi_width=ie.rfront_wid,
-                viscosity_solid=10.0 ** float(ie.solid_log10visc),
-                viscosity_liquid=10.0 ** float(ie.melt_log10visc),
-                grain_size=ie.grain_size,
-                k_solid=float(ie.solid_cond),
-                k_liquid=float(ie.melt_cond),
-                matprop_smooth_width=float(ie.spider.matprop_smooth_width),
-                conduction=ie.trans_conduction,
-                convection=ie.trans_convection,
-                grav_sep=ie.trans_grav_sep,
-                mixing=ie.trans_mixing,
-                eddy_diff_thermal=float(ie.eddy_diffusivity_thermal),
-                eddy_diff_chemical=float(ie.eddy_diffusivity_chemical),
-                kappah_floor=float(ie.kappah_floor),
-                bottom_up_grav_sep=True,
-                phase_smoothing=ie.aragog.phase_smoothing,
-                separation_viscosity=ie.aragog.separation_viscosity,
-                # Width matches hardcoded 1e-2 in numpy entropy_state.py
-                # _spider_get_smoothing call sites (not matprop_smooth_width,
-                # which is a separate SPIDER material-property blend).
-                phase_smoothing_width=0.01,
-            )
+            params_jax = build_jax_phase_params(config)
 
             _t_pre_mesh = time.perf_counter()
             mesh_jax = MeshArrays.from_numpy_mesh(solver.evaluator.mesh)

--- a/src/proteus/interior_energetics/aragog_jax.py
+++ b/src/proteus/interior_energetics/aragog_jax.py
@@ -19,6 +19,7 @@ import jax.numpy as jnp
 import netCDF4 as nc
 import numpy as np
 
+from proteus.interior_energetics.aragog_phase import build_jax_phase_params
 from proteus.interior_energetics.common import Interior_t
 
 jax.config.update('jax_enable_x64', True)
@@ -67,7 +68,6 @@ class AragogJAXRunner:
     def _build_jax_components(self, config: Config, interior_o: Interior_t):
         """Build JAX EOS, params, and BCs from the numpy solver."""
         from aragog.jax.eos import EntropyEOS_JAX
-        from aragog.jax.phase import PhaseParams
         from aragog.jax.solver import BoundaryParams
 
         # EOS: load from the same directory as numpy solver
@@ -81,34 +81,7 @@ class AragogJAXRunner:
         interior_o._jax_eos = eos_jax
 
         # Phase parameters from config.
-        # `bottom_up_grav_sep=True` enables the SPIDER-analogue cubic
-        # Hermite Jgrav smoothing (see aragog/jax/phase.py::compute_fluxes
-        # and aragog/solver/entropy_state.py for the scipy path
-        # equivalent). With it off, the JAX path shows a spurious CMB
-        # drain at first crystallisation. There is no PROTEUS config knob
-        # to disable it in production; the flag exists only so regression
-        # tests can exercise the uncorrected behaviour.
-        interior_o._jax_params = PhaseParams(
-            phi_rheo=config.interior_energetics.rfront_loc,
-            phi_width=config.interior_energetics.rfront_wid,
-            viscosity_solid=10.0 ** float(config.interior_energetics.solid_log10visc),
-            viscosity_liquid=10.0 ** float(config.interior_energetics.melt_log10visc),
-            grain_size=config.interior_energetics.grain_size,
-            k_solid=float(config.interior_energetics.solid_cond),
-            k_liquid=float(config.interior_energetics.melt_cond),
-            conduction=config.interior_energetics.trans_conduction,
-            convection=config.interior_energetics.trans_convection,
-            grav_sep=config.interior_energetics.trans_grav_sep,
-            mixing=config.interior_energetics.trans_mixing,
-            eddy_diff_thermal=float(config.interior_energetics.eddy_diffusivity_thermal),
-            eddy_diff_chemical=float(config.interior_energetics.eddy_diffusivity_chemical),
-            kappah_floor=config.interior_energetics.kappah_floor,
-            matprop_smooth_width=float(config.interior_energetics.spider.matprop_smooth_width),
-            bottom_up_grav_sep=True,
-            phase_smoothing=config.interior_energetics.aragog.phase_smoothing,
-            phase_smoothing_width=0.01,
-            separation_viscosity=config.interior_energetics.aragog.separation_viscosity,
-        )
+        interior_o._jax_params = build_jax_phase_params(config)
 
         # Boundary conditions
         bc_cfg = self.aragog_solver.parameters.boundary_conditions

--- a/src/proteus/interior_energetics/aragog_phase.py
+++ b/src/proteus/interior_energetics/aragog_phase.py
@@ -1,0 +1,276 @@
+"""Single source of the aragog phase parameters built from a PROTEUS config.
+
+The aragog interior module builds phase parameters at three call sites:
+
+- the numpy entropy solver's ``_PhaseMixedParameters`` (``aragog.py``);
+- the JAX CVODE factory's ``PhaseParams`` (``aragog.py``);
+- the JAX research runner's ``PhaseParams`` (``aragog_jax.py``).
+
+The numpy and JAX types name their fields differently and the numpy type
+carries constant-property and mush fields the JAX type does not, so each
+site resolves the same config quantities on its own unless a single
+builder feeds them. A field resolved at one site but forgotten at
+another, or cast at one site but not another, drifts silently.
+
+This module resolves every configured quantity once in
+``_phase_params_from_config`` and exposes two thin type-constructors,
+``build_mixed_phase_params`` and ``build_jax_phase_params``. The three
+call sites carry no field list of their own, so a configured field
+reaches every site it applies to or none, and a shared quantity is cast
+in exactly one place.
+
+Notes
+-----
+The module imports only the aragog library types, never a PROTEUS
+module, so ``aragog.py`` and ``aragog_jax.py`` can both import it at top
+without a cycle. ``_PhaseMixedParameters`` is imported at module top;
+``PhaseParams`` is imported lazily inside ``build_jax_phase_params`` so
+that importing this module, and ``aragog.py`` through it, does not
+require the optional JAX stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from aragog.parser import _PhaseMixedParameters
+
+if TYPE_CHECKING:
+    from aragog.jax.phase import PhaseParams
+
+    from proteus.config import Config
+
+# Fixed at both JAX sites, not exposed in the PROTEUS schema. The
+# SPIDER-analogue cubic-Hermite Jgrav smoothing stays on for production;
+# the width matches the hardcoded 1e-2 in the numpy entropy_state
+# smoothing calls.
+_JAX_BOTTOM_UP_GRAV_SEP = True
+_JAX_PHASE_SMOOTHING_WIDTH = 0.01
+
+# Fixed at the numpy site: the mixed-phase evaluator is always built in
+# the 'mixed' phase.
+_MIXED_PHASE = 'mixed'
+
+
+@dataclass(frozen=True)
+class _PhaseParamsInputs:
+    """Configured quantities that feed the aragog phase parameters.
+
+    Every field is resolved and cast once from a PROTEUS config, so the
+    numpy and JAX constructors that consume this object cannot resolve a
+    shared quantity differently.
+
+    Attributes
+    ----------
+    rheological_transition_melt_fraction, rheological_transition_width : float
+        Melt-fraction centre and width of the rheological transition.
+        Shared: numpy ``rheological_transition_*`` and JAX
+        ``phi_rheo`` / ``phi_width``.
+    grain_size : float
+        Grain size. Shared by both types under the same name.
+    matprop_smooth_width : float
+        SPIDER material-property blend width. Shared by both types under
+        the same name.
+    separation_viscosity : str
+        Gravitational-separation drag viscosity source ('melt' or
+        'mixture'). Shared: the numpy type stores the string, the JAX
+        type stores it as the ``separation_viscosity_mixture`` flag.
+    latent_heat_of_fusion, phase_transition_width : float
+        Numpy-only mixed-phase quantities.
+    const_properties : bool
+        Numpy-only constant-properties switch.
+    const_rho, const_Cp, const_alpha, const_cond, const_log10visc, const_T_ref, const_S_ref : float
+        Numpy-only constant-property values.
+    viscosity_solid, viscosity_liquid : float
+        JAX-only solid and liquid viscosities, already raised from the
+        configured base-10 logarithms.
+    k_solid, k_liquid : float
+        JAX-only solid and liquid thermal conductivities.
+    conduction, convection, grav_sep, mixing : bool
+        JAX-only transport-term switches.
+    eddy_diff_thermal, eddy_diff_chemical, kappah_floor : float
+        JAX-only eddy diffusivities and the mixing-length diffusivity
+        floor.
+    phase_smoothing : str
+        JAX-only phase-boundary smoothing selection ('tanh' or
+        'cubic_hermite').
+    """
+
+    # Shared between the numpy and JAX phase parameters.
+    rheological_transition_melt_fraction: float
+    rheological_transition_width: float
+    grain_size: float
+    matprop_smooth_width: float
+    separation_viscosity: str
+
+    # Numpy mixed-phase parameters only.
+    latent_heat_of_fusion: float
+    phase_transition_width: float
+    const_properties: bool
+    const_rho: float
+    const_Cp: float
+    const_alpha: float
+    const_cond: float
+    const_log10visc: float
+    const_T_ref: float
+    const_S_ref: float
+
+    # JAX phase parameters only.
+    viscosity_solid: float
+    viscosity_liquid: float
+    k_solid: float
+    k_liquid: float
+    conduction: bool
+    convection: bool
+    grav_sep: bool
+    mixing: bool
+    eddy_diff_thermal: float
+    eddy_diff_chemical: float
+    kappah_floor: float
+    phase_smoothing: str
+
+
+def _phase_params_from_config(config: Config) -> _PhaseParamsInputs:
+    """Resolve the aragog phase-parameter inputs from a PROTEUS config.
+
+    Parameters
+    ----------
+    config : Config
+        The PROTEUS configuration. Only ``config.interior_energetics``
+        and its nested ``spider`` and ``aragog`` sections are read.
+
+    Returns
+    -------
+    _PhaseParamsInputs
+        The configured quantities, each cast once to the type the
+        aragog constructors expect.
+
+    Notes
+    -----
+    ``kappah_floor`` is cast to ``float`` here so that both JAX sites
+    store an identical value; the numpy site does not consume it.
+    """
+    ie = config.interior_energetics
+    return _PhaseParamsInputs(
+        rheological_transition_melt_fraction=ie.rfront_loc,
+        rheological_transition_width=ie.rfront_wid,
+        grain_size=ie.grain_size,
+        matprop_smooth_width=float(ie.spider.matprop_smooth_width),
+        separation_viscosity=ie.aragog.separation_viscosity,
+        latent_heat_of_fusion=float(ie.latent_heat_of_fusion),
+        phase_transition_width=float(ie.phase_transition_width),
+        const_properties=bool(ie.const_properties),
+        const_rho=float(ie.const_rho),
+        const_Cp=float(ie.const_Cp),
+        const_alpha=float(ie.const_alpha),
+        const_cond=float(ie.const_cond),
+        const_log10visc=float(ie.const_log10visc),
+        const_T_ref=float(ie.const_T_ref),
+        const_S_ref=float(ie.const_S_ref),
+        viscosity_solid=10.0 ** float(ie.solid_log10visc),
+        viscosity_liquid=10.0 ** float(ie.melt_log10visc),
+        k_solid=float(ie.solid_cond),
+        k_liquid=float(ie.melt_cond),
+        conduction=ie.trans_conduction,
+        convection=ie.trans_convection,
+        grav_sep=ie.trans_grav_sep,
+        mixing=ie.trans_mixing,
+        eddy_diff_thermal=float(ie.eddy_diffusivity_thermal),
+        eddy_diff_chemical=float(ie.eddy_diffusivity_chemical),
+        kappah_floor=float(ie.kappah_floor),
+        phase_smoothing=ie.aragog.phase_smoothing,
+    )
+
+
+def build_mixed_phase_params(
+    config: Config, solidus: str, liquidus: str
+) -> _PhaseMixedParameters:
+    """Build the numpy mixed-phase parameters from a PROTEUS config.
+
+    Parameters
+    ----------
+    config : Config
+        The PROTEUS configuration.
+    solidus, liquidus : str
+        Runtime paths to the solidus and liquidus data files, resolved
+        by the caller from the interior lookup directory.
+
+    Returns
+    -------
+    _PhaseMixedParameters
+        The mixed-phase parameters for the numpy entropy solver.
+
+    Notes
+    -----
+    ``cp_blend`` is not passed, so it stays at the aragog library
+    default. This builder is the only construction site of
+    ``_PhaseMixedParameters`` in PROTEUS.
+    """
+    inputs = _phase_params_from_config(config)
+    return _PhaseMixedParameters(
+        latent_heat_of_fusion=inputs.latent_heat_of_fusion,
+        rheological_transition_melt_fraction=inputs.rheological_transition_melt_fraction,
+        rheological_transition_width=inputs.rheological_transition_width,
+        solidus=solidus,
+        liquidus=liquidus,
+        phase=_MIXED_PHASE,
+        phase_transition_width=inputs.phase_transition_width,
+        grain_size=inputs.grain_size,
+        separation_viscosity=inputs.separation_viscosity,
+        matprop_smooth_width=inputs.matprop_smooth_width,
+        const_properties=inputs.const_properties,
+        const_rho=inputs.const_rho,
+        const_Cp=inputs.const_Cp,
+        const_alpha=inputs.const_alpha,
+        const_cond=inputs.const_cond,
+        const_log10visc=inputs.const_log10visc,
+        const_T_ref=inputs.const_T_ref,
+        const_S_ref=inputs.const_S_ref,
+    )
+
+
+def build_jax_phase_params(config: Config) -> PhaseParams:
+    """Build the JAX phase parameters from a PROTEUS config.
+
+    Parameters
+    ----------
+    config : Config
+        The PROTEUS configuration.
+
+    Returns
+    -------
+    PhaseParams
+        The phase parameters for the JAX entropy solver, shared by the
+        CVODE factory and the research runner.
+
+    Notes
+    -----
+    ``PhaseParams`` is imported here rather than at module top so that
+    importing this module does not require the optional JAX stack. This
+    builder is the only construction site of ``PhaseParams`` in PROTEUS.
+    """
+    from aragog.jax.phase import PhaseParams
+
+    inputs = _phase_params_from_config(config)
+    return PhaseParams(
+        phi_rheo=inputs.rheological_transition_melt_fraction,
+        phi_width=inputs.rheological_transition_width,
+        viscosity_solid=inputs.viscosity_solid,
+        viscosity_liquid=inputs.viscosity_liquid,
+        grain_size=inputs.grain_size,
+        k_solid=inputs.k_solid,
+        k_liquid=inputs.k_liquid,
+        matprop_smooth_width=inputs.matprop_smooth_width,
+        conduction=inputs.conduction,
+        convection=inputs.convection,
+        grav_sep=inputs.grav_sep,
+        mixing=inputs.mixing,
+        eddy_diff_thermal=inputs.eddy_diff_thermal,
+        eddy_diff_chemical=inputs.eddy_diff_chemical,
+        kappah_floor=inputs.kappah_floor,
+        bottom_up_grav_sep=_JAX_BOTTOM_UP_GRAV_SEP,
+        phase_smoothing=inputs.phase_smoothing,
+        phase_smoothing_width=_JAX_PHASE_SMOOTHING_WIDTH,
+        separation_viscosity=inputs.separation_viscosity,
+    )

--- a/tests/interior_energetics/test_aragog_phase.py
+++ b/tests/interior_energetics/test_aragog_phase.py
@@ -35,9 +35,13 @@ import pytest
 
 pytest.importorskip('aragog.jax')
 
+from aragog.jax.phase import PhaseParams  # noqa: E402
+
 from proteus.interior_energetics.aragog import AragogRunner  # noqa: E402
 from proteus.interior_energetics.aragog_jax import AragogJAXRunner  # noqa: E402
 from proteus.interior_energetics.aragog_phase import (  # noqa: E402
+    _JAX_BOTTOM_UP_GRAV_SEP,
+    _JAX_PHASE_SMOOTHING_WIDTH,
     _phase_params_from_config,
     build_jax_phase_params,
     build_mixed_phase_params,
@@ -48,30 +52,6 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 # Runtime solidus / liquidus paths the numpy builder stores verbatim.
 _SOLIDUS = '/data/lookup/solidus.dat'
 _LIQUIDUS = '/data/lookup/liquidus.dat'
-
-# The 19 stored attributes of the JAX PhaseParams, used to assert the runner
-# site and the builder agree field by field.
-_JAX_STORED_ATTRS = (
-    'phi_rheo',
-    'phi_width',
-    'log10_visc_solid',
-    'log10_visc_liquid',
-    'grain_size',
-    'k_solid',
-    'k_liquid',
-    'matprop_smooth_width',
-    'conduction',
-    'convection',
-    'grav_sep',
-    'mixing',
-    'eddy_diff_thermal',
-    'eddy_diff_chemical',
-    'kappah_floor',
-    'bottom_up_grav_sep',
-    'phase_smoothing_tanh',
-    'phase_smoothing_width',
-    'separation_viscosity_mixture',
-)
 
 
 def _make_full_config(*, separation_viscosity: str = 'mixture'):
@@ -229,12 +209,25 @@ def test_jax_only_fields_carry_configured_values():
     assertion. The transport switches are configured False, False, True, so
     the stored flags read 0.0, 0.0, 1.0; the smoothing is 'cubic_hermite', so
     ``phase_smoothing_tanh`` reads 0.0. ``bottom_up_grav_sep`` and
-    ``phase_smoothing_width`` are hardcoded builder constants, asserted
-    against their literal expected values so a flipped constant fails here.
+    ``phase_smoothing_width`` are hardcoded builder constants that happen to
+    equal the aragog library defaults, so a value check on the returned
+    object would pass even with the keyword dropped from the constructor
+    call. A spy on ``PhaseParams`` itself captures the exact keyword
+    arguments the builder passes in, so a dropped keyword surfaces as a
+    missing dict key rather than a coincidentally matching default.
     """
     config = _make_full_config()
     ie = config.interior_energetics
-    jax_params = build_jax_phase_params(config)
+
+    real_phase_params = PhaseParams
+    captured_kwargs = []
+
+    def _spy(**kwargs):
+        captured_kwargs.append(kwargs)
+        return real_phase_params(**kwargs)
+
+    with patch('aragog.jax.phase.PhaseParams', side_effect=_spy):
+        jax_params = build_jax_phase_params(config)
 
     assert jax_params.log10_visc_solid == pytest.approx(ie.solid_log10visc)
     assert jax_params.log10_visc_liquid == pytest.approx(ie.melt_log10visc)
@@ -248,8 +241,11 @@ def test_jax_only_fields_carry_configured_values():
     assert float(jax_params.convection) == pytest.approx(0.0)
     assert float(jax_params.grav_sep) == pytest.approx(1.0)
     assert float(jax_params.mixing) == pytest.approx(1.0)
-    assert float(jax_params.bottom_up_grav_sep) == pytest.approx(1.0)
-    assert jax_params.phase_smoothing_width == pytest.approx(0.01)
+
+    assert captured_kwargs, 'PhaseParams was not constructed by the builder'
+    call_kwargs = captured_kwargs[0]
+    assert call_kwargs['bottom_up_grav_sep'] == _JAX_BOTTOM_UP_GRAV_SEP
+    assert call_kwargs['phase_smoothing_width'] == pytest.approx(_JAX_PHASE_SMOOTHING_WIDTH)
 
 
 def test_numpy_only_fields_carry_configured_values():

--- a/tests/interior_energetics/test_aragog_phase.py
+++ b/tests/interior_energetics/test_aragog_phase.py
@@ -24,6 +24,9 @@ See also:
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -32,6 +35,7 @@ import pytest
 
 pytest.importorskip('aragog.jax')
 
+from proteus.interior_energetics.aragog import AragogRunner  # noqa: E402
 from proteus.interior_energetics.aragog_jax import AragogJAXRunner  # noqa: E402
 from proteus.interior_energetics.aragog_phase import (  # noqa: E402
     _phase_params_from_config,
@@ -110,14 +114,18 @@ def _make_full_config(*, separation_viscosity: str = 'mixture'):
     ie.melt_log10visc = 1.7
     ie.solid_cond = 4.3
     ie.melt_cond = 2.9
-    ie.trans_conduction = True
-    ie.trans_convection = True
-    ie.trans_grav_sep = False
+    # The transport switches and the smoothing selection differ from the
+    # aragog PhaseParams defaults (conduction/convection True, grav_sep
+    # False, smoothing 'tanh'), so a dropped kwarg falls back to a value
+    # that mismatches the assertion.
+    ie.trans_conduction = False
+    ie.trans_convection = False
+    ie.trans_grav_sep = True
     ie.trans_mixing = True
     ie.eddy_diffusivity_thermal = 0.13
     ie.eddy_diffusivity_chemical = 0.07
     ie.kappah_floor = 1.0e-6
-    ie.aragog.phase_smoothing = 'tanh'
+    ie.aragog.phase_smoothing = 'cubic_hermite'
     return config
 
 
@@ -215,11 +223,14 @@ def test_jax_only_fields_carry_configured_values():
     mixing-length floor, and the phase-smoothing selection. A field dropped
     at the JAX builder falls back to the library default.
 
-    Discrimination: the config values differ from any plausible library
-    default, so a dropped field surfaces as a value mismatch. ``kappah_floor``
-    is asserted through the single float cast, and ``phase_smoothing='tanh'``
-    is asserted through its 1.0 flag, so a dropped smoothing kwarg (default
-    'cubic_hermite', flag 0.0) fails here.
+    Discrimination: the config values differ from the aragog library
+    defaults (conduction and convection True, grav_sep False, smoothing
+    'tanh'), so a dropped field falls back to a value that mismatches the
+    assertion. The transport switches are configured False, False, True, so
+    the stored flags read 0.0, 0.0, 1.0; the smoothing is 'cubic_hermite', so
+    ``phase_smoothing_tanh`` reads 0.0. ``bottom_up_grav_sep`` and
+    ``phase_smoothing_width`` are hardcoded builder constants, asserted
+    against their literal expected values so a flipped constant fails here.
     """
     config = _make_full_config()
     ie = config.interior_energetics
@@ -232,11 +243,13 @@ def test_jax_only_fields_carry_configured_values():
     assert jax_params.eddy_diff_thermal == pytest.approx(ie.eddy_diffusivity_thermal)
     assert jax_params.eddy_diff_chemical == pytest.approx(ie.eddy_diffusivity_chemical)
     assert jax_params.kappah_floor == pytest.approx(ie.kappah_floor)
-    assert jax_params.phase_smoothing_tanh == pytest.approx(1.0)
-    assert float(jax_params.conduction) == pytest.approx(1.0)
-    assert float(jax_params.convection) == pytest.approx(1.0)
-    assert float(jax_params.grav_sep) == pytest.approx(0.0)
+    assert jax_params.phase_smoothing_tanh == pytest.approx(0.0)
+    assert float(jax_params.conduction) == pytest.approx(0.0)
+    assert float(jax_params.convection) == pytest.approx(0.0)
+    assert float(jax_params.grav_sep) == pytest.approx(1.0)
     assert float(jax_params.mixing) == pytest.approx(1.0)
+    assert float(jax_params.bottom_up_grav_sep) == pytest.approx(1.0)
+    assert jax_params.phase_smoothing_width == pytest.approx(0.01)
 
 
 def test_numpy_only_fields_carry_configured_values():
@@ -283,51 +296,129 @@ def test_kappah_floor_cast_once_is_float():
     builder, the factory cast the floor and the runner did not, so an int
     or numpy-scalar config value could store two different Python types.
 
-    Discrimination: the resolved input is asserted to be exactly a Python
-    float, and to equal the configured value. A resolver that forwarded the
-    raw config attribute would carry the mock's type instead.
+    Discrimination: the config value is a ``numpy.float64``, which is a
+    subclass of ``float``, so an ``isinstance`` check cannot tell a resolver
+    that forwards the raw scalar from one that casts it. The test asserts the
+    resolved input is exactly a Python ``float`` with ``type(...) is float``,
+    so a dropped ``float`` cast, which leaves a ``numpy.float64``, fails here.
     """
     config = _make_full_config()
+    config.interior_energetics.kappah_floor = np.float64(1.0e-6)
     inputs = _phase_params_from_config(config)
 
-    assert isinstance(inputs.kappah_floor, float)
+    assert type(inputs.kappah_floor) is float
     assert inputs.kappah_floor == pytest.approx(config.interior_energetics.kappah_floor)
 
 
-def test_runner_site_uses_the_shared_jax_builder(tmp_path):
-    """The JAX research runner's ``PhaseParams`` equals the builder output
-    field by field, so the runner site cannot drift from the factory site.
+def test_runner_site_delegates_to_the_shared_jax_builder(tmp_path):
+    """The JAX research runner delegates to ``build_jax_phase_params`` and
+    stores the builder's own return object.
 
     Contract: ``AragogJAXRunner._build_jax_components`` sets
     ``interior_o._jax_params = build_jax_phase_params(config)``. This test
     drives the real constructor (with the heavy EOS and mesh construction
-    mocked) and compares the runner-built params against an independent
-    ``build_jax_phase_params(config)`` over all 19 stored attributes.
+    mocked) and spies on the builder at the runner's import site.
 
-    Discrimination: comparing every stored attribute, not just one, means a
-    regression that reintroduced an inline ``PhaseParams(...)`` at the
-    runner and dropped or re-cast any single field fails here. The
-    separation-viscosity flag and the ``kappah_floor`` float are included,
-    the two fields most exposed to a re-cast divergence.
+    Discrimination: a spy wraps the real builder, so the runner still gets a
+    valid ``PhaseParams`` while the test records the call. It asserts the
+    builder is called once with the config object, and that the stored
+    ``interior_o._jax_params`` IS the object the builder returned. A
+    regression that re-inlined ``PhaseParams(...)`` at the runner never calls
+    the patched builder, so the spy stays uncalled and the test fails; value
+    parity alone could not tell an inline constructor from a delegation.
     """
     config = _make_full_config()
     interior_o = _make_runner_interior_o(spider_eos_dir=str(tmp_path))
-    expected = build_jax_phase_params(config)
+
+    # Wrap the real builder so the runner still receives a valid PhaseParams
+    # while the spy records the exact object returned.
+    real_builder = build_jax_phase_params
+    captured = []
+
+    def _spy(cfg):
+        result = real_builder(cfg)
+        captured.append(result)
+        return result
 
     with (
+        patch(
+            'proteus.interior_energetics.aragog_jax.build_jax_phase_params',
+            side_effect=_spy,
+        ) as mock_builder,
         patch('aragog.jax.eos.EntropyEOS_JAX', return_value=MagicMock()),
         patch.object(AragogJAXRunner, '_build_mesh_arrays', return_value=MagicMock()),
     ):
         AragogJAXRunner(config, {'output': str(tmp_path)}, {}, None, interior_o)
 
-    built = interior_o._jax_params
-    # The two fields most exposed to a re-cast divergence, asserted by name.
-    assert built.separation_viscosity_mixture == pytest.approx(
-        expected.separation_viscosity_mixture
-    )
-    assert built.kappah_floor == pytest.approx(expected.kappah_floor)
-    for attr in _JAX_STORED_ATTRS:
-        assert float(getattr(built, attr)) == pytest.approx(float(getattr(expected, attr))), (
-            f'runner-site PhaseParams.{attr}={getattr(built, attr)!r} '
-            f'differs from build_jax_phase_params.{attr}={getattr(expected, attr)!r}'
-        )
+    mock_builder.assert_called_once_with(config)
+    assert captured, 'the shared JAX builder was not called at the runner site'
+    assert interior_o._jax_params is captured[0]
+
+
+def test_cvode_factory_site_delegates_to_the_shared_jax_builder(tmp_path):
+    """The JAX CVODE factory installer resolves its phase parameters through
+    ``build_jax_phase_params``, not an inline ``PhaseParams``.
+
+    Contract: ``AragogRunner._maybe_install_jax_cvode_factory``, active only
+    for backend='jax', calls ``build_jax_phase_params(config)`` to build the
+    factory's phase pytree. This test spies on that builder while the
+    installer runs against a mock solver, with the heavy entropy-EOS load and
+    the mesh conversion patched out.
+
+    Discrimination: the spy asserts the builder is called once with the
+    config object. A regression that re-inlined ``PhaseParams(...)`` at this
+    site never calls the patched builder, so the spy stays uncalled and the
+    test fails; the builder call happens before the mesh conversion, so the
+    patched mesh keeps the installer on its success path.
+    """
+    config = _make_full_config()
+    config.interior_energetics.aragog.backend = 'jax'
+    interior_o = _make_runner_interior_o(spider_eos_dir=str(tmp_path))
+
+    with (
+        patch(
+            'proteus.interior_energetics.aragog._cached_entropy_eos_jax',
+            return_value=MagicMock(),
+        ),
+        patch('aragog.jax.phase.MeshArrays.from_numpy_mesh', return_value=MagicMock()),
+        patch(
+            'proteus.interior_energetics.aragog.build_jax_phase_params',
+            return_value=MagicMock(),
+        ) as mock_builder,
+    ):
+        AragogRunner._maybe_install_jax_cvode_factory(config, interior_o)
+
+    mock_builder.assert_called_once_with(config)
+
+
+def test_numpy_setup_solver_site_delegates_to_the_shared_builder():
+    """The numpy entropy solver builds the mixed-phase parameters through
+    ``build_mixed_phase_params``, never by constructing ``_PhaseMixedParameters``
+    inline.
+
+    Contract: ``AragogRunner.setup_solver`` sets
+    ``phase_mixed = build_mixed_phase_params(config, solidus, liquidus)``.
+    This site loads real EOS tables and a real mesh before that call, so a
+    runtime spy would need a near-complete real config and real data files;
+    the delegation is asserted structurally on the function's own AST instead.
+
+    Discrimination: the test parses ``setup_solver`` and collects every call
+    target. It requires ``build_mixed_phase_params`` among them and forbids
+    ``_PhaseMixedParameters``, so a regression that re-inlined the mixed-phase
+    constructor at this site fails here. The solid and liquid ``_PhaseParameters``
+    constructors are a different type and stay legitimately inline.
+    """
+    source = textwrap.dedent(inspect.getsource(AragogRunner.setup_solver))
+    tree = ast.parse(source)
+
+    call_targets = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                call_targets.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                call_targets.add(func.attr)
+
+    assert 'build_mixed_phase_params' in call_targets
+    assert '_PhaseMixedParameters' not in call_targets

--- a/tests/interior_energetics/test_aragog_phase.py
+++ b/tests/interior_energetics/test_aragog_phase.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for proteus.interior_energetics.aragog_phase: the single builder
+that resolves the aragog phase parameters from a PROTEUS config.
+
+The aragog interior module builds phase parameters at three call sites: the
+numpy entropy solver's ``_PhaseMixedParameters``, the JAX CVODE factory's
+``PhaseParams`` (both in ``aragog.py``), and the JAX research runner's
+``PhaseParams`` (in ``aragog_jax.py``). The numpy and JAX types name their
+fields differently, so a configured quantity resolved at one site but
+forgotten or cast differently at another drifts silently.
+
+``aragog_phase`` resolves every configured quantity once in
+``_phase_params_from_config`` and feeds ``build_mixed_phase_params`` and
+``build_jax_phase_params``. These tests pin the anti-drift contract: the
+five quantities shared by the numpy and JAX types carry the SAME configured
+value at both, and every configured field reaches its site rather than the
+aragog library default, so a dropped or re-cast field at any site surfaces
+as a test failure.
+
+See also:
+- docs/How-to/testing.md
+- tests/interior_energetics/test_aragog_jax.py (the runner-site harness)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip('aragog.jax')
+
+from proteus.interior_energetics.aragog_jax import AragogJAXRunner  # noqa: E402
+from proteus.interior_energetics.aragog_phase import (  # noqa: E402
+    _phase_params_from_config,
+    build_jax_phase_params,
+    build_mixed_phase_params,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+# Runtime solidus / liquidus paths the numpy builder stores verbatim.
+_SOLIDUS = '/data/lookup/solidus.dat'
+_LIQUIDUS = '/data/lookup/liquidus.dat'
+
+# The 19 stored attributes of the JAX PhaseParams, used to assert the runner
+# site and the builder agree field by field.
+_JAX_STORED_ATTRS = (
+    'phi_rheo',
+    'phi_width',
+    'log10_visc_solid',
+    'log10_visc_liquid',
+    'grain_size',
+    'k_solid',
+    'k_liquid',
+    'matprop_smooth_width',
+    'conduction',
+    'convection',
+    'grav_sep',
+    'mixing',
+    'eddy_diff_thermal',
+    'eddy_diff_chemical',
+    'kappah_floor',
+    'bottom_up_grav_sep',
+    'phase_smoothing_tanh',
+    'phase_smoothing_width',
+    'separation_viscosity_mixture',
+)
+
+
+def _make_full_config(*, separation_viscosity: str = 'mixture'):
+    """Build a mock PROTEUS Config with every field the builder reads.
+
+    The values are discriminating and differ from the aragog library
+    defaults, so a field dropped at a call site (falling back to the
+    library default) produces a value mismatch rather than a coincidental
+    pass. Unlike ``test_aragog_jax._make_config``, this also sets the
+    numpy-only mixed-phase and constant-property fields.
+
+    Parameters
+    ----------
+    separation_viscosity : str
+        The gravitational-separation drag viscosity source ('mixture' or
+        'melt'), shared by the numpy and JAX types under different
+        representations.
+    """
+    config = MagicMock()
+    ie = config.interior_energetics
+    # Shared between the numpy and JAX phase parameters.
+    ie.rfront_loc = 0.37
+    ie.rfront_wid = 0.11
+    ie.grain_size = 0.023
+    ie.spider.matprop_smooth_width = 0.017
+    ie.aragog.separation_viscosity = separation_viscosity
+    # Numpy mixed-phase parameters only.
+    ie.latent_heat_of_fusion = 4.1e5
+    ie.phase_transition_width = 0.019
+    ie.const_properties = True
+    ie.const_rho = 4123.0
+    ie.const_Cp = 1234.0
+    ie.const_alpha = 3.3e-5
+    ie.const_cond = 4.7
+    ie.const_log10visc = 2.3
+    ie.const_T_ref = 3456.0
+    ie.const_S_ref = 3021.0
+    # JAX phase parameters only.
+    ie.solid_log10visc = 22.3
+    ie.melt_log10visc = 1.7
+    ie.solid_cond = 4.3
+    ie.melt_cond = 2.9
+    ie.trans_conduction = True
+    ie.trans_convection = True
+    ie.trans_grav_sep = False
+    ie.trans_mixing = True
+    ie.eddy_diffusivity_thermal = 0.13
+    ie.eddy_diffusivity_chemical = 0.07
+    ie.kappah_floor = 1.0e-6
+    ie.aragog.phase_smoothing = 'tanh'
+    return config
+
+
+def _make_runner_interior_o(*, spider_eos_dir: str):
+    """Build a mock Interior_t the AragogJAXRunner constructor inspects.
+
+    Mirrors ``test_aragog_jax._make_interior_o`` for the numpy-solver BC,
+    mesh, and solver attributes read inside ``_build_jax_components``.
+    """
+    interior_o = SimpleNamespace()
+    interior_o._spider_eos_dir = spider_eos_dir
+    interior_o.aragog_solver = MagicMock()
+    bc_cfg = MagicMock()
+    bc_cfg.outer_boundary_condition = 4
+    bc_cfg.outer_boundary_value = 0.0
+    bc_cfg.emissivity = 1.0
+    bc_cfg.equilibrium_temperature = 1500.0
+    bc_cfg.inner_boundary_condition = 3
+    bc_cfg.inner_boundary_value = 0.0
+    bc_cfg.core_heat_capacity = 880.0
+    bc_cfg.tfac_core_avg = 1.147
+    interior_o.aragog_solver.parameters.boundary_conditions = bc_cfg
+    interior_o.aragog_solver.parameters.mesh.core_density = 12000.0
+    interior_o.aragog_solver.parameters.solver.start_time = 0.0
+    interior_o.aragog_solver.parameters.solver.end_time = 1.0
+    interior_o.aragog_solver._S0 = np.linspace(2000.0, 3000.0, 5)
+    return interior_o
+
+
+def test_shared_quantities_match_across_numpy_and_jax():
+    """The five config quantities shared by the numpy and JAX phase types
+    carry the same configured value at both sites.
+
+    Contract: ``rfront_loc``, ``rfront_wid``, ``grain_size``,
+    ``spider.matprop_smooth_width`` and ``aragog.separation_viscosity`` feed
+    both ``_PhaseMixedParameters`` and ``PhaseParams`` under different field
+    names. The single builder must map the same resolved input to both, so
+    the numpy field and the JAX stored attribute reflect one config value.
+
+    Discrimination: the config values differ from the aragog library
+    defaults, so a call site that dropped one of these kwargs would fall
+    back to the library default and mismatch the other site. The numpy
+    ``matprop_smooth_width`` and the JAX ``matprop_smooth_width`` also pin
+    the single float cast: a site that skipped the cast on an already-float
+    value would still match here, and the separate parity check below over
+    the runner site closes the coercion gap.
+    """
+    config = _make_full_config()
+    ie = config.interior_energetics
+    numpy_params = build_mixed_phase_params(config, _SOLIDUS, _LIQUIDUS)
+    jax_params = build_jax_phase_params(config)
+
+    assert numpy_params.rheological_transition_melt_fraction == pytest.approx(ie.rfront_loc)
+    assert jax_params.phi_rheo == pytest.approx(ie.rfront_loc)
+    assert numpy_params.rheological_transition_width == pytest.approx(ie.rfront_wid)
+    assert jax_params.phi_width == pytest.approx(ie.rfront_wid)
+    assert numpy_params.grain_size == pytest.approx(ie.grain_size)
+    assert jax_params.grain_size == pytest.approx(ie.grain_size)
+    assert numpy_params.matprop_smooth_width == pytest.approx(ie.spider.matprop_smooth_width)
+    assert jax_params.matprop_smooth_width == pytest.approx(ie.spider.matprop_smooth_width)
+
+
+@pytest.mark.parametrize(
+    ('separation_viscosity', 'expected_mixture_flag'),
+    [('mixture', 1.0), ('melt', 0.0)],
+)
+def test_separation_viscosity_shared_across_sites(separation_viscosity, expected_mixture_flag):
+    """The separation-viscosity source reaches the numpy string field and
+    the JAX flag from one config value.
+
+    Contract: the numpy type stores ``separation_viscosity`` as the string,
+    the JAX type stores it as the ``separation_viscosity_mixture`` flag
+    (1.0 for 'mixture', 0.0 for 'melt'). The builder feeds both from
+    ``config.interior_energetics.aragog.separation_viscosity``.
+
+    Discrimination: the aragog library default is 'melt', so the 'mixture'
+    case fails at either site if the kwarg is dropped there, while the
+    'melt' case would pass by coincidence. Parametrizing over both values
+    catches a drop at either site regardless of the default.
+    """
+    config = _make_full_config(separation_viscosity=separation_viscosity)
+    numpy_params = build_mixed_phase_params(config, _SOLIDUS, _LIQUIDUS)
+    jax_params = build_jax_phase_params(config)
+
+    assert numpy_params.separation_viscosity == separation_viscosity
+    assert jax_params.separation_viscosity_mixture == pytest.approx(expected_mixture_flag)
+
+
+def test_jax_only_fields_carry_configured_values():
+    """Every JAX-only configured field reaches the JAX ``PhaseParams``
+    stored attribute rather than the aragog library default.
+
+    Contract: the JAX type carries viscosities (as base-10 logarithms),
+    conductivities, the transport switches, the eddy diffusivities, the
+    mixing-length floor, and the phase-smoothing selection. A field dropped
+    at the JAX builder falls back to the library default.
+
+    Discrimination: the config values differ from any plausible library
+    default, so a dropped field surfaces as a value mismatch. ``kappah_floor``
+    is asserted through the single float cast, and ``phase_smoothing='tanh'``
+    is asserted through its 1.0 flag, so a dropped smoothing kwarg (default
+    'cubic_hermite', flag 0.0) fails here.
+    """
+    config = _make_full_config()
+    ie = config.interior_energetics
+    jax_params = build_jax_phase_params(config)
+
+    assert jax_params.log10_visc_solid == pytest.approx(ie.solid_log10visc)
+    assert jax_params.log10_visc_liquid == pytest.approx(ie.melt_log10visc)
+    assert jax_params.k_solid == pytest.approx(ie.solid_cond)
+    assert jax_params.k_liquid == pytest.approx(ie.melt_cond)
+    assert jax_params.eddy_diff_thermal == pytest.approx(ie.eddy_diffusivity_thermal)
+    assert jax_params.eddy_diff_chemical == pytest.approx(ie.eddy_diffusivity_chemical)
+    assert jax_params.kappah_floor == pytest.approx(ie.kappah_floor)
+    assert jax_params.phase_smoothing_tanh == pytest.approx(1.0)
+    assert float(jax_params.conduction) == pytest.approx(1.0)
+    assert float(jax_params.convection) == pytest.approx(1.0)
+    assert float(jax_params.grav_sep) == pytest.approx(0.0)
+    assert float(jax_params.mixing) == pytest.approx(1.0)
+
+
+def test_numpy_only_fields_carry_configured_values():
+    """Every numpy-only configured field reaches the ``_PhaseMixedParameters``
+    field rather than the aragog library default.
+
+    Contract: the numpy type carries the latent heat, the phase-transition
+    width, and the constant-property block. ``cp_blend`` is intentionally
+    NOT wired by PROTEUS, so it must stay at the aragog library default
+    'latent'; wiring it would be an out-of-scope schema change.
+
+    Discrimination: the config values differ from the library defaults, so
+    a dropped field surfaces as a value mismatch. ``cp_blend`` is asserted
+    to equal the library default, so a builder that started forwarding it
+    from a non-existent config field would fail here.
+    """
+    config = _make_full_config()
+    ie = config.interior_energetics
+    numpy_params = build_mixed_phase_params(config, _SOLIDUS, _LIQUIDUS)
+
+    assert numpy_params.latent_heat_of_fusion == pytest.approx(ie.latent_heat_of_fusion)
+    assert numpy_params.phase_transition_width == pytest.approx(ie.phase_transition_width)
+    assert numpy_params.const_properties is True
+    assert numpy_params.const_rho == pytest.approx(ie.const_rho)
+    assert numpy_params.const_Cp == pytest.approx(ie.const_Cp)
+    assert numpy_params.const_alpha == pytest.approx(ie.const_alpha)
+    assert numpy_params.const_cond == pytest.approx(ie.const_cond)
+    assert numpy_params.const_log10visc == pytest.approx(ie.const_log10visc)
+    assert numpy_params.const_T_ref == pytest.approx(ie.const_T_ref)
+    assert numpy_params.const_S_ref == pytest.approx(ie.const_S_ref)
+    assert numpy_params.solidus == _SOLIDUS
+    assert numpy_params.liquidus == _LIQUIDUS
+    assert numpy_params.phase == 'mixed'
+    assert numpy_params.cp_blend == 'latent'
+
+
+def test_kappah_floor_cast_once_is_float():
+    """The mixing-length floor is cast to a Python float once in the shared
+    resolver, so both JAX sites store an identical float.
+
+    Contract: ``_phase_params_from_config`` casts ``kappah_floor`` with
+    ``float`` so the CVODE factory and the research runner, which both call
+    ``build_jax_phase_params``, receive one value. Before the shared
+    builder, the factory cast the floor and the runner did not, so an int
+    or numpy-scalar config value could store two different Python types.
+
+    Discrimination: the resolved input is asserted to be exactly a Python
+    float, and to equal the configured value. A resolver that forwarded the
+    raw config attribute would carry the mock's type instead.
+    """
+    config = _make_full_config()
+    inputs = _phase_params_from_config(config)
+
+    assert isinstance(inputs.kappah_floor, float)
+    assert inputs.kappah_floor == pytest.approx(config.interior_energetics.kappah_floor)
+
+
+def test_runner_site_uses_the_shared_jax_builder(tmp_path):
+    """The JAX research runner's ``PhaseParams`` equals the builder output
+    field by field, so the runner site cannot drift from the factory site.
+
+    Contract: ``AragogJAXRunner._build_jax_components`` sets
+    ``interior_o._jax_params = build_jax_phase_params(config)``. This test
+    drives the real constructor (with the heavy EOS and mesh construction
+    mocked) and compares the runner-built params against an independent
+    ``build_jax_phase_params(config)`` over all 19 stored attributes.
+
+    Discrimination: comparing every stored attribute, not just one, means a
+    regression that reintroduced an inline ``PhaseParams(...)`` at the
+    runner and dropped or re-cast any single field fails here. The
+    separation-viscosity flag and the ``kappah_floor`` float are included,
+    the two fields most exposed to a re-cast divergence.
+    """
+    config = _make_full_config()
+    interior_o = _make_runner_interior_o(spider_eos_dir=str(tmp_path))
+    expected = build_jax_phase_params(config)
+
+    with (
+        patch('aragog.jax.eos.EntropyEOS_JAX', return_value=MagicMock()),
+        patch.object(AragogJAXRunner, '_build_mesh_arrays', return_value=MagicMock()),
+    ):
+        AragogJAXRunner(config, {'output': str(tmp_path)}, {}, None, interior_o)
+
+    built = interior_o._jax_params
+    # The two fields most exposed to a re-cast divergence, asserted by name.
+    assert built.separation_viscosity_mixture == pytest.approx(
+        expected.separation_viscosity_mixture
+    )
+    assert built.kappah_floor == pytest.approx(expected.kappah_floor)
+    for attr in _JAX_STORED_ATTRS:
+        assert float(getattr(built, attr)) == pytest.approx(float(getattr(expected, attr))), (
+            f'runner-site PhaseParams.{attr}={getattr(built, attr)!r} '
+            f'differs from build_jax_phase_params.{attr}={getattr(expected, attr)!r}'
+        )


### PR DESCRIPTION
## Description
The aragog mixed-phase parameters were constructed at three separate call sites: the numpy `_PhaseMixedParameters` in `interior_energetics/aragog.py`, the JAX CVODE factory in the same file, and `_build_jax_components` in `aragog_jax.py`. A phase field added to one site could be forgotten at another, so a configured value could silently reach the numpy path but not the JAX path, or the reverse.

This routes all three sites through one shared builder in `interior_energetics/aragog_phase.py`. A single resolver reads the configured phase fields once, and the numpy and JAX constructors are built from that one source, so a configured field reaches every site or none. The builder also casts `kappah_floor` to a float on both JAX paths, which the research-runner site previously did not do.

Closes #855.

## Validation of changes
A field-by-field parity test in `tests/interior_energetics/test_aragog_phase.py` asserts that each configured phase field reaches the numpy and JAX constructors with the configured value rather than falling back to an aragog library default, so a field dropped at one site fails the test. Where a builder constant equals the library default, the test captures the constructor keyword arguments directly, so a dropped keyword still fails rather than passing on a coincidental default match. Three delegation tests confirm each of the three call sites routes through the shared builder.

The `tests/interior_energetics/` suite passes (498 passed, 7 skipped, the skips tied to SPIDER output availability and unrelated to this change) on macOS with Python 3.12. `ruff check` and `ruff format --check` are clean on the touched files.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
