### PR TITLE
Pin gcc to keep SOCRATES shim symbols exported on macOS CI

### DIFF
--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -586,7 +586,26 @@ runs:
       run: |
         export RAD_DIR="$GITHUB_WORKSPACE/socrates"
         shim="$RAD_DIR/julia/lib/libSOCRATES_C.so"
+        obj="$RAD_DIR/julia/lib/Utilities_CF.o"
         echo "RAD_DIR=$RAD_DIR"
+        echo "-- gfortran --version --"
+        gfortran --version | head -n 1 || echo "(gfortran not on PATH)"
+        echo "-- SOCRATES tree revision vs pin --"
+        git -C "$RAD_DIR" rev-parse HEAD 2>&1 || echo "(not a git checkout / rev-parse failed)"
+        cat "$RAD_DIR/version" 2>&1 || echo "(no version file)"
+        echo "-- RAD_DIR/bin/Mk_cmd (compiler flags SOCRATES's own configure wrote) --"
+        if [ -f "$RAD_DIR/bin/Mk_cmd" ]; then
+          echo "present:"
+          cat "$RAD_DIR/bin/Mk_cmd"
+        else
+          echo "(no $RAD_DIR/bin/Mk_cmd; Makefile's -include finds nothing and falls back to bare gfortran)"
+        fi
+        echo "-- grep -n PS_real_kind_bytes socrates/julia/src/Utilities_CF.f90 --"
+        grep -n PS_real_kind_bytes "$RAD_DIR/julia/src/Utilities_CF.f90" || echo "(symbol absent from source)"
+        echo "-- nm -g $obj | grep -i real_kind --"
+        nm -g "$obj" 2>&1 | grep -i real_kind || echo "(not found / nm failed on $obj)"
+        echo "-- nm -g $shim | grep -i real_kind --"
+        nm -g "$shim" 2>&1 | grep -i real_kind || echo "(not found / nm failed on $shim)"
         echo "-- nm -gU $shim | grep PS_real_kind_bytes --"
         nm -gU "$shim" 2>&1 | grep PS_real_kind_bytes || echo "(not found / nm failed on $shim)"
         echo "-- nm -gU $RAD_DIR/bin/radlib.a | grep PS_real_kind_bytes --"

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -606,9 +606,10 @@ runs:
       run: |
         set -euo pipefail
         shim="$GITHUB_WORKSPACE/socrates/julia/lib/libSOCRATES_C.so"
-        if ! nm -gU "$shim" 2>&1 | grep -q PS_real_kind_bytes; then
+        symbols="$(nm -gU "$shim" 2>&1)"
+        if ! grep -q PS_real_kind_bytes <<<"$symbols"; then
           echo "PS_real_kind_bytes is not an external symbol in $shim" >&2
-          nm -gU "$shim" 2>&1 | grep -i real_kind >&2 || echo "(no real_kind symbol found at all)" >&2
+          grep -i real_kind <<<"$symbols" >&2 || echo "(no real_kind symbol found at all)" >&2
           exit 1
         fi
         echo "PS_real_kind_bytes confirmed exported in $shim"

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -180,11 +180,13 @@ runs:
       run: |
         set -euo pipefail
         source "${{ github.action_path }}/retry-with-timeout.sh"
-        # gcc is pinned to the last release before Homebrew's Darwin driver
-        # stopped exporting SOCRATES's dlsym-visible shim symbols. Formulae
-        # must live in a tap, so the formula is fetched into a throwaway tap;
-        # pinned before netcdf-fortran so its gcc dependency resolves to it.
-        gcc_formula_url="https://raw.githubusercontent.com/Homebrew/homebrew-core/4509561/Formula/g/gcc.rb"
+        # This gcc revision's Darwin driver exports SOCRATES's dlsym-visible
+        # shim symbols; a newer gcc drops them, so gcc stays pinned here.
+        # Formulae must live in a tap, so the formula is fetched into a
+        # throwaway tap; pinned before netcdf-fortran so its gcc dependency
+        # resolves to it. Commit 4509561fedf07807c6b806f82551e5f8dac5e678
+        # provides gcc 16.1.0.
+        gcc_formula_url="https://raw.githubusercontent.com/Homebrew/homebrew-core/4509561fedf07807c6b806f82551e5f8dac5e678/Formula/g/gcc.rb"
         brew tap-new local/pinned-toolchain --no-git >/dev/null
         pinned_tap_formula_dir="$(brew --repository)/Library/Taps/local/homebrew-pinned-toolchain/Formula"
         retry_with_timeout "fetch pinned gcc formula" 60 10 "" \
