### PR TITLE
Source the get_* install scripts from one shared shell library

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -353,7 +353,9 @@ runs:
       uses: actions/cache@v5
       with:
         path: socrates/
-        key: socrates-${{ runner.os }}-${{ runner.arch }}-portable-${{ steps.runner-image.outputs.version }}-${{ steps.pins.outputs.socrates_ref }}-${{ hashFiles('tools/get_socrates.sh') }}
+        # Both files: get_socrates.sh sources the shared helpers in
+        # tools/_get_common.sh, so a change there also changes what is built.
+        key: socrates-${{ runner.os }}-${{ runner.arch }}-portable-${{ steps.runner-image.outputs.version }}-${{ steps.pins.outputs.socrates_ref }}-${{ hashFiles('tools/get_socrates.sh', 'tools/_get_common.sh') }}
 
     - name: Build SOCRATES (cache miss)
       if: steps.cache-socrates.outputs.cache-hit != 'true'

--- a/docs/How-to/development_standards.md
+++ b/docs/How-to/development_standards.md
@@ -62,6 +62,32 @@ field sets) are written one entry per line with a trailing comma, grouped by
 module under a header comment, and ordered alphabetically within each group.
 This keeps two independent additions on different lines so they merge cleanly.
 
+**Module install scripts**
+
+The `tools/get_*.sh` scripts share one sourced library, `tools/_get_common.sh`.
+It provides `portable_realpath`, the checkout root (`proteus_root`) and tools
+directory (`proteus_tools_dir`), the `--force` and install-path argument split
+(`get_parse_args`), the dirty-checkout guard (`guard_dirty_checkout`), the
+GitHub SSH probe (`github_use_ssh`), the https-to-SSH URL rewrite
+(`github_ssh_url`), and the pin reader (`resolve_module_pin`).
+
+A new install script starts with the same bootstrap the existing ones use:
+
+```bash
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
+```
+
+Add a helper to the library rather than copying one into a script, and give it
+a parameter for the variation a caller needs: `get_socrates.sh` passes a git
+pathspec to `guard_dirty_checkout` so its regenerable `make/Mk_cmd` does not
+count as local work. The helpers target bash 3.2 and run the same with or
+without `set -euo pipefail`, because the scripts differ on that.
+
 **Editing shared files**
 
 - When adding to the main coupling loop, add a stage function and call it rather

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -1037,6 +1037,29 @@ def test_optional_backends_vulcan_atmodeller_are_extras_not_mandatory():
 
 
 @pytest.mark.unit
