### PR TITLE
Bump AGNI to restore the SOCRATES thermal source-function grid

### DIFF
--- a/docs/Reference/module_versions.md
+++ b/docs/Reference/module_versions.md
@@ -35,7 +35,7 @@ pinned commit.
 <!-- BEGIN GIT_TABLE -->
 | Module | Role | Pin | Docs |
 |--------|------|-----|------|
-| AGNI | Radiative-convective atmosphere (Julia) | [![AGNI](https://img.shields.io/badge/AGNI-c7ffdf00-green)](https://github.com/nichollsh/AGNI/commit/c7ffdf000a49439fc597eff3f586c2c54caba647){target="_blank" rel="noopener"} | [Docs](https://www.h-nicholls.space/AGNI/) |
+| AGNI | Radiative-convective atmosphere (Julia) | [![AGNI](https://img.shields.io/badge/AGNI-8a494d7c-green)](https://github.com/nichollsh/AGNI/commit/8a494d7c74db78163eba7354d78d1389e6f63072){target="_blank" rel="noopener"} | [Docs](https://www.h-nicholls.space/AGNI/) |
 | SOCRATES | Spectral radiative transfer (Fortran) | [![SOCRATES](https://img.shields.io/badge/SOCRATES-43b86d4d-green)](https://github.com/FormingWorlds/SOCRATES/commit/43b86d4d46dcb1fa2e94fb24b9246421a03a9acb){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SOCRATES/) |
 | SPIDER | Interior evolution (C, requires PETSc) | [![SPIDER](https://img.shields.io/badge/SPIDER-c9a3fd43-green)](https://github.com/FormingWorlds/SPIDER/commit/c9a3fd4301c7008291d4f4921506d36b6288f8ca){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/SPIDER/) |
 <!-- END GIT_TABLE -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,7 +277,7 @@ directory = "htmlcov"
 # Tracks nichollsh/AGNI main. Bump after every AGNI release that
 # PROTEUS depends on.
 url = "https://github.com/nichollsh/AGNI.git"
-ref = "c7ffdf000a49439fc597eff3f586c2c54caba647"
+ref = "8a494d7c74db78163eba7354d78d1389e6f63072"
 
 [tool.proteus.modules.socrates]
 # Spectral radiative transfer library (Fortran). Compiled in-place


### PR DESCRIPTION
## Description

Bump the AGNI pin from `c7ffdf00` to `8a494d7c` to restore the SOCRATES thermal source-function tabulation grid.

The nightly Integration tier fails on `test_transparent_banded_olr_recovers_blackbody_emission`: the banded transparent OLR at `T_surf = 1500 K` overshoots the black-body emission by about 0.073% (`F_olr` 287271.57 vs 287062.70 W/m^2, tolerance `RTOL_SOCRATES = 5e-4`), on both ubuntu and macos with an identical value, so it is not a toolchain effect. It traces to AGNI commit `66a61da0`, which coarsened the `prep_spec` thermal source-function grid from a roughly 3.25 K step to a 25 K step; the coarser tabulation raises the banded-RT interpolation error enough to tip this tolerance. AGNI restored a finer grid upstream (`ba7bec1e`, then `8a494d7c` at a 5 K step as a runtime-vs-accuracy compromise), so moving the pin forward to `8a494d7c` recovers the accuracy while keeping the hydrostatic-integration and spin parameters that the previous pin bump added. The SOCRATES pin is unchanged and still satisfies AGNI's minimum-version check.

## Validation of changes

Test configuration: Linux and macOS, Python 3.12, real SOCRATES spectral files.

Built AGNI at `8a494d7c` and ran `test_transparent_banded_olr_recovers_blackbody_emission`: it passes over the full surface-temperature sweep (1000, 1500, 2000, 3000 K), all inside `RTOL_SOCRATES`. The full AGNI integration tier (`-m 'integration and not slow'`) passes (44 of 44). The change to `pyproject.toml` is the single-line pin bump; the diff carries no other file. I confirmed by reverting only the thermal-grid constants in the previous pin that the test flips from failing to passing, which isolates the grid coarsening as the cause.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