@@ -197,14 +199,26 @@ runs:
         brew_rc=0
         retry_with_timeout "brew install gcc (pinned)" 240 10 "" \
           brew install --quiet local/pinned-toolchain/gcc || brew_rc=$?
-        gcc_version="$(brew list --versions gcc 2>/dev/null || true)"
-        case "$gcc_version" in
-          "gcc 16.1."*) : ;;
-          *)
-            echo "ERROR: brew install rc=$brew_rc, expected pinned gcc 16.1.x, got: '$gcc_version'" >&2
-            exit 1
-            ;;
+        # A prefix match on `brew list --versions gcc` false-fails once a
+        # second gcc keg coexists (unlink above does not remove the runner
+        # image's pre-existing keg), since the versions then print on one
+        # line in Cellar order, e.g. "gcc 15.2.0 16.1.0". Check the pinned
+        # version is present as its own token, and that it is the one
+        # actually linked.
+        gcc_versions="$(brew list --versions gcc 2>/dev/null || true)"
+        gcc_linked_keg="$(readlink "$(brew --prefix)/opt/gcc" 2>/dev/null || true)"
+        version_present=0
+        if tr ' ' '\n' <<<"$gcc_versions" | grep -qx '16\.1\..*'; then
+          version_present=1
+        fi
+        version_linked=0
+        case "$gcc_linked_keg" in
+          */gcc/16.1.*) version_linked=1 ;;
         esac
+        if [ "$version_present" -ne 1 ] || [ "$version_linked" -ne 1 ]; then
+          echo "ERROR: brew install rc=$brew_rc, expected pinned gcc 16.1.x installed and linked, got versions: '$gcc_versions', linked keg: '$gcc_linked_keg'" >&2
+          exit 1
+        fi
         brew pin local/pinned-toolchain/gcc
         retry_with_timeout "brew install" 240 10 "" \
           brew install --quiet netcdf netcdf-fortran openssl@3 || brew_rc=$?
@@ -606,7 +620,11 @@ runs:
       run: |
         set -euo pipefail
         shim="$GITHUB_WORKSPACE/socrates/julia/lib/libSOCRATES_C.so"
-        symbols="$(nm -gU "$shim" 2>&1)"
+        if ! symbols="$(nm -gU "$shim" 2>&1)"; then
+          echo "nm failed on $shim:" >&2
+          echo "$symbols" >&2
+          exit 1
+        fi
         if ! grep -q PS_real_kind_bytes <<<"$symbols"; then
           echo "PS_real_kind_bytes is not an external symbol in $shim" >&2
           grep -i real_kind <<<"$symbols" >&2 || echo "(no real_kind symbol found at all)" >&2

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -622,6 +622,13 @@ runs:
         grep -n PS_real_kind_bytes "$RAD_DIR/julia/src/Utilities_CF.f90" || echo "(symbol absent from source)"
         echo "-- nm -g $obj | grep -i real_kind --"
         nm_check "-g" "$obj" "obj, global symbols"
+        sym_name=$(nm -g "$obj" 2>&1 | grep -i real_kind | awk '{print $NF}' | head -n 1) || true
+        if [ -z "$sym_name" ]; then
+          sym_name="_PS_real_kind_bytes"
+          echo "(nm -g found no real_kind symbol in $obj; export-list probe falls back to $sym_name)"
+        else
+          echo "exact linker symbol name for the export list: $sym_name"
+        fi
         echo "-- nm -g $shim | grep -i real_kind --"
         nm_check "-g" "$shim" "shim, global symbols"
         echo "-- nm -gU $shim | grep PS_real_kind_bytes --"
@@ -678,6 +685,15 @@ runs:
             relink_probe "exported_symbol" "-Wl,-exported_symbol,_PS_real_kind_bytes"
             echo "-- relink probe: -Wl,-export_dynamic --"
             relink_probe "export_dynamic" "-Wl,-export_dynamic"
