### PR TITLE
Raise the SOCRATES and AGNI pins for GCC 16 symbol export

### DIFF
--- a/docs/Reference/module_versions.md
+++ b/docs/Reference/module_versions.md
@@ -35,7 +35,7 @@ pinned commit.
 <!-- BEGIN GIT_TABLE -->
 | Module | Role | Pin | Docs |
 |--------|------|-----|------|
-| AGNI | Radiative-convective atmosphere (Julia) | [![AGNI](https://img.shields.io/badge/AGNI-c7ffdf00-green)](https://github.com/nichollsh/AGNI/commit/c7ffdf000a49439fc597eff3f586c2c54caba647){target="_blank" rel="noopener"} | [Docs](https://www.h-nicholls.space/AGNI/) |
+| AGNI | Radiative-convective atmosphere (Julia) | [![AGNI](https://img.shields.io/badge/AGNI-f94940b6-green)](https://github.com/nichollsh/AGNI/commit/f94940b69c740a62aee186e35590f0a5c4f7e605){target="_blank" rel="noopener"} | [Docs](https://www.h-nicholls.space/AGNI/) |
 | SOCRATES | Spectral radiative transfer (Fortran) | [![SOCRATES](https://img.shields.io/badge/SOCRATES-c3296586-green)](https://github.com/FormingWorlds/SOCRATES/commit/c32965865c2c6bb1ba27b94e958a36982d74b0bf){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SOCRATES/) |
 | SPIDER | Interior evolution (C, requires PETSc) | [![SPIDER](https://img.shields.io/badge/SPIDER-c9a3fd43-green)](https://github.com/FormingWorlds/SPIDER/commit/c9a3fd4301c7008291d4f4921506d36b6288f8ca){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SPIDER/) |
 <!-- END GIT_TABLE -->

--- a/docs/Reference/module_versions.md
+++ b/docs/Reference/module_versions.md
@@ -36,7 +36,7 @@ pinned commit.
 | Module | Role | Pin | Docs |
 |--------|------|-----|------|
 | AGNI | Radiative-convective atmosphere (Julia) | [![AGNI](https://img.shields.io/badge/AGNI-c7ffdf00-green)](https://github.com/nichollsh/AGNI/commit/c7ffdf000a49439fc597eff3f586c2c54caba647){target="_blank" rel="noopener"} | [Docs](https://www.h-nicholls.space/AGNI/) |
-| SOCRATES | Spectral radiative transfer (Fortran) | [![SOCRATES](https://img.shields.io/badge/SOCRATES-43b86d4d-green)](https://github.com/FormingWorlds/SOCRATES/commit/43b86d4d46dcb1fa2e94fb24b9246421a03a9acb){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SOCRATES/) |
+| SOCRATES | Spectral radiative transfer (Fortran) | [![SOCRATES](https://img.shields.io/badge/SOCRATES-c3296586-green)](https://github.com/FormingWorlds/SOCRATES/commit/c32965865c2c6bb1ba27b94e958a36982d74b0bf){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SOCRATES/) |
 | SPIDER | Interior evolution (C, requires PETSc) | [![SPIDER](https://img.shields.io/badge/SPIDER-c9a3fd43-green)](https://github.com/FormingWorlds/SPIDER/commit/c9a3fd4301c7008291d4f4921506d36b6288f8ca){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SPIDER/) |
 <!-- END GIT_TABLE -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,7 +284,7 @@ ref = "c7ffdf000a49439fc597eff3f586c2c54caba647"
 # under socrates/ by tools/get_socrates.sh; the build output is what
 # the AGNI / JANUS atmosphere modules link against at runtime.
 url = "https://github.com/FormingWorlds/SOCRATES.git"
-ref = "43b86d4d46dcb1fa2e94fb24b9246421a03a9acb"
+ref = "c32965865c2c6bb1ba27b94e958a36982d74b0bf"
 
 [tool.proteus.modules.spider]
 # Interior thermal evolution module (C, requires PETSc). Cloned and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,7 +277,7 @@ directory = "htmlcov"
 # Tracks nichollsh/AGNI main. Bump after every AGNI release that
 # PROTEUS depends on.
 url = "https://github.com/nichollsh/AGNI.git"
-ref = "c7ffdf000a49439fc597eff3f586c2c54caba647"
+ref = "f94940b69c740a62aee186e35590f0a5c4f7e605"
 
 [tool.proteus.modules.socrates]
 # Spectral radiative transfer library (Fortran). Compiled in-place


### PR DESCRIPTION
## Description

Raises two pins that must move together:

- SOCRATES `43b86d4d` (2603.8) to `c3296586` (2603.10), the current SOCRATES `main`.
- AGNI `c7ffdf00` (1.12.3) to `f94940b6` (1.12.4), the current AGNI `main`.

GCC 16.2 gives a `PRIVATE` Fortran module procedure hidden ELF visibility even where its `bind(C)` label grants external linkage, so `dlsym` cannot resolve it. The generated Julia wrapper modules and `julia/src/SOCRATES_C.f90` each declared their contents private, which left 125 of the 128 `PS_` entry points local in `libSOCRATES_C.so` and stopped AGNI at `PS_create_StrDim`. SOCRATES 2603.10 declares them public (FormingWorlds/SOCRATES#30). The previous pin carried only the earlier fix for `real_kind_bytes` (FormingWorlds/SOCRATES#29), which cleared the precision probe but none of the wrapper or radiative transfer entry points.

The SOCRATES pin cannot move on its own. AGNI compared SOCRATES versions by parsing the whole version string as a float, and 2603.10 is the first SOCRATES release whose minor number reaches two digits, so `"2603.10"` read as 2603.1: below the declared floor of 2603.6, and numerically identical to the real earlier release 2603.1. AGNI reported the library as out of date and setup failed. AGNI 1.12.4 splits the version string and compares major and minor as integers, and raises the floor to 2603.9.

The module version table in `docs/Reference/module_versions.md` is regenerated for both pins, which the `generate_version_badges.py --check` job requires.

No linked issue exists for this.

Bumping the SOCRATES pin invalidates the cached CI SOCRATES build, whose key derives from `[tool.proteus.modules]`.

## Validation of changes

Test configuration: macOS 15 arm64 (Darwin 25.6.0), GCC 16.2.0 (Homebrew), netCDF-Fortran 4.6.4, Julia 1.12.7, Python 3.12.14, both modules checked out at the refs pinned by this branch, SOCRATES cloned fresh and compiled with `./configure && ./build_code` followed by the Julia wrapper build.

**Symbol export, measured with `nm` on `julia/lib/libSOCRATES_C.so`:**

| Build | Exported (`T`) | Local (`t`) |
|---|---|---|
| New pin `c3296586` | 128 | 0 |
| Previous pin `43b86d4d`, same tree and compiler | 3 | 125 |

The second row is a control: only the two wrapper source files were reverted, everything else held fixed. At the previous pin `PS_create_StrDim`, `PS_radiance_calc` and `PS_read_spectrum` are all local, and `PS_real_kind_bytes` is the single exported entry point. Restoring the new pin and rebuilding returns the count to 128 exported and 0 local. The compiler is therefore ruled out as the variable.

**Coupled behaviour**, `pytest tests/integration/test_integration_agni_transparent_limit.py tests/integration/test_integration_agni_greygas_interior.py` with `PROTEUS_CI_NIGHTLY=1`:

| Test | Result |
|---|---|
| `test_transparent_greygas_olr_equals_blackbody_emission` | PASSED |
| `test_transparent_greygas_olr_scales_with_surface_emissivity` | PASSED |
| `test_agni_greygas_dummy_interior_coupling` | PASSED |
| `test_transparent_banded_olr_recovers_blackbody_emission` | FAILED, pre-existing, see below |

All four tests reach `AGNI.atmosphere.setup!`, which allocates `SOCRATES.StrDim()` and so calls `PS_create_StrDim`, the exact symbol that could not be resolved before the fix. Against the previous SOCRATES pin these tests fail at that call. The banded test additionally exercises the full spectral-file path through the SOCRATES two-stream solver, which the grey-gas tests do not touch.

**Unit tier**, `pytest -m "unit and not skip and not slow and not integration" --ignore=tests/examples`: 2987 passed, 41 skipped (optional dependencies absent), 0 failed.

**Lint, structure and docs**: `ruff check src/ tests/` clean, `ruff format --check src/ tests/` reports 343 files already formatted, `bash tools/validate_test_structure.sh` passes, `python tools/generate_version_badges.py --check` reports the table up to date.

## Pre-existing failure in the banded test

`test_transparent_banded_olr_recovers_blackbody_emission` fails, and it fails identically without this change. Running it against the pins currently on `main` (AGNI `c7ffdf00` with a SOCRATES build of the same vintage) produces the same value to the last digit, 287271.5671661585, so neither pin in this pull request moves the result.

The observed outgoing longwave flux sits slightly above the Stefan-Boltzmann limit rather than below it:

| T_surf | Obtained F_olr | sigma T^4 | Excess | Relative |
|---|---|---|---|---|
| 1000 K | 56719.7053 | 56703.7442 | +15.9611 | +2.82e-4 |
| 1500 K | 287271.5672 | 287062.7050 | +208.8622 | +7.28e-4 |

The test tolerance is 5e-4, so 1000 K passes and 1500 K does not. Worth noting for whoever picks this up: the test also asserts `F_olr < sigma T^4` on the grounds that band truncation and midpoint evaluation can only lose flux against the exact integral, and the measured values violate that in the same direction at both temperatures. That points at something other than tolerance calibration.

This is out of scope here. The SOCRATES change cannot be responsible: the diff from the previously pinned SOCRATES to `c3296586` touches only `julia/src` wrapper files, docs and the version file, leaving the radiative transfer core untouched. Integration tests run nightly rather than on pull requests, so this does not gate the checks on this branch.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer, with the one pre-existing failure described above
- [x] I have updated the docs, as appropriate: `docs/Reference/module_versions.md` regenerated
- [ ] I have added tests for these changes, as appropriate: the existing AGNI integration tests already cover the affected path, and the symbol export itself is a property of the SOCRATES build rather than of PROTEUS
- [x] I have checked that all dependencies have been updated, as required