+def test_socrates_cache_key_covers_every_file_the_build_reads():
+    """The SOCRATES cache key hashes the install script and its library.
+
+    The key busts on a change to the build so a reworded install does not
+    restore a tree the old one produced. get_socrates.sh sources the
+    shared helpers, so a key naming only the script would restore a stale
+    tree after a change to the SSH probe, the guard, or the pin lookup,
+    and the staleness would be invisible: the restored build simply wins
+    and no step reports a mismatch.
+    """
+    action = (TOOLS_DIR.parent / '.github/actions/setup-proteus/action.yml').read_text(
+        encoding='utf-8'
+    )
+    key_lines = [ln for ln in action.splitlines() if 'key: socrates-' in ln]
+    assert len(key_lines) == 1, key_lines
+
+    hashed = re.search(r'hashFiles\(([^)]*)\)', key_lines[0])
+    assert hashed, key_lines[0]
+    assert 'tools/get_socrates.sh' in hashed.group(1)
+    assert 'tools/_get_common.sh' in hashed.group(1)
+
+
+@pytest.mark.unit
 def test_ci_setup_installs_every_declared_extra():
     """The CI setup action must install extras whose keys exist in pyproject.
 

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -449,6 +449,26 @@ def test_get_parse_args_splits_force_from_the_install_path(argv, expected, stric
 
 
 @pytest.mark.unit
+def test_get_parse_args_leaves_the_callers_variables_alone():
+    """Parsing the arguments does not clobber a caller's own variables.
+
+    The scripts share a namespace with every helper they source, and
+    ``arg`` is an ordinary name for a script to use. A helper that leaked
+    its loop variable would overwrite the caller's value with the last
+    argument, silently and only when arguments are passed.
+    """
+    body = (
+        'arg=keepme\n'
+        'get_parse_args --force some/path\n'
+        'printf \'%s|%s|%s\\n\' "$arg" "$get_force" "$get_install_path"\n'
+    )
+    res = _run_bash(_with_common(body, strict=True))
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == 'keepme|true|some/path'
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ('probe_rc', 'expected'),
     [(1, 'true'), (255, 'false'), (0, 'false')],

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -4,18 +4,35 @@ configuration invariants they depend on.
 
 Reusable shell logic replicated inline from ``tools/get_petsc.sh`` and
 ``tools/get_spider.sh``:
-- ``portable_realpath()``: cross-platform path resolution
 - ERR trap: exit-code and step-name capture
 - Platform detection: PETSC_ARCH assignment
 - Homebrew prefix fallback: architecture-aware default
 - Workpath argument handling: ``$1`` override vs default
 - PETSc library detection: versioned ``.so``, ``.dylib``, missing
 
+``tools/_get_common.sh``, the helper library every ``get_*.sh`` sources, is
+sourced by the cases below rather than copied into them, so they run against
+the shipped text:
+- ``portable_realpath()``: cross-platform path resolution, including a
+  destination that does not exist yet
+- the checkout root and tools directory the library derives from its own
+  location
+- ``get_parse_args``: the ``--force`` switch and the optional install path
+- ``guard_dirty_checkout``: the refusal to delete local work, and the
+  pathspec exclusion ``get_socrates.sh`` passes it
+- ``github_use_ssh`` and ``github_ssh_url``: the SSH probe and URL rewrite
+- ``resolve_module_pin``: a missing pin stops the install
+- the bootstrap in each script, which stops when the library is absent, and
+  the invariant that no script carries a private copy of a helper
+
 Blocks lifted out of the shipped scripts at run time, so that rewording a
 script re-runs its cases against the new text:
-- ``tools/get_aragog.sh``: the dirty-checkout guard shared across ``get_*.sh``
-- ``tools/get_socrates.sh``: the portable-flag rewrite, its post-build flag
-  check, and the conditional AGNI-wrapper rebuild note
+- ``tools/get_socrates.sh``: the install-path resolution, the portable-flag
+  rewrite, its post-build flag check, and the conditional AGNI-wrapper
+  rebuild note
+
+Whole scripts run against stubbed ``git`` and ``ssh``, to pin the clone
+destination and transport each one resolves.
 
 Also pins invariants that live in checked-in configuration and documentation
 rather than in shell, each of which fails silently when its counterpart moves:
@@ -39,26 +56,61 @@ See also:
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / 'tools'
+COMMON_LIB = TOOLS_DIR / '_get_common.sh'
+
 
 # ---------------------------------------------------------------------------
-# Helper: extract portable_realpath function from a script
+# Helpers: run bash against the shipped helper library
 # ---------------------------------------------------------------------------
-def _portable_realpath_fn() -> str:
-    """Return the bash source for ``portable_realpath()``."""
-    return """\
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
-"""
+def _with_common(body: str, strict: bool = False) -> str:
+    """Return a bash snippet that sources the shipped helper library.
+
+    The library is sourced, not copied, so a change to it re-runs through
+    every case below. ``strict`` mirrors the ``get_*`` scripts that enable
+    ``set -euo pipefail``: the helpers must behave the same either way.
+    """
+    prelude = 'set -euo pipefail\n' if strict else ''
+    return f'{prelude}source "{COMMON_LIB}"\n{body}'
+
+
+def _run_bash(snippet: str, *argv: str, **kwargs) -> subprocess.CompletedProcess:
+    """Run ``snippet`` with ``argv`` as its positional parameters."""
+    return subprocess.run(
+        ['bash', '-c', snippet, 'get_test.sh', *argv],
+        capture_output=True,
+        text=True,
+        **kwargs,
+    )
+
+
+def _extract_script_block(script: str, start_marker: str, end_marker: str) -> str:
+    """Return the shipped lines of ``tools/<script>`` between two markers.
+
+    Reading the block from the script under test, rather than copying it
+    here, keeps the cases below running against the text that ships.
+    """
+    lines = (TOOLS_DIR / script).read_text().splitlines()
+    start = next(i for i, ln in enumerate(lines) if start_marker in ln)
+    end = next(i for i, ln in enumerate(lines) if end_marker in ln and i > start)
+    return '\n'.join(lines[start:end])
+
+
+def _write_stub(directory: Path, name: str, body: str) -> Path:
+    """Write an executable stub command into ``directory``."""
+    stub = directory / name
+    stub.write_text(body)
+    stub.chmod(0o755)
+    return stub
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +124,7 @@ def test_portable_realpath_resolves_relative(tmp_path):
     subdir = tmp_path / 'subdir'
     subdir.mkdir()
 
-    snippet = _portable_realpath_fn() + f'\ncd "{tmp_path}"\nportable_realpath ./subdir'
+    snippet = _with_common(f'cd "{tmp_path}"\nportable_realpath ./subdir')
     result = subprocess.run(
         ['bash', '-c', snippet],
         capture_output=True,
@@ -85,13 +137,37 @@ def test_portable_realpath_resolves_relative(tmp_path):
 
 
 @pytest.mark.unit
+def test_portable_realpath_resolves_missing_path(tmp_path):
+    """Resolves a destination that does not exist yet, as an install path.
+
+    BSD realpath (macOS) rejects a missing leaf and GNU realpath a missing
+    parent, so both a missing leaf and a missing nested path are covered.
+    An empty result here is the regression: the caller feeds the value
+    straight to ``git clone``, which then fails on an empty work-tree name.
+    """
+    leaf = tmp_path / 'not-created-yet'
+    nested = tmp_path / 'no' / 'such' / 'tree'
+    snippet = _with_common(f'portable_realpath "{leaf}"\nportable_realpath "{nested}"')
+    result = subprocess.run(['bash', '-c', snippet], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    resolved = result.stdout.split()
+    assert len(resolved) == 2, result.stdout
+    # tmp_path is under a symlinked /var on macOS, so compare against the
+    # resolved parent rather than against the literal input path.
+    real_root = os.path.realpath(tmp_path)
+    assert resolved[0] == os.path.join(real_root, 'not-created-yet')
+    assert resolved[1] == os.path.join(real_root, 'no', 'such', 'tree')
+
+
+@pytest.mark.unit
 def test_portable_realpath_resolves_parent_refs(tmp_path):
     """Resolves ``../`` components to a canonical absolute path."""
     child = tmp_path / 'a' / 'b'
     child.mkdir(parents=True)
 
     # a/b/../ should resolve to a/
-    snippet = _portable_realpath_fn() + f'\nportable_realpath "{child}/.."'
+    snippet = _with_common(f'portable_realpath "{child}/.."')
     result = subprocess.run(
         ['bash', '-c', snippet],
         capture_output=True,
@@ -109,7 +185,7 @@ def test_portable_realpath_resolves_symlink(tmp_path):
     link = tmp_path / 'link_dir'
     link.symlink_to(real)
 
-    snippet = _portable_realpath_fn() + f'\nportable_realpath "{link}"'
+    snippet = _with_common(f'portable_realpath "{link}"')
     result = subprocess.run(
         ['bash', '-c', snippet],
         capture_output=True,
@@ -143,7 +219,7 @@ def test_portable_realpath_python_fallback(tmp_path):
     # even with the restricted PATH (which excludes /bin and /usr/bin).
     bash_abs = subprocess.run(['which', 'bash'], capture_output=True, text=True).stdout.strip()
 
-    snippet = _portable_realpath_fn() + f'\nportable_realpath "{target}"'
+    snippet = _with_common(f'portable_realpath "{target}"')
     env = {**os.environ, 'PATH': str(safe_bin)}
 
     result = subprocess.run(
@@ -156,6 +232,329 @@ def test_portable_realpath_python_fallback(tmp_path):
     resolved = result.stdout.strip()
     assert os.path.isabs(resolved)
     assert resolved == str(target)
+
+
+# ---------------------------------------------------------------------------
+# One shipped copy of the shared helpers (tools/_get_common.sh)
+# ---------------------------------------------------------------------------
+
+# A private copy of a shared helper is recognised by the text that used to
+# be duplicated: the function header, the dirty test, and the SSH probe.
+PRIVATE_HELPER_SIGNATURES = (
+    ('portable_realpath() {', 'portable_realpath'),
+    ('status --porcelain --untracked-files=no', 'the dirty-checkout guard'),
+    ('-T git@github.com', 'the GitHub SSH probe'),
+)
+
+# Names a script can only use because the library defines or sets them.
+LIBRARY_NAMES = (
+    'portable_realpath',
+    'get_parse_args',
+    'guard_dirty_checkout',
+    'github_use_ssh',
+    'github_ssh_url',
+    'resolve_module_pin',
+    'proteus_root',
+    'proteus_tools_dir',
+)
+
+
+def _get_scripts() -> list[Path]:
+    """Return the shipped ``tools/get_*.sh`` scripts."""
+    return sorted(TOOLS_DIR.glob('get_*.sh'))
+
+
+@pytest.mark.unit
+def test_no_get_script_carries_a_private_helper_copy():
+    """Each shared helper is defined once, in the library.
+
+    Nine scripts once carried their own ``portable_realpath``, and a fix to
+    one copy left the other eight broken. A script that grows a private
+    copy again is also outside the reach of the cases in this file, which
+    read the library rather than the scripts.
+    """
+    scripts = _get_scripts()
+    # Guard the guard: a mis-rooted glob would make the scan vacuous.
+    assert len(scripts) >= 10, [s.name for s in scripts]
+
+    offenders: dict[str, list[str]] = {}
+    for script in scripts:
+        for line in script.read_text().splitlines():
+            stripped = line.strip()
+            # Prose and user-facing messages may still name the commands.
+            if stripped.startswith('#') or 'echo ' in stripped:
+                continue
+            for needle, label in PRIVATE_HELPER_SIGNATURES:
+                if needle in stripped:
+                    offenders.setdefault(script.name, []).append(label)
+    assert offenders == {}, offenders
+
+
+@pytest.mark.unit
+def test_every_helper_user_sources_the_library():
+    """A script calling a shared helper also sources the file defining it.
+
+    Without the source line the helper name is unset, and under a shell
+    without ``set -u`` the call is a silent no-op rather than an error.
+    """
+    users, missing = [], []
+    for script in _get_scripts():
+        text = script.read_text()
+        if not any(name in text for name in LIBRARY_NAMES):
+            continue
+        users.append(script.name)
+        if 'source "$_get_common"' not in text:
+            missing.append(script.name)
+
+    assert missing == [], missing
+    # Guard the guard: a renamed helper would leave nothing to check.
+    assert len(users) >= 10, users
+
+
+@pytest.mark.unit
+def test_a_missing_helper_library_stops_the_script(tmp_path):
+    """A script whose library is absent stops before touching a checkout.
+
+    Continuing would leave every helper call undefined and reach git with
+    an empty destination, so the bootstrap names the missing file, exits
+    non-zero, and runs no git command.
+    """
+    lone_tools = tmp_path / 'tools'
+    lone_tools.mkdir()
+    shutil.copy2(TOOLS_DIR / 'get_aragog.sh', lone_tools / 'get_aragog.sh')
+    log = tmp_path / 'calls.log'
+    log.write_text('')
+    stubs = tmp_path / 'stubs'
+    stubs.mkdir()
+    _write_stub(stubs, 'git', '#!/bin/bash\necho "git $*" >> "$STUB_LOG"\nexit 0\n')
+
+    res = subprocess.run(
+        ['bash', str(lone_tools / 'get_aragog.sh')],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            'PATH': f'{stubs}:{os.environ["PATH"]}',
+            'STUB_LOG': str(log),
+        },
+    )
+
+    assert res.returncode == 1, res.stdout
+    assert '_get_common.sh' in res.stderr
+    assert log.read_text() == ''
+
+
+@pytest.mark.unit
+def test_library_derives_the_root_from_its_own_location(tmp_path):
+    """The checkout root follows the library, not the caller's directory.
+
+    ``proteus install-all`` runs the scripts through data.py without
+    setting a working directory, so a root taken from the CWD would
+    install into whichever tree the caller happened to be sitting in.
+    """
+    fake_tools = tmp_path / 'FakeProteus' / 'tools'
+    fake_tools.mkdir(parents=True)
+    shutil.copy2(COMMON_LIB, fake_tools / '_get_common.sh')
+    elsewhere = tmp_path / 'elsewhere'
+    elsewhere.mkdir()
+
+    snippet = (
+        f'source "{fake_tools}/_get_common.sh"\necho "$proteus_root"\necho "$proteus_tools_dir"'
+    )
+    res = subprocess.run(['bash', '-c', snippet], cwd=elsewhere, capture_output=True, text=True)
+
+    assert res.returncode == 0, res.stderr
+    root, tools = res.stdout.split()
+    assert root == os.path.realpath(tmp_path / 'FakeProteus')
+    assert tools == os.path.realpath(fake_tools)
+    # The caller's directory must not leak into either value.
+    assert os.path.realpath(elsewhere) not in (root, tools)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('strict', [False, True], ids=['plain shell', 'errexit shell'])
+@pytest.mark.parametrize(
+    ('argv', 'expected'),
+    [
+        ([], 'false|'),
+        (['--force'], 'true|'),
+        (['some/path'], 'false|some/path'),
+        (['--force', 'some/path'], 'true|some/path'),
+        (['some/path', '--force'], 'true|some/path'),
+        (['first/path', 'second/path'], 'false|first/path'),
+    ],
+    ids=[
+        'no arguments',
+        'force only',
+        'path only',
+        'force before path',
+        'force after path',
+        'second path ignored',
+    ],
+)
+def test_get_parse_args_splits_force_from_the_install_path(argv, expected, strict):
+    """The switch and the optional path are read in either order.
+
+    Six scripts pass only ``--force`` and two also accept a destination, so
+    a path must not be mistaken for the switch or the other way round. The
+    empty argument list is the edge case: under ``set -u`` an unguarded
+    ``"$@"`` would abort the script before the first helper ran.
+    """
+    body = 'get_parse_args "$@"\nprintf \'%s|%s\\n\' "$get_force" "$get_install_path"\n'
+    res = _run_bash(_with_common(body, strict=strict), *argv)
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ('probe_rc', 'expected'),
+    [(1, 'true'), (255, 'false'), (0, 'false')],
+    ids=['key accepted', 'key refused', 'shell opened'],
+)
+@pytest.mark.parametrize('strict', [False, True], ids=['plain shell', 'errexit shell'])
+def test_github_use_ssh_reads_the_probe_exit_code(tmp_path, probe_rc, expected, strict):
+    """Only exit code 1 means GitHub accepted the key.
+
+    GitHub refuses the interactive shell that ``ssh -T`` asks for, so a
+    working key exits 1 and a rejected one exits 255. Exit code 0 means
+    something other than GitHub answered, which must not select SSH. The
+    stub also prints a banner on stdout, as the real probe may: that text
+    must not reach the answer, which the caller reads by command
+    substitution.
+    """
+    stubs = tmp_path / 'stubs'
+    stubs.mkdir()
+    _write_stub(
+        stubs,
+        'ssh',
+        f'#!/bin/bash\necho "Hi there! You have successfully authenticated."\nexit {probe_rc}\n',
+    )
+
+    body = 'answer=$(github_use_ssh)\necho "[$answer]"\n'
+    env = {**os.environ, 'PATH': f'{stubs}:{os.environ["PATH"]}'}
+    env.pop('GIT_SSH_COMMAND', None)
+    res = _run_bash(_with_common(body, strict=strict), env=env)
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == f'[{expected}]'
+    # The banner is still shown to the user, on stderr.
+    assert 'successfully authenticated' in res.stderr
+
+
+@pytest.mark.unit
+def test_github_use_ssh_honours_git_ssh_command(tmp_path):
+    """GIT_SSH_COMMAND replaces the probe command, options included.
+
+    CI sets it to a non-interactive, fast-failing ssh invocation; a probe
+    that ignored it would hang on a host-key prompt instead.
+    """
+    stubs = tmp_path / 'stubs'
+    stubs.mkdir()
+    log = tmp_path / 'calls.log'
+    _write_stub(
+        stubs,
+        'stub-ssh',
+        '#!/bin/bash\necho "stub-ssh $*" > "$STUB_LOG"\nexit 1\n',
+    )
+
+    body = 'answer=$(github_use_ssh)\necho "[$answer]"\n'
+    res = _run_bash(
+        _with_common(body),
+        env={
+            **os.environ,
+            'PATH': f'{stubs}:{os.environ["PATH"]}',
+            'STUB_LOG': str(log),
+            'GIT_SSH_COMMAND': 'stub-ssh -o BatchMode=yes',
+        },
+    )
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == '[true]'
+    assert log.read_text().strip() == 'stub-ssh -o BatchMode=yes -T git@github.com'
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ('url', 'expected'),
+    [
+        (
+            'https://github.com/FormingWorlds/PROTEUS.git',
+            'git@github.com:FormingWorlds/PROTEUS.git',
+        ),
+        (
+            'git@github.com:FormingWorlds/PROTEUS.git',
+            'git@github.com:FormingWorlds/PROTEUS.git',
+        ),
+        ('https://gitlab.com/group/repo.git', 'https://gitlab.com/group/repo.git'),
+    ],
+    ids=['https github', 'already ssh', 'other host'],
+)
+def test_github_ssh_url_rewrites_only_github_https(url, expected):
+    """Only an https github.com URL is rewritten for SSH transport.
+
+    A pin that already names SSH, or a repository hosted elsewhere, must
+    pass through unchanged; rewriting either one produces a URL git cannot
+    resolve.
+    """
+    res = _run_bash(_with_common(f'github_ssh_url "{url}"'))
+
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == expected
+
+
+@pytest.mark.unit
+def test_resolve_module_pin_reads_the_pin_and_stops_when_it_is_missing(tmp_path):
+    """A pinned module resolves; an unpinned one stops the install.
+
+    The url and ref go straight into ``git clone`` and ``git checkout``, so
+    an empty pin would otherwise clone the default branch of nothing.
+    """
+    fake_tools = tmp_path / 'tools'
+    fake_tools.mkdir()
+    shutil.copy2(COMMON_LIB, fake_tools / '_get_common.sh')
+    (fake_tools / '_module_pins.py').write_text('')
+    stubs = tmp_path / 'stubs'
+    stubs.mkdir()
+    _write_stub(
+        stubs,
+        'python',
+        '#!/bin/bash\n'
+        'if [ "$2" = "pinned" ]; then\n'
+        '    if [ "$3" = "url" ]; then\n'
+        '        echo "https://github.com/FormingWorlds/Thing.git"\n'
+        '    else\n'
+        '        echo "v1.2.3"\n'
+        '    fi\n'
+        'fi\n'
+        'exit 0\n',
+    )
+    env = {**os.environ, 'PATH': f'{stubs}:{os.environ["PATH"]}'}
+    prelude = f'source "{fake_tools}/_get_common.sh"\n'
+
+    good = subprocess.run(
+        [
+            'bash',
+            '-c',
+            prelude + 'resolve_module_pin pinned\necho "$module_url @ $module_ref"\n',
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert good.returncode == 0, good.stderr
+    assert good.stdout.strip() == 'https://github.com/FormingWorlds/Thing.git @ v1.2.3'
+
+    missing = subprocess.run(
+        ['bash', '-c', prelude + 'resolve_module_pin absent\necho REACHED_CLONE\n'],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert missing.returncode == 1, missing.stdout
+    assert 'could not resolve absent url/ref' in missing.stderr
+    assert 'REACHED_CLONE' not in missing.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -344,59 +743,44 @@ echo "$brew_prefix"
 # ---------------------------------------------------------------------------
 
 
+def _petsc_workpath_block() -> str:
+    """Return the shipped install-path resolution of tools/get_petsc.sh."""
+    block = _extract_script_block(
+        'get_petsc.sh', '# Default: ./petsc/ relative', 'export PETSC_DIR'
+    )
+    return _with_common(block + '\necho "$workpath"\n')
+
+
 @pytest.mark.unit
 def test_petsc_workpath_uses_first_argument(tmp_path):
-    """When ``$1`` is set, ``workpath`` is derived from ``$1``."""
+    """A destination passed as ``$1`` becomes the resolved install path.
+
+    data.py:get_petsc() passes the full path, so the argument must win over
+    the ``./petsc/`` default and must come back absolute: PETSC_DIR is
+    exported from it and read by SPIDER's Makefile from another directory.
+    """
     custom = tmp_path / 'custom_petsc'
 
-    snippet = (
-        _portable_realpath_fn()
-        + """\
-if [[ -n "$1" ]]; then
-    mkdir -p "$1"
-    workpath=$(portable_realpath "$1")
-else
-    mkdir -p petsc
-    workpath=$(portable_realpath petsc)
-fi
-echo "$workpath"
-"""
-    )
-    result = subprocess.run(
-        ['bash', '-c', snippet, '--', str(custom)],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
+    result = _run_bash(_petsc_workpath_block(), str(custom))
+
+    assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(custom)
     assert custom.is_dir()
 
 
 @pytest.mark.unit
 def test_petsc_workpath_defaults_to_petsc(tmp_path):
-    """When ``$1`` is empty, ``workpath`` defaults to ``./petsc/``."""
-    snippet = (
-        _portable_realpath_fn()
-        + """\
-if [[ -n "$1" ]]; then
-    mkdir -p "$1"
-    workpath=$(portable_realpath "$1")
-else
-    mkdir -p petsc
-    workpath=$(portable_realpath petsc)
-fi
-echo "$workpath"
-"""
-    )
-    result = subprocess.run(
-        ['bash', '-c', snippet],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
-    assert result.returncode == 0
+    """With no argument the install path is ``./petsc/`` under the CWD.
+
+    This is the documented no-argument install, and the empty argument list
+    is the edge case the ``$1`` test must not mistake for a path.
+    """
+    result = _run_bash(_petsc_workpath_block(), cwd=str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
     resolved = result.stdout.strip()
     assert resolved.endswith('/petsc')
+    assert resolved == os.path.join(os.path.realpath(tmp_path), 'petsc')
     assert (tmp_path / 'petsc').is_dir()
 
 
@@ -693,31 +1077,23 @@ def test_ci_setup_installs_every_declared_extra():
 
 
 # ---------------------------------------------------------------------------
-# Dirty-checkout guard (shared shape across tools/get_*.sh)
+# Dirty-checkout guard (tools/_get_common.sh, called by every get_*.sh)
 # ---------------------------------------------------------------------------
 
 
-def _extract_guard_block() -> str:
-    """Extract the shipped dirty-checkout guard from tools/get_aragog.sh.
+def _run_guard(tmp_path, *args: str, pathspec: str = '') -> subprocess.CompletedProcess:
+    """Run the shipped guard against the ``aragog`` checkout in ``tmp_path``.
 
-    Reading the block from the script under test (rather than copying it
-    into the test) pins the exact shipped lines: any rewording or logic
-    change in the guard re-runs through these cases.
+    ``pathspec`` appends a git pathspec, as ``get_socrates.sh`` does for its
+    regenerable build config.
     """