+            echo "-- relink probe: -Wl,-exported_symbols_list (list-file form, using $sym_name, verbose) --"
+            list_file="/tmp/relink-exported_symbols_list.txt"
+            printf '%s\n' "$sym_name" > "$list_file"
+            gfortran -shared $base_flags -Wl,-exported_symbols_list,"$list_file" -v -o /tmp/relink-exported_symbols_list.so $objs "$radlib" 2>&1 || echo "(verbose relink with export list failed, see output above)"
+            if [ -f /tmp/relink-exported_symbols_list.so ]; then
+              nm_check "" "/tmp/relink-exported_symbols_list.so" "relink exported_symbols_list"
+            else
+              echo "(relink exported_symbols_list produced no output file)"
+            fi
           fi
         else
           echo "(link-step probes are macOS-only; skipped on $(uname -s))"

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -31,13 +31,6 @@ inputs:
       data is downloaded (spectral file + minimal stellar spectrum).
     required: false
     default: 'false'
-  shim-diagnostics:
-    description: >
-      If 'true', log which libSOCRATES_C.so on disk exports
-      PS_real_kind_bytes, which file Julia's Libdl resolves, and any
-      other libSOCRATES_C* copies found on the Julia depot / load path.
-    required: false
-    default: 'false'
 
 outputs:
   rad-dir:
@@ -598,131 +591,27 @@ runs:
         julia --project=. deps/build.jl nodata
 
     # ------------------------------------------------------------------
-    # 7b. Shim diagnostics
+    # 7b. Verify the SOCRATES shim's symbol export (macOS only)
     # ------------------------------------------------------------------
-    # Prints which libSOCRATES_C.so on disk exports PS_real_kind_bytes,
-    # which file Julia's Libdl actually resolves and opens, and any other
-    # libSOCRATES_C* copies on the Julia depot or the restored SOCRATES
-    # tree that could shadow the intended one. Opt-in per caller via
-    # shim-diagnostics so it does not run on every setup-proteus job.
-    - name: Log AGNI shim diagnostics
-      if: inputs.shim-diagnostics == 'true' && runner.os == 'macOS'
+    # deps/build.jl above recompiles socrates/julia/lib/libSOCRATES_C.so on
+    # every run, regardless of the SOCRATES-build or Julia-depot cache
+    # state, so this check always sees the shim this job just built and
+    # cannot pass on a stale cached artifact. Guards against Homebrew's gcc
+    # Darwin driver dropping this symbol from the shim's external symbol
+    # table, which breaks Julia's dlsym lookup in AGNI; the gcc pin earlier
+    # in this action keeps it exported.
+    - name: Verify SOCRATES shim exports PS_real_kind_bytes (macOS)
+      if: runner.os == 'macOS'
       shell: bash
       run: |
-        export RAD_DIR="$GITHUB_WORKSPACE/socrates"
-        shim="$RAD_DIR/julia/lib/libSOCRATES_C.so"
-        obj="$RAD_DIR/julia/lib/Utilities_CF.o"
-        # nm's own exit status is checked separately from grep's match
-        # result, so a failed nm (bad file, wrong flag) is distinguishable
-        # from a clean run that simply found no match. The assignment sits
-        # in the if condition: this shell runs with GitHub Actions' default
-        # -eo pipefail, and a bare `out=$(nm ...)` would abort the step.
-        nm_check() {
-          local flags="$1" file="$2" label="$3" out rc
-          if out=$(nm $flags "$file" 2>&1); then
-            rc=0
-          else
-            rc=$?
-          fi
-          if [ "$rc" -ne 0 ]; then
-            echo "nm $flags $file ($label) exited $rc: $out"
-            return
-          fi
-          echo "$out" | grep -i real_kind || echo "(nm $flags $file ($label) ok, no real_kind match)"
-        }
-        echo "RAD_DIR=$RAD_DIR"
-        echo "-- gfortran --version --"
-        gfortran --version | head -n 1 || echo "(gfortran not on PATH)"
-        echo "-- SOCRATES tree revision vs pin --"
-        git -C "$RAD_DIR" rev-parse HEAD 2>&1 || echo "(not a git checkout / rev-parse failed)"
-        cat "$RAD_DIR/version" 2>&1 || echo "(no version file)"
-        echo "-- RAD_DIR/bin/Mk_cmd (compiler flags SOCRATES's own configure wrote) --"
-        if [ -f "$RAD_DIR/bin/Mk_cmd" ]; then
-          echo "present:"
-          cat "$RAD_DIR/bin/Mk_cmd"
-        else
-          echo "(no $RAD_DIR/bin/Mk_cmd; Makefile's -include finds nothing and falls back to bare gfortran)"
+        set -euo pipefail
+        shim="$GITHUB_WORKSPACE/socrates/julia/lib/libSOCRATES_C.so"
+        if ! nm -gU "$shim" 2>&1 | grep -q PS_real_kind_bytes; then
+          echo "PS_real_kind_bytes is not an external symbol in $shim" >&2
+          nm -gU "$shim" 2>&1 | grep -i real_kind >&2 || echo "(no real_kind symbol found at all)" >&2
+          exit 1
         fi
-        echo "-- grep -n PS_real_kind_bytes socrates/julia/src/Utilities_CF.f90 --"
-        grep -n PS_real_kind_bytes "$RAD_DIR/julia/src/Utilities_CF.f90" || echo "(symbol absent from source)"
-        echo "-- nm -g $obj | grep -i real_kind --"
-        nm_check "-g" "$obj" "obj, global symbols"
-        sym_name=$(nm -g "$obj" 2>&1 | grep -i real_kind | awk '{print $NF}' | head -n 1) || true
-        if [ -z "$sym_name" ]; then
-          sym_name="_PS_real_kind_bytes"
-          echo "(nm -g found no real_kind symbol in $obj; export-list probe falls back to $sym_name)"
-        else
-          echo "exact linker symbol name for the export list: $sym_name"
-        fi
-        echo "-- nm -g $shim | grep -i real_kind --"
-        nm_check "-g" "$shim" "shim, global symbols"
-        echo "-- nm -gU $shim | grep PS_real_kind_bytes --"
-        nm_check "-gU" "$shim" "shim, defined global symbols"
-        echo "-- nm -gU $RAD_DIR/bin/radlib.a | grep PS_real_kind_bytes --"
-        nm_check "-gU" "$RAD_DIR/bin/radlib.a" "radlib.a, defined global symbols"
-        echo "-- Julia-resolved shim path and dlsym(PS_real_kind_bytes) (matches AGNI's own load path) --"
-        julia -e '
-          using Libdl
-          h = dlopen(joinpath(ENV["RAD_DIR"], "julia/lib/libSOCRATES_C.so"))
-          println(dlpath(h))
-          sym = dlsym(h, :PS_real_kind_bytes; throw_error=false)
-          println(sym === nothing ? "dlsym(PS_real_kind_bytes) = not found" : "dlsym(PS_real_kind_bytes) = $sym")
-        ' || echo "(Julia dlopen/dlsym of the shim failed)"
-        echo "-- other libSOCRATES_C* files under the Julia depot (~/.julia) --"
-        find ~/.julia -name 'libSOCRATES_C*' 2>/dev/null || echo "(depot search failed)"
-        echo "-- other libSOCRATES_C* files under RAD_DIR --"
-        find "$RAD_DIR" -name 'libSOCRATES_C*' 2>/dev/null || echo "(RAD_DIR search failed)"
-        echo "-- DYLD_LIBRARY_PATH (macOS only, empty elsewhere) --"
-        echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH:-}"
-        if [ "$(uname -s)" = "Darwin" ]; then
-          echo "-- nm (no -g, all symbols) $shim | grep -i real_kind --"
-          nm_check "" "$shim" "shim, all symbols"
-          echo "-- dyld_info -exports $shim | grep -i real_kind --"
-          dyld_info -exports "$shim" 2>&1 | grep -i real_kind || echo "(not found / dyld_info failed on $shim)"
-          echo "-- toolchain identity --"
-          gfortran -print-prog-name=ld || echo "(gfortran -print-prog-name=ld failed)"
-          ld -v 2>&1 || echo "(ld -v failed)"
-          xcrun --show-sdk-version || echo "(xcrun --show-sdk-version failed)"
-          pkgutil --pkg-info=com.apple.pkg.CLTools_Executables || echo "(pkgutil CLTools_Executables lookup failed, CLT may be an Xcode install instead)"
-          echo "-- relink diagnostics (reproduce socrates/julia/lib/Makefile's link recipe) --"
-          objs=$(ls "$RAD_DIR"/julia/lib/*.o 2>/dev/null)
-          radlib="$RAD_DIR/bin/radlib.a"
-          base_flags="-O3 -Wall -fPIC -cpp -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/"
-          if [ -z "$objs" ]; then
-            echo "(no .o files under $RAD_DIR/julia/lib; skipping relink probes)"
-          else
-            echo "-- gfortran -shared -v re-link (full driver dump, shows the real ld invocation) --"
-            gfortran -shared $base_flags -v -o /tmp/relink-verbose.so $objs "$radlib" 2>&1 || echo "(verbose relink failed, see output above)"
-            relink_probe() {
-              local label="$1" extra="$2" out="/tmp/relink-${label}.so"
-              gfortran -shared $base_flags $extra -o "$out" $objs "$radlib" 2>&1 | tail -n 20 || true
-              if [ -f "$out" ]; then
-                nm_check "" "$out" "relink $label"
-              else
-                echo "(relink $label produced no output file)"
-              fi
-            }
-            echo "-- relink probe: baseline (no extra flag, control) --"
-            relink_probe "baseline" ""
-            echo "-- relink probe: -Wl,-ld_classic --"
-            relink_probe "ld_classic" "-Wl,-ld_classic"
-            echo "-- relink probe: -Wl,-exported_symbol,_PS_real_kind_bytes --"
-            relink_probe "exported_symbol" "-Wl,-exported_symbol,_PS_real_kind_bytes"
-            echo "-- relink probe: -Wl,-export_dynamic --"
-            relink_probe "export_dynamic" "-Wl,-export_dynamic"
-            echo "-- relink probe: -Wl,-exported_symbols_list (list-file form, using $sym_name, verbose) --"
-            list_file="/tmp/relink-exported_symbols_list.txt"
-            printf '%s\n' "$sym_name" > "$list_file"
-            gfortran -shared $base_flags -Wl,-exported_symbols_list,"$list_file" -v -o /tmp/relink-exported_symbols_list.so $objs "$radlib" 2>&1 || echo "(verbose relink with export list failed, see output above)"
-            if [ -f /tmp/relink-exported_symbols_list.so ]; then
-              nm_check "" "/tmp/relink-exported_symbols_list.so" "relink exported_symbols_list"
-            else
-              echo "(relink exported_symbols_list produced no output file)"
-            fi
-          fi
-        else
-          echo "(link-step probes are macOS-only; skipped on $(uname -s))"
-        fi
+        echo "PS_real_kind_bytes confirmed exported in $shim"
 
     # ------------------------------------------------------------------
     # 8. PROTEUS pip install (resolves PyPI + git deps in pyproject.toml)

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -31,6 +31,13 @@ inputs:
       data is downloaded (spectral file + minimal stellar spectrum).
     required: false
     default: 'false'
+  shim-diagnostics:
+    description: >
+      If 'true', log which libSOCRATES_C.so on disk exports
+      PS_real_kind_bytes, which file Julia's Libdl resolves, and any
+      other libSOCRATES_C* copies found on the Julia depot / load path.
+    required: false
+    default: 'false'
 
 outputs:
   rad-dir:
@@ -564,6 +571,38 @@ runs:
         fi
         julia --project=. -e 'using Pkg; Pkg.instantiate()'
         julia --project=. deps/build.jl nodata
+
+    # ------------------------------------------------------------------
+    # 7b. Shim diagnostics
+    # ------------------------------------------------------------------
+    # Prints which libSOCRATES_C.so on disk exports PS_real_kind_bytes,
+    # which file Julia's Libdl actually resolves and opens, and any other
+    # libSOCRATES_C* copies on the Julia depot or the restored SOCRATES
+    # tree that could shadow the intended one. Opt-in per caller via
+    # shim-diagnostics so it does not run on every setup-proteus job.
+    - name: Log AGNI shim diagnostics
+      if: inputs.shim-diagnostics == 'true'
+      shell: bash
+      run: |
+        export RAD_DIR="$GITHUB_WORKSPACE/socrates"
+        shim="$RAD_DIR/julia/lib/libSOCRATES_C.so"
+        echo "RAD_DIR=$RAD_DIR"
+        echo "-- nm -gU $shim | grep PS_real_kind_bytes --"
+        nm -gU "$shim" 2>&1 | grep PS_real_kind_bytes || echo "(not found / nm failed on $shim)"
+        echo "-- nm -gU $RAD_DIR/bin/radlib.a | grep PS_real_kind_bytes --"
+        nm -gU "$RAD_DIR/bin/radlib.a" 2>&1 | grep PS_real_kind_bytes || echo "(not found / nm failed on $RAD_DIR/bin/radlib.a)"
+        echo "-- Julia-resolved shim path (Libdl.dlopen/dlpath) --"
+        julia -e '
+          using Libdl
+          h = dlopen(joinpath(ENV["RAD_DIR"], "julia/lib/libSOCRATES_C.so"))
+          println(dlpath(h))
+        ' || echo "(Julia dlopen of the shim failed)"
+        echo "-- other libSOCRATES_C* files under the Julia depot (~/.julia) --"
+        find ~/.julia -name 'libSOCRATES_C*' 2>/dev/null || echo "(depot search failed)"
+        echo "-- other libSOCRATES_C* files under RAD_DIR --"
+        find "$RAD_DIR" -name 'libSOCRATES_C*' 2>/dev/null || echo "(RAD_DIR search failed)"
+        echo "-- DYLD_LIBRARY_PATH (macOS only, empty elsewhere) --"
+        echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH:-}"
 
     # ------------------------------------------------------------------
     # 8. PROTEUS pip install (resolves PyPI + git deps in pyproject.toml)

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -212,7 +212,7 @@ runs:
             exit 1
             ;;
         esac
-        brew pin gcc
+        brew pin local/pinned-toolchain/gcc
         retry_with_timeout "brew install" 240 10 "" \
           brew install --quiet netcdf netcdf-fortran openssl@3 || brew_rc=$?
         missing=()

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -187,9 +187,34 @@ runs:
       run: |
         set -euo pipefail
         source "${{ github.action_path }}/retry-with-timeout.sh"
+        # gcc is pinned to the last release before Homebrew's Darwin driver
+        # stopped exporting SOCRATES's dlsym-visible shim symbols. Formulae
+        # must live in a tap, so the formula is fetched into a throwaway tap;
+        # pinned before netcdf-fortran so its gcc dependency resolves to it.
+        gcc_formula_url="https://raw.githubusercontent.com/Homebrew/homebrew-core/4509561/Formula/g/gcc.rb"
+        brew tap-new local/pinned-toolchain --no-git >/dev/null
+        pinned_tap_formula_dir="$(brew --repository)/Library/Taps/local/homebrew-pinned-toolchain/Formula"
+        retry_with_timeout "fetch pinned gcc formula" 60 10 "" \
+          curl -fsSL -o "$pinned_tap_formula_dir/gcc.rb" "$gcc_formula_url"
+        # Unlink any gcc the runner image already ships (a different tap, same
+        # formula name) so linking the pinned keg below cannot hit a conflict.
+        if brew list --formula gcc >/dev/null 2>&1; then
+          brew unlink gcc >/dev/null 2>&1 || true
+        fi
         brew_rc=0
+        retry_with_timeout "brew install gcc (pinned)" 240 10 "" \
+          brew install --quiet local/pinned-toolchain/gcc || brew_rc=$?
+        gcc_version="$(brew list --versions gcc 2>/dev/null || true)"
+        case "$gcc_version" in
+          "gcc 16.1."*) : ;;
+          *)
+            echo "ERROR: brew install rc=$brew_rc, expected pinned gcc 16.1.x, got: '$gcc_version'" >&2
+            exit 1
+            ;;
+        esac
+        brew pin gcc
         retry_with_timeout "brew install" 240 10 "" \
-          brew install --quiet gcc netcdf netcdf-fortran openssl@3 || brew_rc=$?
+          brew install --quiet netcdf netcdf-fortran openssl@3 || brew_rc=$?
         missing=()
         for pkg in gcc netcdf netcdf-fortran openssl@3; do
           brew list "$pkg" >/dev/null 2>&1 || missing+=("$pkg")

--- a/.github/actions/setup-proteus/action.yml
+++ b/.github/actions/setup-proteus/action.yml
@@ -581,12 +581,30 @@ runs:
     # tree that could shadow the intended one. Opt-in per caller via
     # shim-diagnostics so it does not run on every setup-proteus job.
     - name: Log AGNI shim diagnostics
-      if: inputs.shim-diagnostics == 'true'
+      if: inputs.shim-diagnostics == 'true' && runner.os == 'macOS'
       shell: bash
       run: |
         export RAD_DIR="$GITHUB_WORKSPACE/socrates"
         shim="$RAD_DIR/julia/lib/libSOCRATES_C.so"
         obj="$RAD_DIR/julia/lib/Utilities_CF.o"
+        # nm's own exit status is checked separately from grep's match
+        # result, so a failed nm (bad file, wrong flag) is distinguishable
+        # from a clean run that simply found no match. The assignment sits
+        # in the if condition: this shell runs with GitHub Actions' default
+        # -eo pipefail, and a bare `out=$(nm ...)` would abort the step.
+        nm_check() {
+          local flags="$1" file="$2" label="$3" out rc
+          if out=$(nm $flags "$file" 2>&1); then
+            rc=0
+          else
+            rc=$?
+          fi
+          if [ "$rc" -ne 0 ]; then
+            echo "nm $flags $file ($label) exited $rc: $out"
+            return
+          fi
+          echo "$out" | grep -i real_kind || echo "(nm $flags $file ($label) ok, no real_kind match)"
+        }
         echo "RAD_DIR=$RAD_DIR"
         echo "-- gfortran --version --"
         gfortran --version | head -n 1 || echo "(gfortran not on PATH)"
@@ -603,25 +621,67 @@ runs:
         echo "-- grep -n PS_real_kind_bytes socrates/julia/src/Utilities_CF.f90 --"
         grep -n PS_real_kind_bytes "$RAD_DIR/julia/src/Utilities_CF.f90" || echo "(symbol absent from source)"
         echo "-- nm -g $obj | grep -i real_kind --"
-        nm -g "$obj" 2>&1 | grep -i real_kind || echo "(not found / nm failed on $obj)"
+        nm_check "-g" "$obj" "obj, global symbols"
         echo "-- nm -g $shim | grep -i real_kind --"
-        nm -g "$shim" 2>&1 | grep -i real_kind || echo "(not found / nm failed on $shim)"
+        nm_check "-g" "$shim" "shim, global symbols"
         echo "-- nm -gU $shim | grep PS_real_kind_bytes --"
-        nm -gU "$shim" 2>&1 | grep PS_real_kind_bytes || echo "(not found / nm failed on $shim)"
+        nm_check "-gU" "$shim" "shim, defined global symbols"
         echo "-- nm -gU $RAD_DIR/bin/radlib.a | grep PS_real_kind_bytes --"
-        nm -gU "$RAD_DIR/bin/radlib.a" 2>&1 | grep PS_real_kind_bytes || echo "(not found / nm failed on $RAD_DIR/bin/radlib.a)"
-        echo "-- Julia-resolved shim path (Libdl.dlopen/dlpath) --"
+        nm_check "-gU" "$RAD_DIR/bin/radlib.a" "radlib.a, defined global symbols"
+        echo "-- Julia-resolved shim path and dlsym(PS_real_kind_bytes) (matches AGNI's own load path) --"
         julia -e '
           using Libdl
           h = dlopen(joinpath(ENV["RAD_DIR"], "julia/lib/libSOCRATES_C.so"))
           println(dlpath(h))
-        ' || echo "(Julia dlopen of the shim failed)"
+          sym = dlsym(h, :PS_real_kind_bytes; throw_error=false)
+          println(sym === nothing ? "dlsym(PS_real_kind_bytes) = not found" : "dlsym(PS_real_kind_bytes) = $sym")
+        ' || echo "(Julia dlopen/dlsym of the shim failed)"
         echo "-- other libSOCRATES_C* files under the Julia depot (~/.julia) --"
         find ~/.julia -name 'libSOCRATES_C*' 2>/dev/null || echo "(depot search failed)"
         echo "-- other libSOCRATES_C* files under RAD_DIR --"
         find "$RAD_DIR" -name 'libSOCRATES_C*' 2>/dev/null || echo "(RAD_DIR search failed)"
         echo "-- DYLD_LIBRARY_PATH (macOS only, empty elsewhere) --"
         echo "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH:-}"
+        if [ "$(uname -s)" = "Darwin" ]; then
+          echo "-- nm (no -g, all symbols) $shim | grep -i real_kind --"
+          nm_check "" "$shim" "shim, all symbols"
+          echo "-- dyld_info -exports $shim | grep -i real_kind --"
+          dyld_info -exports "$shim" 2>&1 | grep -i real_kind || echo "(not found / dyld_info failed on $shim)"
+          echo "-- toolchain identity --"
+          gfortran -print-prog-name=ld || echo "(gfortran -print-prog-name=ld failed)"
+          ld -v 2>&1 || echo "(ld -v failed)"
+          xcrun --show-sdk-version || echo "(xcrun --show-sdk-version failed)"
+          pkgutil --pkg-info=com.apple.pkg.CLTools_Executables || echo "(pkgutil CLTools_Executables lookup failed, CLT may be an Xcode install instead)"
+          echo "-- relink diagnostics (reproduce socrates/julia/lib/Makefile's link recipe) --"
+          objs=$(ls "$RAD_DIR"/julia/lib/*.o 2>/dev/null)
+          radlib="$RAD_DIR/bin/radlib.a"
+          base_flags="-O3 -Wall -fPIC -cpp -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/"
+          if [ -z "$objs" ]; then
+            echo "(no .o files under $RAD_DIR/julia/lib; skipping relink probes)"
+          else
+            echo "-- gfortran -shared -v re-link (full driver dump, shows the real ld invocation) --"
+            gfortran -shared $base_flags -v -o /tmp/relink-verbose.so $objs "$radlib" 2>&1 || echo "(verbose relink failed, see output above)"
+            relink_probe() {
+              local label="$1" extra="$2" out="/tmp/relink-${label}.so"
+              gfortran -shared $base_flags $extra -o "$out" $objs "$radlib" 2>&1 | tail -n 20 || true
+              if [ -f "$out" ]; then
+                nm_check "" "$out" "relink $label"
+              else
+                echo "(relink $label produced no output file)"
+              fi
+            }
+            echo "-- relink probe: baseline (no extra flag, control) --"
+            relink_probe "baseline" ""
+            echo "-- relink probe: -Wl,-ld_classic --"
+            relink_probe "ld_classic" "-Wl,-ld_classic"
+            echo "-- relink probe: -Wl,-exported_symbol,_PS_real_kind_bytes --"
+            relink_probe "exported_symbol" "-Wl,-exported_symbol,_PS_real_kind_bytes"
+            echo "-- relink probe: -Wl,-export_dynamic --"
+            relink_probe "export_dynamic" "-Wl,-export_dynamic"
+          fi
+        else
+          echo "(link-step probes are macOS-only; skipped on $(uname -s))"
+        fi
 
     # ------------------------------------------------------------------
     # 8. PROTEUS pip install (resolves PyPI + git deps in pyproject.toml)

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -152,7 +152,10 @@ jobs:
       - uses: ./.github/actions/setup-proteus
         with:
           full-data: 'true'
+          shim-diagnostics: 'true'
       - name: Run integration tier (not slow)
+        env:
+          JULIA_DEBUG: loading
         run: |
           pytest tests/integration \
             -m "integration and not slow" \

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -152,10 +152,7 @@ jobs:
       - uses: ./.github/actions/setup-proteus
         with:
           full-data: 'true'
-          shim-diagnostics: 'true'
       - name: Run integration tier (not slow)
-        env:
-          JULIA_DEBUG: loading
         run: |
           pytest tests/integration \
             -m "integration and not slow" \


### PR DESCRIPTION
## Description
On macOS CI, a newer Homebrew gcc Darwin driver drops the SOCRATES shim's dlsym-visible symbols (`PS_real_kind_bytes`, `PS_create_StrDim`, ...) from `libSOCRATES_C.so`'s export table, so Julia's `dlsym` lookup in AGNI fails at runtime and the Integration and Slow tiers fail with `could not load symbol`.

This pins gcc to the homebrew-core formula revision whose Darwin driver exports those symbols, installed through a throwaway tap and verified to be both present and the linked keg before the dependent packages install. It also adds a macOS step that runs `nm -gU` on the freshly rebuilt shim and fails fast if `PS_real_kind_bytes` is no longer exported, so a future toolchain regression is caught at setup rather than deep in a test run.

## Validation of changes
I dispatched the full nightly science validation workflow against this branch (run 34328401618): all 21 jobs pass, including the macOS Integration tier and every Slow tier shard that previously failed on the `dlsym` lookup. The version gate and the shim symbol check were exercised on the GitHub-hosted macOS runner image.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