-    from pathlib import Path
-
-    tools_dir = Path(__file__).resolve().parents[2] / 'tools'
-    script = (tools_dir / 'get_aragog.sh').read_text().splitlines()
-    start = next(i for i, ln in enumerate(script) if 'Refuse to delete a checkout' in ln)
-    end = next(i for i, ln in enumerate(script) if ln.startswith('rm -rf'))
-    return '\n'.join(script[start:end])
-
-
-def _run_guard(tmp_path, *args: str) -> subprocess.CompletedProcess:
-    """Run the extracted guard with ``root`` pointing at ``tmp_path``."""
-    snippet = 'root="$GUARD_ROOT"\n' + _extract_guard_block() + '\necho GUARD_PASSED\n'
+    body = (
+        'get_parse_args "$@"\n'
+        f'guard_dirty_checkout "$GUARD_ROOT/aragog" get_aragog.sh {pathspec}\n'
+        'echo GUARD_PASSED\n'
+    )
     return subprocess.run(
-        ['bash', '-c', snippet, 'guard', *args],
+        ['bash', '-c', _with_common(body), 'guard', *args],
         capture_output=True,
         text=True,
         env={**os.environ, 'GUARD_ROOT': str(tmp_path)},
@@ -800,6 +1176,45 @@ def test_guard_passes_clean_remote_backed_checkout(tmp_path):
     res = _run_guard(tmp_path, '--force')
     assert res.returncode == 0
     assert 'GUARD_PASSED' in res.stdout
+
+
+def test_guard_excludes_only_the_pathspec_the_caller_names(tmp_path):
+    """An excluded path does not block the refresh, but its neighbours do.
+
+    get_socrates.sh excludes make/Mk_cmd because configure rewrites it on
+    every build, so treating it as user work would block every refresh.
+    Without the exclusion the same modification must still block, which is
+    what makes the exclusion the reason the refresh proceeds rather than a
+    guard that stopped looking.
+    """
+    upstream = tmp_path / 'upstream'
+    (upstream / 'make').mkdir(parents=True)
+    _git(upstream, 'init', '-q')
+    (upstream / 'make' / 'Mk_cmd').write_text('FORTCOMP = gfortran\n')
+    (upstream / 'src.f90').write_text('end\n')
+    _git(upstream, 'add', '.')
+    _git(upstream, 'commit', '-q', '-m', 'c1')
+
+    workdir = tmp_path / 'aragog'
+    _git(tmp_path, 'clone', '-q', str(upstream), str(workdir))
+    exclude = "-- ':(exclude)make/Mk_cmd'"
+
+    # Regenerated build config only: the exclusion lets the refresh run.
+    (workdir / 'make' / 'Mk_cmd').write_text('FORTCOMP = gfortran -Ofast\n')
+    res = _run_guard(tmp_path, pathspec=exclude)
+    assert res.returncode == 0, res.stderr
+    assert 'GUARD_PASSED' in res.stdout
+
+    # The same state without the exclusion blocks: the guard still looks.
+    res = _run_guard(tmp_path)
+    assert res.returncode == 1
+    assert 'uncommitted changes' in res.stderr
+
+    # A modification outside the excluded path blocks either way.
+    (workdir / 'src.f90').write_text('stop\n')
+    res = _run_guard(tmp_path, pathspec=exclude)
+    assert res.returncode == 1
+    assert 'GUARD_PASSED' not in res.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -1017,6 +1432,234 @@ def test_post_build_guard_rejects_cpu_specific_template_flags(tmp_path):
         assert res.returncode == 1, f'{flags} not rejected'
         assert 'non-portable' in res.stderr
         assert 'GUARD_OK' not in res.stdout
+
+
+# ---------------------------------------------------------------------------
+# Install-path resolution (tools/get_socrates.sh)
+# ---------------------------------------------------------------------------
+
+
+def _run_install_path_block(root, argv, stub_resolver: str = '') -> subprocess.CompletedProcess:
+    """Run the shipped argument split and install-path resolution.
+
+    ``stub_resolver`` redefines ``portable_realpath`` after the library is
+    sourced, so the empty-resolution branch can be reached without an
+    unusable host.
+    """
+    block = _extract_script_block(
+        'get_socrates.sh', '# Separate the --force flag', '# make/Mk_cmd is excluded'
+    )
+    body = f'set -u\nroot="{root}"\n' + stub_resolver + block + '\necho "SOCPATH=$socpath"\n'
+    return _run_bash(_with_common(body), *argv)
+
+
+@pytest.mark.unit
+def test_install_path_resolves_before_the_checkout_exists(tmp_path):
+    """A custom destination that does not exist yet resolves to a real path.
+
+    git clone creates the destination, including its parents, so the script
+    must not require the directory up front. An empty resolution is the
+    failure this pins: git clone then reports an empty work-tree name.
+    """
+    dest = tmp_path / 'no' / 'socrates-here'
+    res = _run_install_path_block(tmp_path / 'root', [str(dest)])
+
+    assert res.returncode == 0, res.stderr
+    socpath = res.stdout.strip().removeprefix('SOCPATH=')
+    assert socpath, res.stderr
+    assert socpath == os.path.join(os.path.realpath(tmp_path), 'no', 'socrates-here')
+
+
+@pytest.mark.unit
+def test_install_path_default_and_force_flag(tmp_path):
+    """--force alone keeps the default destination; a path with it is honoured.
+
+    The flag and the optional positional share one argument list, so the
+    ordering of the two must not shift which value lands in socpath.
+    """
+    root = tmp_path / 'root'
+    dest = tmp_path / 'elsewhere'
+
+    default = _run_install_path_block(root, ['--force'])
+    assert default.returncode == 0, default.stderr
+    assert default.stdout.strip() == f'SOCPATH={root}/socrates'
+
+    override = _run_install_path_block(root, ['--force', str(dest)])
+    assert override.returncode == 0, override.stderr
+    assert override.stdout.strip() == f'SOCPATH={os.path.realpath(tmp_path)}/elsewhere'
+
+
+@pytest.mark.unit
+def test_install_path_rejects_unresolvable_path(tmp_path):
+    """An empty resolution stops the script instead of reaching git clone.
+
+    set -euo pipefail is enabled further down the script, so a resolver that
+    fails here would otherwise leave socpath empty and continue.
+    """
+    stub = 'portable_realpath() {\n    return 1\n}\n'
+    res = _run_install_path_block(tmp_path / 'root', ['some/path'], stub_resolver=stub)
+
+    assert res.returncode == 1, res.stdout
+    assert 'could not resolve install path' in res.stderr
+    assert 'some/path' in res.stderr
+    assert 'SOCPATH=' not in res.stdout
+
+
+# ---------------------------------------------------------------------------
+# Clone destination and transport, whole scripts against stubbed git and ssh
+# ---------------------------------------------------------------------------
+
+# The commands the scripts probe for before they clone. Stubbing them keeps
+# the run independent of what the host has installed.
+_INSTALL_STUB_COMMANDS = (
+    'pip',
+    'make',
+    'julia',
+    'clang',
+    'gfortran',
+    'nc-config',
+    'nf-config',
+    'mpicc',
+)
+
+# script, arguments, expected destination, expected clone URL, ssh probe exit.
+# The pinned URLs are the ones tools/_module_pins.py resolves today for the
+# scripts that read a pin; moving a pin updates this table with it.
+CLONE_CASES = (
+    ('get_aragog.sh', (), '{root}/aragog/', 'git@github.com:FormingWorlds/aragog.git', 1),
+    ('get_zalmoxis.sh', (), '{root}/Zalmoxis/', 'git@github.com:FormingWorlds/Zalmoxis.git', 1),
+    ('get_boreas.sh', (), '{root}/BOREAS/', 'git@github.com:ExoInteriors/BOREAS.git', 1),
+    ('get_lavatmos.sh', (), '{root}/LavAtmos/', 'git@github.com:FormingWorlds/LavAtmos', 1),
+    (
+        'get_thermoenginelite.sh',
+        (),
+        '{root}/ThermoEngineLite/',
+        'git@github.com:FormingWorlds/ThermoEngineLite',
+        1,
+    ),
+    ('get_vulcan.sh', (), '{root}/VULCAN/', 'git@github.com:FormingWorlds/VULCAN.git', 1),
+    ('get_socrates.sh', (), '{root}/socrates', 'git@github.com:FormingWorlds/SOCRATES.git', 1),
+    (
+        'get_socrates.sh',
+        ('{root}/custom/socrates',),
+        '{root}/custom/socrates',
+        'git@github.com:FormingWorlds/SOCRATES.git',
+        1,
+    ),
+    ('get_agni.sh', (), '{root}/AGNI', 'https://github.com/nichollsh/AGNI.git', 1),
+    (
+        'get_spider.sh',
+        ('{root}/custom/SPIDER',),
+        '{root}/custom/SPIDER',
+        'https://github.com/FormingWorlds/SPIDER.git',
+        1,
+    ),
+    # SSH refused: the same destination, over https.
+    ('get_aragog.sh', (), '{root}/aragog/', 'https://github.com/FormingWorlds/aragog.git', 255),
+    ('get_boreas.sh', (), '{root}/BOREAS/', 'https://github.com/ExoInteriors/BOREAS.git', 255),
+)
+
+CLONE_IDS = (
+    'aragog over ssh',
+    'zalmoxis over ssh',
+    'boreas over ssh',
+    'lavatmos over ssh',
+    'thermoenginelite over ssh',
+    'vulcan over ssh',
+    'socrates default path',
+    'socrates custom path',
+    'agni pinned url',
+    'spider custom path',
+    'aragog without ssh',
+    'boreas without ssh',
+)
+
+
+def _fake_checkout(tmp_path) -> Path:
+    """Build a throwaway PROTEUS root holding the shipped install scripts.
+
+    Only the scripts, the helper library, the pin reader and pyproject.toml
+    are copied, so a run cannot reach into the real checkout.
+    """
+    root = tmp_path / 'PROTEUS'
+    tools = root / 'tools'
+    tools.mkdir(parents=True)
+    for src in [*TOOLS_DIR.glob('get_*.sh'), COMMON_LIB, TOOLS_DIR / '_module_pins.py']:
+        shutil.copy2(src, tools / src.name)
+    shutil.copy2(TOOLS_DIR.parent / 'pyproject.toml', root / 'pyproject.toml')
+
+    # SPIDER validates a built PETSc before it clones.
+    conf = root / 'petsc' / 'lib' / 'petsc' / 'conf'
+    conf.mkdir(parents=True)
+    (conf / 'variables').write_text('')
+    (conf / 'rules').write_text('')
+    for arch in ('arch-linux-c-opt', 'arch-darwin-c-opt'):
+        lib = root / 'petsc' / arch / 'lib'
+        lib.mkdir(parents=True)
+        (lib / 'libpetsc.dylib').write_text('')
+        (lib / 'libpetsc.so').write_text('')
+    return root
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ('script', 'argv', 'dest', 'url', 'probe_rc'), CLONE_CASES, ids=CLONE_IDS
+)
+def test_script_clones_the_expected_destination(tmp_path, script, argv, dest, url, probe_rc):
+    """Each script resolves its destination and clones the pinned URL.
+
+    Run whole against a stubbed git and ssh, in a throwaway checkout: the
+    destination the script computes and the transport it selects are the
+    two values a refactor of the shared helpers can silently change, and an
+    empty or CWD-relative destination is what a broken path resolution
+    produces. The steps after the clone need real trees, so the exit status
+    is not the contract here; the recorded git call is.
+    """
+    root = _fake_checkout(tmp_path)
+    real_root = os.path.realpath(root)
+    stubs = tmp_path / 'stubs'
+    stubs.mkdir()
+    log = tmp_path / 'calls.log'
+    log.write_text('')
+
+    _write_stub(
+        stubs,
+        'git',
+        '#!/bin/bash\n'
+        'echo "git $*" >> "$STUB_LOG"\n'
+        'if [ "$1" = "clone" ]; then\n'
+        '    mkdir -p "${@: -1}/.git"\n'
+        'fi\n'
+        'exit 0\n',
+    )
+    _write_stub(stubs, 'ssh', f'#!/bin/bash\nexit {probe_rc}\n')
+    for command in _INSTALL_STUB_COMMANDS:
+        _write_stub(stubs, command, '#!/bin/bash\nexit 0\n')
+
+    env = {
+        **os.environ,
+        'PATH': f'{stubs}:{os.environ["PATH"]}',
+        'STUB_LOG': str(log),
+        # Both are read before the scripts would sleep on a warning.
+        'RAD_DIR': '',
+        'LAVA_DIR': '',
+    }
+    env.pop('GIT_SSH_COMMAND', None)
+
+    subprocess.run(
+        ['bash', str(root / 'tools' / script), *(a.format(root=root) for a in argv)],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    clones = [ln for ln in log.read_text().splitlines() if ln.startswith('git clone ')]
+    assert len(clones) == 1, log.read_text()
+    assert clones[0] == f'git clone {url} {dest.format(root=real_root)}'
+    # Nothing may resolve outside the throwaway checkout.
+    assert clones[0].split()[-1].startswith(real_root)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_install_scripts.py
+++ b/tests/tools/test_install_scripts.py
@@ -7,7 +7,6 @@ Reusable shell logic replicated inline from ``tools/get_petsc.sh`` and
 - ERR trap: exit-code and step-name capture
 - Platform detection: PETSC_ARCH assignment
 - Homebrew prefix fallback: architecture-aware default
-- Workpath argument handling: ``$1`` override vs default
 - PETSc library detection: versioned ``.so``, ``.dylib``, missing
 
 ``tools/_get_common.sh``, the helper library every ``get_*.sh`` sources, is
@@ -27,6 +26,8 @@ the shipped text:
 
 Blocks lifted out of the shipped scripts at run time, so that rewording a
 script re-runs its cases against the new text:
+- ``tools/get_petsc.sh``: the install-path resolution, ``$1`` against the
+  ``./petsc/`` default
 - ``tools/get_socrates.sh``: the install-path resolution, the portable-flag
   rewrite, its post-build flag check, and the conditional AGNI-wrapper
   rebuild note
@@ -40,6 +41,7 @@ rather than in shell, each of which fails silently when its counterpart moves:
   scripts resolve through ``tools/_module_pins.py``
 - the extras the ``setup-proteus`` composite action installs, against the
   extra keys pyproject declares
+- the SOCRATES cache key, against every file its build step reads
 - the installation docs' guidance on editable installs, against those pins
 - CI config leaving USER at the runner default, which the action's macOS
   ``brew install`` step requires
@@ -238,24 +240,30 @@ def test_portable_realpath_python_fallback(tmp_path):
 # One shipped copy of the shared helpers (tools/_get_common.sh)
 # ---------------------------------------------------------------------------
 
-# A private copy of a shared helper is recognised by the text that used to
-# be duplicated: the function header, the dirty test, and the SSH probe.
-PRIVATE_HELPER_SIGNATURES = (
-    ('portable_realpath() {', 'portable_realpath'),
-    ('status --porcelain --untracked-files=no', 'the dirty-checkout guard'),
-    ('-T git@github.com', 'the GitHub SSH probe'),
-)
+# The shell the library exports, read from the library rather than listed
+# here: a helper renamed in one place and not the other would otherwise
+# drop out of both scans below without either failing.
+LIBRARY_VARIABLES = ('proteus_root', 'proteus_tools_dir')
 
-# Names a script can only use because the library defines or sets them.
-LIBRARY_NAMES = (
-    'portable_realpath',
-    'get_parse_args',
-    'guard_dirty_checkout',
-    'github_use_ssh',
-    'github_ssh_url',
-    'resolve_module_pin',
-    'proteus_root',
-    'proteus_tools_dir',
+
+def _library_function_names() -> list[str]:
+    """Return the function names ``tools/_get_common.sh`` defines."""
+    names = re.findall(
+        r'^(?:function\s+)?([a-z_][a-z0-9_]*)\s*\(\s*\)\s*\{',
+        COMMON_LIB.read_text(),
+        re.MULTILINE,
+    )
+    return [name for name in names if not name.startswith('_')]
+
+
+# A private copy is a function definition of a library name, or the shell
+# the library replaced: the dirty test and the SSH probe as commands.
+# Matching the command form, not the text, keeps a mention inside a
+# user-facing message (get_spider.sh names the probe in its
+# troubleshooting output) from reading as a copy.
+COPIED_SHELL_PATTERNS = (
+    (r'git\s+(?:-C\s+\S+\s+)?status\s+--porcelain', 'the dirty-checkout guard'),
+    (r'^(?:if\s+)?(?:\$\{GIT_SSH_COMMAND[^}]*\}|ssh)\s+-T\s+git@github\.com', 'the SSH probe'),
 )
 
 
@@ -264,49 +272,82 @@ def _get_scripts() -> list[Path]:
     return sorted(TOOLS_DIR.glob('get_*.sh'))
 
 
+def _code_lines(script: Path) -> list[tuple[int, str]]:
+    """Return ``(index, code)`` for each line, with comments stripped.
+
+    Comments are dropped because a script's own prose names the helpers it
+    calls, and a quoted ``#`` is not a comment.
+    """
+    stripped = []
+    for index, line in enumerate(script.read_text().splitlines()):
+        code = re.sub(r'(^|\s)#.*$', '', line) if line.count('"') % 2 == 0 else line
+        stripped.append((index, code.strip()))
+    return stripped
+
+
 @pytest.mark.unit
 def test_no_get_script_carries_a_private_helper_copy():
     """Each shared helper is defined once, in the library.
 
     Nine scripts once carried their own ``portable_realpath``, and a fix to
-    one copy left the other eight broken. A script that grows a private
-    copy again is also outside the reach of the cases in this file, which
-    read the library rather than the scripts.
+    one copy left the other eight broken. A private copy also shadows the
+    library even in a script that sources it, so the definition, not the
+    absence of the source line, is what has to be caught: the shadowed
+    script would silently keep the old behaviour while every case in this
+    file kept passing against the library.
     """
     scripts = _get_scripts()
-    # Guard the guard: a mis-rooted glob would make the scan vacuous.
+    functions = _library_function_names()
+    # Guard the guard: a mis-rooted glob or a failed name extraction would
+    # make the scan vacuous.
     assert len(scripts) >= 10, [s.name for s in scripts]
+    assert 'portable_realpath' in functions, functions
+    assert len(functions) >= 6, functions
+
+    # Accept the spellings bash accepts: `name() {`, `name ()  {`, and
+    # `function name {`.
+    definitions = [
+        (
+            rf'^(?:function\s+)?{re.escape(name)}\s*\(\s*\)\s*\{{|^function\s+{re.escape(name)}\s*\{{',
+            f'a private {name}',
+        )
+        for name in functions
+    ]
 
     offenders: dict[str, list[str]] = {}
     for script in scripts:
-        for line in script.read_text().splitlines():
-            stripped = line.strip()
-            # Prose and user-facing messages may still name the commands.
-            if stripped.startswith('#') or 'echo ' in stripped:
-                continue
-            for needle, label in PRIVATE_HELPER_SIGNATURES:
-                if needle in stripped:
+        for _, code in _code_lines(script):
+            for pattern, label in (*definitions, *COPIED_SHELL_PATTERNS):
+                if re.search(pattern, code):
                     offenders.setdefault(script.name, []).append(label)
     assert offenders == {}, offenders
 
 
 @pytest.mark.unit
-def test_every_helper_user_sources_the_library():
-    """A script calling a shared helper also sources the file defining it.
+def test_every_helper_user_sources_the_library_before_calling_it():
+    """A script calls a shared helper only after sourcing its definition.
 
-    Without the source line the helper name is unset, and under a shell
-    without ``set -u`` the call is a silent no-op rather than an error.
+    An unsourced or late-sourced call is worse than a missing one: without
+    ``set -u`` the name is empty, so the call is a silent no-op. For
+    ``guard_dirty_checkout`` that means the refusal to delete a checkout
+    holding local work is simply absent, and the script deletes it.
     """
-    users, missing = [], []
+    names = (*_library_function_names(), *LIBRARY_VARIABLES)
+    users, unsourced, late = [], [], []
     for script in _get_scripts():
-        text = script.read_text()
-        if not any(name in text for name in LIBRARY_NAMES):
+        lines = _code_lines(script)
+        uses = [i for i, code in lines if any(name in code for name in names)]
+        if not uses:
             continue
         users.append(script.name)
-        if 'source "$_get_common"' not in text:
-            missing.append(script.name)
+        sourced = [i for i, code in lines if 'source "$_get_common"' in code]
+        if not sourced:
+            unsourced.append(script.name)
+        elif min(uses) < sourced[0]:
+            late.append(script.name)
 
-    assert missing == [], missing
+    assert unsourced == [], unsourced
+    assert late == [], late
     # Guard the guard: a renamed helper would leave nothing to check.
     assert len(users) >= 10, users
 
@@ -1104,11 +1145,15 @@ def test_ci_setup_installs_every_declared_extra():
 # ---------------------------------------------------------------------------
 
 
-def _run_guard(tmp_path, *args: str, pathspec: str = '') -> subprocess.CompletedProcess:
+def _run_guard(
+    tmp_path, *args: str, pathspec: str = '', strict: bool = False
+) -> subprocess.CompletedProcess:
     """Run the shipped guard against the ``aragog`` checkout in ``tmp_path``.
 
     ``pathspec`` appends a git pathspec, as ``get_socrates.sh`` does for its
-    regenerable build config.
+    regenerable build config. ``strict`` selects the shell the callers
+    split over: get_boreas.sh and get_vulcan.sh enable
+    ``set -euo pipefail``, the other six do not.
     """
     body = (
         'get_parse_args "$@"\n'
@@ -1116,7 +1161,7 @@ def _run_guard(tmp_path, *args: str, pathspec: str = '') -> subprocess.Completed
         'echo GUARD_PASSED\n'
     )
     return subprocess.run(
-        ['bash', '-c', _with_common(body), 'guard', *args],
+        ['bash', '-c', _with_common(body, strict=strict), 'guard', *args],
         capture_output=True,
         text=True,
         env={**os.environ, 'GUARD_ROOT': str(tmp_path)},
@@ -1132,14 +1177,17 @@ def _git(cwd, *args: str) -> None:
     )
 
 
-def test_guard_blocks_dirty_and_unpushed_checkouts(tmp_path):
+@pytest.mark.parametrize('strict', [False, True], ids=['plain shell', 'errexit shell'])
+def test_guard_blocks_dirty_and_unpushed_checkouts(tmp_path, strict):
     """Tracked modifications and local-only commits block the refresh.
 
     A modified tracked file must exit 1 with the recovery command in the
     message; a repo whose commits exist on no remote (covers both the
     remote-less and the never-pushed case) must also block. Untracked
     files alone must NOT block: build artifacts and egg-info dirs are
-    routine in refreshed checkouts.
+    routine in refreshed checkouts. Both shells are exercised: the guard
+    is shared by scripts that enable ``set -euo pipefail`` and scripts
+    that do not.
     """
     workdir = tmp_path / 'aragog'
     workdir.mkdir()
@@ -1149,19 +1197,20 @@ def test_guard_blocks_dirty_and_unpushed_checkouts(tmp_path):
     _git(workdir, 'commit', '-q', '-m', 'c1')
 
     # Local-only commit (no remotes at all): blocked.
-    res = _run_guard(tmp_path)
+    res = _run_guard(tmp_path, strict=strict)
     assert res.returncode == 1
     assert '--force' in res.stderr  # recovery command is named
     assert 'GUARD_PASSED' not in res.stdout
 
     # Same state plus a dirty tracked file: still blocked.
     (workdir / 'tracked.py').write_text('x = 2\n')
-    res = _run_guard(tmp_path)
+    res = _run_guard(tmp_path, strict=strict)
     assert res.returncode == 1
     assert 'uncommitted changes' in res.stderr
 
 
-def test_guard_passes_clean_remote_backed_checkout(tmp_path):
+@pytest.mark.parametrize('strict', [False, True], ids=['plain shell', 'errexit shell'])
+def test_guard_passes_clean_remote_backed_checkout(tmp_path, strict):
     """A clean checkout whose commits are on a remote is refreshed.
 
     Mimics the normal installed state: a clone (origin exists), detached
@@ -1181,7 +1230,7 @@ def test_guard_passes_clean_remote_backed_checkout(tmp_path):
     _git(workdir, 'checkout', '-q', '--detach', 'HEAD')
     (workdir / 'build_artifact.o').write_text('')  # untracked: must not block
 
-    res = _run_guard(tmp_path)
+    res = _run_guard(tmp_path, strict=strict)
     assert res.returncode == 0
     assert 'GUARD_PASSED' in res.stdout
 
@@ -1191,17 +1240,50 @@ def test_guard_passes_clean_remote_backed_checkout(tmp_path):
     (workdir / 'f.py').write_text('a = 2\n')
     _git(workdir, 'add', 'f.py')
     _git(workdir, 'commit', '-q', '-m', 'local work')
-    res = _run_guard(tmp_path)
+    res = _run_guard(tmp_path, strict=strict)
     assert res.returncode == 1
     assert 'not on a remote' in res.stderr
 
     # --force bypasses deliberately.
-    res = _run_guard(tmp_path, '--force')
+    res = _run_guard(tmp_path, '--force', strict=strict)
     assert res.returncode == 0
     assert 'GUARD_PASSED' in res.stdout
 
 
-def test_guard_excludes_only_the_pathspec_the_caller_names(tmp_path):
+@pytest.mark.parametrize('strict', [False, True], ids=['plain shell', 'errexit shell'])
+def test_guard_keeps_a_checkout_git_cannot_report_on(tmp_path, strict):
+    """A checkout whose state git cannot report is kept, in either shell.
+
+    An unborn HEAD, from a ``git init`` with nothing committed or an
+    interrupted clone, makes ``git log HEAD`` exit 128. Reading that
+    through a pipe made the outcome depend on the shell: under
+    ``set -o pipefail`` the script stopped with no message at all, and
+    without it the guard read an empty result and the checkout was
+    deleted, staged work included. Whether such a checkout holds local
+    work is unknown, so it is kept and the reason named, identically in
+    both shells.
+    """
+    workdir = tmp_path / 'aragog'
+    workdir.mkdir()
+    _git(workdir, 'init', '-q')
+    # Staged and never committed: work a refresh would destroy.
+    (workdir / 'work.py').write_text('x = 1\n')
+    _git(workdir, 'add', 'work.py')
+
+    res = _run_guard(tmp_path, strict=strict)
+    assert res.returncode == 1, res.stdout
+    assert 'could not report the state' in res.stderr
+    assert '--force' in res.stderr  # the recovery command is named
+    assert 'GUARD_PASSED' not in res.stdout
+
+    # --force still discards deliberately, in either shell.
+    forced = _run_guard(tmp_path, '--force', strict=strict)
+    assert forced.returncode == 0, forced.stderr
+    assert 'GUARD_PASSED' in forced.stdout
+
+
+@pytest.mark.parametrize('strict', [False, True], ids=['plain shell', 'errexit shell'])
+def test_guard_excludes_only_the_pathspec_the_caller_names(tmp_path, strict):
     """An excluded path does not block the refresh, but its neighbours do.
 
     get_socrates.sh excludes make/Mk_cmd because configure rewrites it on
@@ -1224,18 +1306,18 @@ def test_guard_excludes_only_the_pathspec_the_caller_names(tmp_path):
 
     # Regenerated build config only: the exclusion lets the refresh run.
     (workdir / 'make' / 'Mk_cmd').write_text('FORTCOMP = gfortran -Ofast\n')
-    res = _run_guard(tmp_path, pathspec=exclude)
+    res = _run_guard(tmp_path, pathspec=exclude, strict=strict)
     assert res.returncode == 0, res.stderr
     assert 'GUARD_PASSED' in res.stdout
 
     # The same state without the exclusion blocks: the guard still looks.
-    res = _run_guard(tmp_path)
+    res = _run_guard(tmp_path, strict=strict)
     assert res.returncode == 1
     assert 'uncommitted changes' in res.stderr
 
     # A modification outside the excluded path blocks either way.
     (workdir / 'src.f90').write_text('stop\n')
-    res = _run_guard(tmp_path, pathspec=exclude)
+    res = _run_guard(tmp_path, pathspec=exclude, strict=strict)
     assert res.returncode == 1
     assert 'GUARD_PASSED' not in res.stdout
 
@@ -1671,7 +1753,12 @@ def test_script_clones_the_expected_destination(tmp_path, script, argv, dest, ur
 
     subprocess.run(
         ['bash', str(root / 'tools' / script), *(a.format(root=root) for a in argv)],
-        cwd=root,
+        # Deliberately not the checkout: a destination taken from the
+        # working directory would otherwise land on the expected path by
+        # coincidence, and the CWD-relative regression would be invisible.
+        # get_spider.sh is the one script whose default destination is
+        # CWD-relative by design, so its case passes a path.
+        cwd=tmp_path,
         env=env,
         capture_output=True,
         text=True,
@@ -1681,8 +1768,10 @@ def test_script_clones_the_expected_destination(tmp_path, script, argv, dest, ur
     clones = [ln for ln in log.read_text().splitlines() if ln.startswith('git clone ')]
     assert len(clones) == 1, log.read_text()
     assert clones[0] == f'git clone {url} {dest.format(root=real_root)}'
-    # Nothing may resolve outside the throwaway checkout.
+    # Nothing may resolve outside the throwaway checkout, and in particular
+    # not into the directory the script was run from.
     assert clones[0].split()[-1].startswith(real_root)
+    assert not (tmp_path / dest.format(root='').lstrip('/')).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/_get_common.sh
+++ b/tools/_get_common.sh
@@ -66,6 +66,7 @@ proteus_root=$(portable_realpath "$proteus_tools_dir/..")
 # destination read get_force only; --force may appear before or after the
 # path. guard_dirty_checkout honours get_force.
 get_parse_args() {
+    local arg
     get_force=false
     get_install_path=""
     for arg in "$@"; do
@@ -88,6 +89,12 @@ get_parse_args() {
 # Trailing arguments are passed to git status, which get_socrates.sh uses
 # to exclude its regenerable build config from the dirty test. Exits 1
 # when the checkout is guarded, so call it as a plain command.
+#
+# Neither probe is piped: `git ... | head -1` reports the pipeline's
+# status, which is git's exit code under `set -o pipefail` and head's
+# otherwise, so the same unreadable checkout stopped some scripts and was
+# deleted by others. git's own -1 bounds the log instead, and a probe that
+# cannot run is reported rather than read as a clean result.
 guard_dirty_checkout() {
     local workpath="$1"
     local script="$2"
@@ -100,9 +107,18 @@ guard_dirty_checkout() {
         return 0
     fi
 
-    local dirty unpushed
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no "$@" 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
+    local dirty unpushed rc=0
+    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no "$@" 2>/dev/null) || rc=$?
+    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline -1 2>/dev/null) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        # An unborn HEAD, an incomplete .git, or no git at all. Whether the
+        # checkout holds local work is then unknown, so keep it.
+        echo "ERROR: git could not report the state of $workpath, so whether" >&2
+        echo "       it holds local work is unknown. Refusing to delete it." >&2
+        echo "       Inspect the checkout, or run" >&2
+        echo "       bash tools/$script --force  to discard it." >&2
+        exit 1
+    fi
     if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
         echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
         echo "       Refusing to delete it. Commit and push your work, or run" >&2
@@ -116,7 +132,9 @@ guard_dirty_checkout() {
 # `ssh -T git@github.com` exits 1 when the key is accepted (GitHub refuses
 # the interactive shell it was asked for) and 255 when it is not, so exit
 # code 1 is the success signal. The probe honours GIT_SSH_COMMAND, so a
-# caller such as CI can make it non-interactive and fast-failing. Its own
+# caller such as CI can make it non-interactive and fast-failing; the
+# expansion is unquoted so that its options reach ssh as separate words,
+# which means an option value containing a space does not survive. Its own
 # output is sent to stderr, where the user still sees it, so that it
 # cannot contaminate the answer read by a command substitution.
 github_use_ssh() {

--- a/tools/_get_common.sh
+++ b/tools/_get_common.sh
@@ -1,0 +1,151 @@
+# shellcheck shell=bash
+#
+# Shared shell helpers for the tools/get_*.sh module install scripts.
+#
+# This file is sourced, never executed. Source it near the top of a get_*
+# script, before the first helper call:
+#
+#     _get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+#     [ -f "$_get_common" ] || {
+#         echo "ERROR: $_get_common is missing." >&2
+#         exit 1
+#     }
+#     source "$_get_common"
+#
+# Every caller runs a get_* script by path (docs, install.sh, the CI setup
+# action, and proteus install-all through src/proteus/utils/data.py), so
+# ${BASH_SOURCE[0]} locates this file without needing a resolved path
+# first, which is what makes the bootstrap above safe to run before
+# portable_realpath exists.
+#
+# The helpers target bash 3.2, the version macOS ships, and behave the same
+# whether or not the sourcing script enables `set -euo pipefail`. Two of
+# them exit the script on failure (guard_dirty_checkout, resolve_module_pin)
+# and so must be called as plain commands: inside a command substitution
+# the exit would only leave the subshell.
+#
+# Sourcing this file sets:
+#   proteus_tools_dir   absolute path of the tools/ directory
+#   proteus_root        absolute path of the PROTEUS checkout root
+#
+# and defines:
+#   portable_realpath     resolve a path, whether or not it exists yet
+#   get_parse_args        split --force from an optional install path
+#   guard_dirty_checkout  refuse to delete a checkout holding local work
+#   github_use_ssh        report whether GitHub accepts an SSH key
+#   github_ssh_url        rewrite an https GitHub URL for SSH transport
+#   resolve_module_pin    read a module's pinned clone URL and ref
+
+# Resolve a path to an absolute one, with symlinks and .. expanded.
+#
+# macOS before 13 (Catalina through Monterey) does not ship the coreutils
+# realpath, so fall back to python3, which is always present in PROTEUS's
+# Python environment. A path that does not exist yet is also rejected by
+# realpath (BSD refuses a missing leaf, GNU a missing parent) and takes
+# the same fallback: install destinations are resolved before git clone
+# creates them, so a missing path must resolve rather than fail.
+portable_realpath() {
+    if command -v realpath >/dev/null 2>&1 && realpath "$1" 2>/dev/null; then
+        return 0
+    fi
+    python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
+}
+
+# The directory holding this file, without calling out to dirname, so that
+# sourcing it depends on nothing but bash itself.
+_get_common_dir="${BASH_SOURCE[0]%/*}"
+if [ "$_get_common_dir" = "${BASH_SOURCE[0]}" ]; then
+    _get_common_dir="."
+fi
+proteus_tools_dir=$(portable_realpath "$_get_common_dir")
+proteus_root=$(portable_realpath "$proteus_tools_dir/..")
+
+# Split the script's arguments into the --force switch and an optional
+# install-path positional, reported as get_force (true / false) and
+# get_install_path (empty when no path was given). Scripts with a fixed
+# destination read get_force only; --force may appear before or after the
+# path. guard_dirty_checkout honours get_force.
+get_parse_args() {
+    get_force=false
+    get_install_path=""
+    for arg in "$@"; do
+        if [ "$arg" = "--force" ]; then
+            get_force=true
+        elif [ -z "$get_install_path" ]; then
+            get_install_path="$arg"
+        fi
+    done
+}
+
+# Refuse to delete a checkout that holds local work, unless --force was
+# given. Guarded states: modified tracked files, and commits that are on
+# no remote. Untracked files (build artifacts, egg-info) do not block the
+# refresh, because they are routine in a refreshed checkout.
+#
+# Usage: guard_dirty_checkout <checkout-path> <script-name> [git pathspec...]
+#
+# The script name goes into the recovery command in the error message.
+# Trailing arguments are passed to git status, which get_socrates.sh uses
+# to exclude its regenerable build config from the dirty test. Exits 1
+# when the checkout is guarded, so call it as a plain command.
+guard_dirty_checkout() {
+    local workpath="$1"
+    local script="$2"
+    shift 2
+
+    if [ "${get_force:-false}" = true ]; then
+        return 0
+    fi
+    if [ ! -d "$workpath/.git" ]; then
+        return 0
+    fi
+
+    local dirty unpushed
+    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no "$@" 2>/dev/null | head -1)
+    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
+    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
+        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
+        echo "       Refusing to delete it. Commit and push your work, or run" >&2
+        echo "       bash tools/$script --force  to discard the checkout." >&2
+        exit 1
+    fi
+}
+
+# Report whether GitHub accepts an SSH key, as "true" or "false" on stdout.
+#
+# `ssh -T git@github.com` exits 1 when the key is accepted (GitHub refuses
+# the interactive shell it was asked for) and 255 when it is not, so exit
+# code 1 is the success signal. The probe honours GIT_SSH_COMMAND, so a
+# caller such as CI can make it non-interactive and fast-failing. Its own
+# output is sent to stderr, where the user still sees it, so that it
+# cannot contaminate the answer read by a command substitution.
+github_use_ssh() {
+    local rc=0
+    ${GIT_SSH_COMMAND:-ssh} -T git@github.com >&2 || rc=$?
+    if [ "$rc" -eq 1 ]; then
+        echo true
+    else
+        echo false
+    fi
+}
+
+# Rewrite an https GitHub URL to its SSH form for cloning over SSH.
+# A URL that is not on github.com is returned unchanged.
+github_ssh_url() {
+    printf '%s\n' "${1/https:\/\/github.com\//git@github.com:}"
+}
+
+# Read a module's pinned clone URL and ref from pyproject.toml, through
+# tools/_module_pins.py, into module_url and module_ref. A module whose
+# pin is missing or empty stops the install here, where the cause is
+# named, rather than at a git clone with an empty argument. Exits 1 in
+# that case, so call it as a plain command.
+resolve_module_pin() {
+    local module="$1"
+    module_url=$(python "$proteus_tools_dir/_module_pins.py" "$module" url)
+    module_ref=$(python "$proteus_tools_dir/_module_pins.py" "$module" ref)
+    if [ -z "$module_url" ] || [ -z "$module_ref" ]; then
+        echo "ERROR: could not resolve $module url/ref from pyproject.toml" >&2
+        exit 1
+    fi
+}

--- a/tools/get_agni.sh
+++ b/tools/get_agni.sh
@@ -17,16 +17,22 @@ if ! command -v julia >/dev/null 2>&1; then
     exit 1
 fi
 
-script_root="$(cd "$(dirname "$0")/.." && pwd)"
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
-ag_url="${AGNI_GIT_URL:-$(python "$script_root/tools/_module_pins.py" agni url)}"
-ag_ref="${AGNI_GIT_REF:-$(python "$script_root/tools/_module_pins.py" agni ref)}"
+ag_url="${AGNI_GIT_URL:-$(python "$proteus_tools_dir/_module_pins.py" agni url)}"
+ag_ref="${AGNI_GIT_REF:-$(python "$proteus_tools_dir/_module_pins.py" agni ref)}"
 
 # First positional arg can be either "0" (skip AGNI test step) or a path.
 # Preserve AGNI's upstream get_agni.sh interface: passing "0" tells it
 # to skip Pkg.test. Anything else is treated as a destination path.
 skip_tests=""
-dest="$script_root/AGNI"
+dest="$proteus_root/AGNI"
 if [ "${1:-}" = "0" ]; then
     skip_tests="0"
 elif [ -n "${1:-}" ]; then

--- a/tools/get_aragog.sh
+++ b/tools/get_aragog.sh
@@ -16,17 +16,16 @@
 
 echo "Set up Aragog..."
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # Path to PROTEUS folder
-root=$(dirname $(portable_realpath $0))
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
 # Paired-branch detection. When PROTEUS is on a feature branch and aragog has a
 # branch of the same name, install that aragog branch so CI exercises the real
@@ -39,36 +38,15 @@ if [ -z "$proteus_branch" ]; then
     proteus_branch=$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null)
 fi
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts, egg-info) do not block the refresh.
-force=false
-for arg in "$@"; do
-    [ "$arg" = "--force" ] && force=true
-done
+get_parse_args "$@"
 workpath=$root/aragog/
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_aragog.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_aragog.sh
 
 # Make room
 rm -rf $workpath
 
 # Check SSH access to GitHub
-ssh -T git@github.com
-if [ $? -eq 1 ]; then
-    use_ssh=true
-else
-    use_ssh=false
-fi
+use_ssh=$(github_use_ssh)
 
 # Download
 echo "Cloning from GitHub"

--- a/tools/get_aragog.sh
+++ b/tools/get_aragog.sh
@@ -39,11 +39,11 @@ if [ -z "$proteus_branch" ]; then
 fi
 
 get_parse_args "$@"
-workpath=$root/aragog/
+workpath="$root/aragog/"
 guard_dirty_checkout "$workpath" get_aragog.sh
 
 # Make room
-rm -rf $workpath
+rm -rf "$workpath"
 
 # Check SSH access to GitHub
 use_ssh=$(github_use_ssh)
@@ -93,7 +93,7 @@ fi
 pip install -U -e . || { echo "ERROR: editable install failed" >&2; exit 1; }
 
 # Back to old folder
-cd $root
+cd "$root"
 
 # Done
 echo "Done!"

--- a/tools/get_boreas.sh
+++ b/tools/get_boreas.sh
@@ -12,67 +12,35 @@ set -euo pipefail
 
 echo "Set up BOREAS..."
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # Path to PROTEUS folder
-root=$(dirname "$(portable_realpath "$0")")
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts, egg-info) do not block the refresh.
-force=false
-for arg in "$@"; do
-    [ "$arg" = "--force" ] && force=true
-done
+get_parse_args "$@"
 workpath="$root/BOREAS/"
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_boreas.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_boreas.sh
 
 # Make room
 rm -rf "$workpath"
 
-# Detect SSH access to GitHub. `ssh -T git@github.com` exits 1 when
-# authentication succeeds (GitHub refuses the shell), so a plain call
-# would trip `set -e`; keeping it as the `if` condition keeps it in
-# scope where a non-zero exit is expected rather than fatal.
-if ssh -T git@github.com; then
-    use_ssh=false
-else
-    if [ $? -eq 1 ]; then
-        use_ssh=true
-    else
-        use_ssh=false
-    fi
-fi
+# Detect SSH access to GitHub.
+use_ssh=$(github_use_ssh)
 
 # Resolve the pinned URL + ref from pyproject.toml.
-b_url=$(python "$root/tools/_module_pins.py" boreas url)
-b_ref=$(python "$root/tools/_module_pins.py" boreas ref)
-if [ -z "$b_url" ] || [ -z "$b_ref" ]; then
-    echo "ERROR: could not resolve boreas url/ref from pyproject.toml" >&2
-    exit 1
-fi
+resolve_module_pin boreas
+b_url="$module_url"
+b_ref="$module_ref"
 
 echo "Cloning from GitHub"
 if [ "$use_ssh" = true ]; then
-    # Rewrite https://github.com/ -> git@github.com: for SSH transport.
-    uri=${b_url/https:\/\/github.com\//git@github.com:}
+    uri=$(github_ssh_url "$b_url")
 else
     uri="$b_url"
 fi

--- a/tools/get_lavatmos.sh
+++ b/tools/get_lavatmos.sh
@@ -3,26 +3,18 @@
 
 echo "Set up LavAtmos..."
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # Path to PROTEUS folder
-root=$(dirname "$(portable_realpath "$0")")
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts, egg-info) do not block the refresh.
-force=false
-for arg in "$@"; do
-    [ "$arg" = "--force" ] && force=true
-done
+get_parse_args "$@"
 workpath="$root/LavAtmos/"
 
 # Already setup?
@@ -35,46 +27,22 @@ if [ -n "$LAVA_DIR" ]; then
     sleep 5
 fi
 
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_lavatmos.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_lavatmos.sh
 
 # Make room
 rm -rf "$workpath"
 
-# Detect SSH access to GitHub. `ssh -T git@github.com` exits 1 when
-# authentication succeeds (GitHub refuses the shell), so a plain call
-# would trip `set -e`; keeping it as the `if` condition keeps it in
-# scope where a non-zero exit is expected rather than fatal.
-if ssh -T git@github.com; then
-    use_ssh=false
-else
-    if [ $? -eq 1 ]; then
-        use_ssh=true
-    else
-        use_ssh=false
-    fi
-fi
+# Detect SSH access to GitHub.
+use_ssh=$(github_use_ssh)
 
 # Resolve the pinned URL + ref from pyproject.toml.
-l_url=$(python "$root/tools/_module_pins.py" lavatmos url)
-l_ref=$(python "$root/tools/_module_pins.py" lavatmos ref)
-if [ -z "$l_url" ] || [ -z "$l_ref" ]; then
-    echo "ERROR: could not resolve lavatmos url/ref from pyproject.toml" >&2
-    exit 1
-fi
+resolve_module_pin lavatmos
+l_url="$module_url"
+l_ref="$module_ref"
 
 echo "Cloning from GitHub"
 if [ "$use_ssh" = true ]; then
-    # Rewrite https://github.com/ -> git@github.com: for SSH transport.
-    uri=${l_url/https:\/\/github.com\//git@github.com:}
+    uri=$(github_ssh_url "$l_url")
 else
     uri="$l_url"
 fi

--- a/tools/get_lovepy.sh
+++ b/tools/get_lovepy.sh
@@ -7,12 +7,19 @@ if ! [ -x "$(command -v julia)" ]; then
   exit 1
 fi
 
-# Resolve the pinned LovePy URL + ref from pyproject.toml. Julia's
-# Pkg.add accepts a `rev=` kwarg for a specific commit / tag / branch;
-# `main` is the default if no ref is configured.
-script_root="$(cd "$(dirname "$0")/.." && pwd)"
-lp_url=$(python "$script_root/tools/_module_pins.py" lovepy url)
-lp_ref=$(python "$script_root/tools/_module_pins.py" lovepy ref)
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
+
+# Resolve the pinned LovePy URL + ref from pyproject.toml. Julia's Pkg.add
+# accepts a `rev=` kwarg for a specific commit / tag / branch.
+resolve_module_pin lovepy
+lp_url="$module_url"
+lp_ref="$module_ref"
 
 echo "Installing LovePy into Julia environment ($lp_url @ $lp_ref)..."
 LD_LIBRARY_PATH="" julia -e "using Pkg; Pkg.add(url=\"$lp_url\", rev=\"$lp_ref\")"

--- a/tools/get_petsc.sh
+++ b/tools/get_petsc.sh
@@ -30,17 +30,14 @@
 set -e
 
 # -----------------------------------------------------------------------------
-# Portable realpath: macOS <13 (Catalina through Monterey) does not ship
-# GNU coreutils realpath. Fall back to python3, which is always available
-# in PROTEUS's conda environment.
+# Shared helpers, portable_realpath among them: see tools/_get_common.sh.
 # -----------------------------------------------------------------------------
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # -----------------------------------------------------------------------------
 # Error handling: report which step failed on any non-zero exit

--- a/tools/get_socrates.sh
+++ b/tools/get_socrates.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 # Download and compile socrates
+#
+# Usage:
+#   tools/get_socrates.sh            # install into ./socrates/
+#   tools/get_socrates.sh some/path  # custom destination, created if missing
+#   tools/get_socrates.sh --force    # discard an existing checkout
 
 # Do we have NetCDF?
 if ! [ -x "$(command -v nc-config)" ]; then
@@ -26,66 +31,43 @@ if [ -n "$RAD_DIR" ]; then
     sleep 5
 fi
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
-
-
-# Check SSH access to GitHub. The probe honours GIT_SSH_COMMAND so
-# callers (e.g. CI) can make it non-interactive and fast-failing.
-${GIT_SSH_COMMAND:-ssh} -T git@github.com
-if [ $? -eq 1 ]; then
-    use_ssh=true
-else
-    use_ssh=false
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
 fi
+source "$_get_common"
+
+# Check SSH access to GitHub.
+use_ssh=$(github_use_ssh)
 
 # Disable SSH (uncomment to allow SSH clone of SOCRATES)
 # use_ssh=false
 
 # Download
-root=$(dirname $(portable_realpath $0))
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
 # Separate the --force flag from the optional install-path argument.
-force=false
-install_path=""
-for arg in "$@"; do
-    if [ "$arg" = "--force" ]; then
-        force=true
-    elif [ -z "$install_path" ]; then
-        install_path="$arg"
-    fi
-done
+get_parse_args "$@"
 
-if [ -n "$install_path" ]; then
-    socpath="$(portable_realpath "$install_path")"
+if [ -n "$get_install_path" ]; then
+    socpath="$(portable_realpath "$get_install_path")"
+    # set -euo pipefail is not active yet, so an unresolvable path would
+    # otherwise reach git clone as an empty string.
+    if [ -z "$socpath" ]; then
+        echo "ERROR: could not resolve install path '$get_install_path'." >&2
+        exit 1
+    fi
 else
     socpath="$root/socrates"
 fi
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (the compiled build tree) do not block the refresh.
-# make/Mk_cmd is excluded: configure regenerates it on every build (compiler
-# detection, host paths, and optimisation flags), so it is regenerable build
-# config rather than user work and would otherwise block every refresh.
-if [ -d "$socpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$socpath" status --porcelain --untracked-files=no \
-        -- ':(exclude)make/Mk_cmd' 2>/dev/null | head -1)
-    unpushed=$(git -C "$socpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $socpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_socrates.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+# make/Mk_cmd is excluded from the dirty test: configure regenerates it on
+# every build (compiler detection, host paths, and optimisation flags), so
+# it is regenerable build config rather than user work and would otherwise
+# block every refresh.
+guard_dirty_checkout "$socpath" get_socrates.sh -- ':(exclude)make/Mk_cmd'
 rm -rf "$socpath"
 
 set -euo pipefail
@@ -93,13 +75,12 @@ set -euo pipefail
 
 # Resolve the pinned URL + ref from pyproject.toml. The HTTPS URL is the
 # default; SSH is used only when ssh -T against github succeeded above.
-soc_url=$(python "$root/tools/_module_pins.py" socrates url)
-soc_ref=$(python "$root/tools/_module_pins.py" socrates ref)
+resolve_module_pin socrates
+soc_url="$module_url"
+soc_ref="$module_ref"
 
 if [ "$use_ssh" = true ]; then
-    # Rewrite https://github.com/ -> git@github.com: for SSH transport.
-    soc_ssh_url=${soc_url/https:\/\/github.com\//git@github.com:}
-    git clone "$soc_ssh_url" "$socpath"
+    git clone "$(github_ssh_url "$soc_url")" "$socpath"
 else
     git clone "$soc_url" "$socpath"
 fi

--- a/tools/get_spider.sh
+++ b/tools/get_spider.sh
@@ -32,17 +32,14 @@
 set -e
 
 # -----------------------------------------------------------------------------
-# Portable realpath: macOS <13 (Catalina through Monterey) does not ship
-# GNU coreutils realpath. Fall back to python3, which is always available
-# in PROTEUS's conda environment.
+# Shared helpers, portable_realpath among them: see tools/_get_common.sh.
 # -----------------------------------------------------------------------------
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # -----------------------------------------------------------------------------
 # Error handling: report which step failed on any non-zero exit
@@ -108,14 +105,12 @@ fi
 # -----------------------------------------------------------------------------
 current_step="Validating PETSc installation"
 
-# Derive the repo root from this script's location (tools/get_spider.sh).
-# This avoids dependence on the caller's CWD — important when invoked by
-# data.py:get_spider() which does not set cwd.
-script_dir="$(cd "$(dirname "$0")" && pwd)"
-repo_root="$(dirname "$script_dir")"
-
-# PETSc is expected at <repo_root>/petsc/.
-petsc_path="$repo_root/petsc"
+# The repo root comes from this script's location, through the shared
+# helpers, rather than from the caller's CWD: data.py:get_spider() invokes
+# the script without setting cwd.
+#
+# PETSc is expected at <repo root>/petsc/.
+petsc_path="$proteus_root/petsc"
 if [[ ! -d "$petsc_path" ]]; then
     echo "ERROR: petsc/ directory not found at $petsc_path."
     echo "Run ./tools/get_petsc.sh first to install PETSc."
@@ -202,34 +197,13 @@ current_step="Cloning SPIDER from GitHub"
 
 # Default install directory: ./SPIDER/ ; override via first argument.
 # The --force flag is separated from the optional path argument.
-force=false
-install_path=""
-for arg in "$@"; do
-    if [ "$arg" = "--force" ]; then
-        force=true
-    elif [ -z "$install_path" ]; then
-        install_path="$arg"
-    fi
-done
+get_parse_args "$@"
 workpath="SPIDER"
-if [[ -n "$install_path" ]]; then
-    workpath="$install_path"
+if [[ -n "$get_install_path" ]]; then
+    workpath="$get_install_path"
 fi
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts) do not block the refresh.
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_spider.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_spider.sh
 
 # Remove any previous installation
 if [[ -d "$workpath" ]]; then
@@ -242,9 +216,8 @@ echo "Cloning SPIDER from GitHub..."
 
 # Resolve the pinned URL + ref from pyproject.toml. Allow override via
 # the SPIDER_GIT_URL / SPIDER_GIT_REF env vars for local dev.
-script_root="$(cd "$(dirname "$0")/.." && pwd)"
-sp_url="${SPIDER_GIT_URL:-$(python "$script_root/tools/_module_pins.py" spider url)}"
-sp_ref="${SPIDER_GIT_REF:-$(python "$script_root/tools/_module_pins.py" spider ref)}"
+sp_url="${SPIDER_GIT_URL:-$(python "$proteus_tools_dir/_module_pins.py" spider url)}"
+sp_ref="${SPIDER_GIT_REF:-$(python "$proteus_tools_dir/_module_pins.py" spider ref)}"
 
 git clone "$sp_url" "$workpath"
 git -C "$workpath" checkout --quiet "$sp_ref"

--- a/tools/get_thermoenginelite.sh
+++ b/tools/get_thermoenginelite.sh
@@ -13,68 +13,36 @@ if ! [ -x "$(command -v pip)" ]; then
   exit 1
 fi
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # Path to PROTEUS folder
-root=$(dirname "$(portable_realpath "$0")")
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts, egg-info) do not block the refresh.
-force=false
-for arg in "$@"; do
-    [ "$arg" = "--force" ] && force=true
-done
+get_parse_args "$@"
 workpath="$root/ThermoEngineLite/"
 
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_thermoenginelite.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_thermoenginelite.sh
 
 # Make room
 rm -rf "$workpath"
 
-# Detect SSH access to GitHub. `ssh -T git@github.com` exits 1 when
-# authentication succeeds (GitHub refuses the shell), so a plain call
-# would trip `set -e`; keeping it as the `if` condition keeps it in
-# scope where a non-zero exit is expected rather than fatal.
-if ssh -T git@github.com; then
-    use_ssh=false
-else
-    if [ $? -eq 1 ]; then
-        use_ssh=true
-    else
-        use_ssh=false
-    fi
-fi
+# Detect SSH access to GitHub.
+use_ssh=$(github_use_ssh)
 
 # Resolve the pinned URL + ref from pyproject.toml.
-l_url=$(python "$root/tools/_module_pins.py" thermoenginelite url)
-l_ref=$(python "$root/tools/_module_pins.py" thermoenginelite ref)
-if [ -z "$l_url" ] || [ -z "$l_ref" ]; then
-    echo "ERROR: could not resolve thermoenginelite url/ref from pyproject.toml" >&2
-    exit 1
-fi
+resolve_module_pin thermoenginelite
+l_url="$module_url"
+l_ref="$module_ref"
 
 echo "Cloning from GitHub"
 if [ "$use_ssh" = true ]; then
-    # Rewrite https://github.com/ -> git@github.com: for SSH transport.
-    uri=${l_url/https:\/\/github.com\//git@github.com:}
+    uri=$(github_ssh_url "$l_url")
 else
     uri="$l_url"
 fi

--- a/tools/get_vulcan.sh
+++ b/tools/get_vulcan.sh
@@ -14,54 +14,26 @@ set -euo pipefail
 
 echo "Set up VULCAN..."
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # Path to PROTEUS folder
-root=$(dirname "$(portable_realpath "$0")")
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts, egg-info) do not block the refresh.
-force=false
-for arg in "$@"; do
-    [ "$arg" = "--force" ] && force=true
-done
+get_parse_args "$@"
 workpath="$root/VULCAN/"
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_vulcan.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_vulcan.sh
 
 # Make room
 rm -rf "$workpath"
 
-# Detect SSH access to GitHub. `ssh -T git@github.com` exits 1 when
-# authentication succeeds (GitHub refuses the shell), so a plain call
-# would trip `set -e`; keeping it as the `if` condition keeps it in
-# scope where a non-zero exit is expected rather than fatal.
-if ssh -T git@github.com; then
-    use_ssh=false
-else
-    if [ $? -eq 1 ]; then
-        use_ssh=true
-    else
-        use_ssh=false
-    fi
-fi
+# Detect SSH access to GitHub.
+use_ssh=$(github_use_ssh)
 
 # Download
 echo "Cloning from GitHub"

--- a/tools/get_zalmoxis.sh
+++ b/tools/get_zalmoxis.sh
@@ -40,11 +40,11 @@ if [ -z "$proteus_branch" ]; then
 fi
 
 get_parse_args "$@"
-workpath=$root/Zalmoxis/
+workpath="$root/Zalmoxis/"
 guard_dirty_checkout "$workpath" get_zalmoxis.sh
 
 # Make room
-rm -rf $workpath
+rm -rf "$workpath"
 
 # Check SSH access to GitHub
 use_ssh=$(github_use_ssh)
@@ -94,7 +94,7 @@ fi
 pip install -U -e . || { echo "ERROR: editable install failed" >&2; exit 1; }
 
 # Back to old folder
-cd $root
+cd "$root"
 
 # Done
 echo "Done!"

--- a/tools/get_zalmoxis.sh
+++ b/tools/get_zalmoxis.sh
@@ -17,17 +17,16 @@
 
 echo "Set up Zalmoxis..."
 
-portable_realpath() {
-    if command -v realpath >/dev/null 2>&1; then
-        realpath "$1"
-    else
-        python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"
-    fi
-}
+# Shared helpers: see tools/_get_common.sh.
+_get_common="$(dirname "${BASH_SOURCE[0]}")/_get_common.sh"
+if [ ! -f "$_get_common" ]; then
+    echo "ERROR: $_get_common is missing; use a complete PROTEUS checkout." >&2
+    exit 1
+fi
+source "$_get_common"
 
 # Path to PROTEUS folder
-root=$(dirname $(portable_realpath $0))
-root=$(portable_realpath "$root/..")
+root="$proteus_root"
 
 # Paired-branch detection. When PROTEUS is on a feature branch and Zalmoxis has
 # a branch of the same name, install that Zalmoxis branch so CI exercises the
@@ -40,36 +39,15 @@ if [ -z "$proteus_branch" ]; then
     proteus_branch=$(git -C "$root" rev-parse --abbrev-ref HEAD 2>/dev/null)
 fi
 
-# Refuse to delete a checkout holding local work unless --force is given.
-# Keep this guard in sync across the get_* scripts that refresh checkouts.
-# Guarded states: modified tracked files, and commits not on any remote.
-# Untracked files (build artifacts, egg-info) do not block the refresh.
-force=false
-for arg in "$@"; do
-    [ "$arg" = "--force" ] && force=true
-done
+get_parse_args "$@"
 workpath=$root/Zalmoxis/
-if [ -d "$workpath/.git" ] && [ "$force" != true ]; then
-    dirty=$(git -C "$workpath" status --porcelain --untracked-files=no 2>/dev/null | head -1)
-    unpushed=$(git -C "$workpath" log HEAD --not --remotes --oneline 2>/dev/null | head -1)
-    if [ -n "$dirty" ] || [ -n "$unpushed" ]; then
-        echo "ERROR: $workpath has uncommitted changes or commits not on a remote." >&2
-        echo "       Refusing to delete it. Commit and push your work, or run" >&2
-        echo "       bash tools/get_zalmoxis.sh --force  to discard the checkout." >&2
-        exit 1
-    fi
-fi
+guard_dirty_checkout "$workpath" get_zalmoxis.sh
 
 # Make room
 rm -rf $workpath
 
 # Check SSH access to GitHub
-ssh -T git@github.com
-if [ $? -eq 1 ]; then
-    use_ssh=true
-else
-    use_ssh=false
-fi
+use_ssh=$(github_use_ssh)
 
 # Download
 echo "Cloning from GitHub"


### PR DESCRIPTION
## Description

Each `tools/get_*.sh` carried its own copy of the same shell: `portable_realpath` in 9 scripts, the dirty-checkout guard in 7, the `--force` split in 6, the GitHub SSH probe in 4, the repo-root derivation in 12. A fix to one copy left the rest untouched, which is why #862 had to patch the same four lines nine times. This is the extraction Harrison asked for in that review.

`tools/_get_common.sh` now holds one copy of each. Every script sources it through `$(dirname "${BASH_SOURCE[0]}")` and stops if it is missing, since half of them set no `-e` and would otherwise run on with `proteus_root` empty and their work path at the filesystem root. Per-script differences became parameters rather than separate copies: `guard_dirty_checkout` takes a git pathspec, so SOCRATES still excludes its regenerable `make/Mk_cmd`, and `get_parse_args` reports both the `--force` switch and the optional install path.

Intended behaviour changes:

- A destination that does not exist yet now resolves. #862 has since merged its nine copies of that fix; this branch keeps the behaviour in the library's single copy, and drops the test that pinned the nine copies as identical text in favour of two invariants: no script defines a helper privately, and every caller sources the library first.
- `get_agni.sh` and `get_spider.sh` resolve the checkout root through symlinks, as the other nine already did.
- The guard no longer pipes its probes into `head`. A checkout git cannot read (unborn HEAD, incomplete `.git`) used to stop two scripts with no message and be deleted by the other six; it is now kept with the reason named.
- The SOCRATES cache key in the CI action hashes the library too, otherwise a change to a helper restores a build tree made by the old script.

Also merged from main: `get_obliqua.sh`, which arrived with its own root derivation and pin lookup, now sources the library, and a second derivation of the checkout root is flagged by the invariant, since that copy carried no helper name for the existing checks to catch.

Scripts: 397 lines removed, 110 added. Library: 167 lines. Docs: a "Module install scripts" section in `development_standards.md`.

## Validation of changes

macOS 26.6.2 (arm64), bash 3.2.57 (the only bash on PATH, so the bash 3.2 target is what ran), Python 3.12.

- Every script ran whole against stubbed `git` and `ssh` in a throwaway checkout, with the SSH probe accepting and refusing, on this branch and on `main`. All clone destinations and transports match, except the two intended cases above. `PETSC_DIR`, `PETSC_ARCH` and the SPIDER default destination are identical.
- `tests/tools/test_install_scripts.py` sources the shipped library instead of copying shell into the tests; helper cases run under both a plain shell and `set -euo pipefail`. Two invariants replace #862's stopgap: no script carries a private copy of a helper, and every caller sources the library first. Each invariant case was checked against the mutation it targets and fails under it.
- `pytest tests/tools/`: 275 passed. `pytest -m "unit and not skip and not slow and not integration"`: 3327 passed, 47 skipped, 9 failed, the same 9 failing on `main` in this environment (`tests/atmos_clim/test_janus.py`).
- `ruff check`/`ruff format --check`, `bash tools/validate_test_structure.sh`, `bash -n` on every script: clean.

Not covered: no real clone or build (git, ssh and the compilers were stubbed); GNU `realpath` not exercised on Linux; `shellcheck` not installed here.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required (none changed)

