### PR TITLE
Recover from CVODE step-budget stalls by relaxing rtol

### DIFF
--- a/docs/Reference/module_versions.md
+++ b/docs/Reference/module_versions.md
@@ -22,7 +22,7 @@ in `[project] dependencies`. Click a badge to view the pinned release.
 | fwl-mors | Stellar evolution | [![fwl-mors](https://img.shields.io/badge/fwl--mors-%3E%3D26.01.02-blue)](https://pypi.org/project/fwl-mors/26.01.02/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/MORS/) |
 | fwl-calliope | Volatile outgassing | [![fwl-calliope](https://img.shields.io/badge/fwl--calliope-%3E%3D26.06.01-blue)](https://pypi.org/project/fwl-calliope/26.06.01/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/CALLIOPE/) |
 | fwl-zephyrus | Atmospheric escape | [![fwl-zephyrus](https://img.shields.io/badge/fwl--zephyrus-%3E%3D25.03.11-blue)](https://pypi.org/project/fwl-zephyrus/25.03.11/){target="_blank" rel="noopener"} | [GitHub](https://github.com/FormingWorlds/ZEPHYRUS) |
-| fwl-aragog | Interior thermal evolution | [![fwl-aragog](https://img.shields.io/badge/fwl--aragog-%3E%3D26.09.06-blue)](https://pypi.org/project/fwl-aragog/26.09.06/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/aragog/) |
+| fwl-aragog | Interior thermal evolution | [![fwl-aragog](https://img.shields.io/badge/fwl--aragog-%3E%3D26.09.09-blue)](https://pypi.org/project/fwl-aragog/26.09.09/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/aragog/) |
 | fwl-zalmoxis | Interior structure | [![fwl-zalmoxis](https://img.shields.io/badge/fwl--zalmoxis-%3E%3D26.07.17-blue)](https://pypi.org/project/fwl-zalmoxis/26.07.17/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/Zalmoxis/) |
 <!-- END PYPI_TABLE -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "fwl-mors>=26.01.02",
     "fwl-calliope>=26.06.01",
     "fwl-zephyrus>=25.03.11",
-    "fwl-aragog>=26.09.06",
+    "fwl-aragog>=26.09.09",
     # 26.07.17 reads the liquid EOS table for fully molten entropy
     # lookups, which the super-liquidus interior initial condition
     # requires (Zalmoxis #79), on top of the JAX structure path for

--- a/src/proteus/interior_energetics/aragog.py
+++ b/src/proteus/interior_energetics/aragog.py
@@ -1960,13 +1960,17 @@ class AragogRunner:
         return 'CVODE' if available else 'Radau'
 
     def _solve_with_retry(self, hf_row, interior_o) -> SolverOutput:
-        """Run aragog_solver.solve() with a dt-halving retry ladder.
+        """Run aragog_solver.solve() with a failure-mode-branched retry ladder.
 
-        On CVODE failure (status != 0), restore the entropy IC and
-        dSdr_cmb_init from before the attempt, halve the integration
-        interval, and retry. Up to ``max_attempts`` attempts; on final
-        failure, returns the SolverOutput from the last attempt
-        (caller propagates status to the helpfile via dt_actual).
+        On CVODE failure the recovery lever depends on the failure mode.
+        A CV_TOO_MUCH_WORK stall (cvode_flag == -1) is a stiffness /
+        step-budget problem, so recovery first raises the CVODE step
+        budget (max_steps), then relaxes rtol (bounded), and only then
+        halves the integration interval, over up to eight attempts. Every
+        other failure keeps the dt-halving plus atol-scaling ladder over
+        six attempts. Each retry restores the entropy IC and dSdr_cmb_init
+        from before the attempt. On final failure this raises RuntimeError
+        so the caller can apply its skip-step fallback.
 
         Parameters
         ----------
@@ -1983,6 +1987,10 @@ class AragogRunner:
         """
         solver = self.aragog_solver
         max_attempts = 6
+        # A CV_TOO_MUCH_WORK stall front-loads three non-dt attempts (raise
+        # max_steps, then relax rtol) before dt-halving starts, so its ladder
+        # runs longer than the other-mode ladder.
+        max_attempts_stiff = 8
         atol_sf_max = 5.0  # cap on atol scaling; tested 125x corrupted T_core
         # Scale the T_core-jump sanity threshold with planet mass, with a floor.
         # The early-evolution transient in T_core grows with planet mass because
@@ -2003,6 +2011,11 @@ class AragogRunner:
         sanity_dT_core = max(
             3000.0, 1500.0 * mass_tot
         )  # max plausible T_core change per retry [K]
+        # Coarse catastrophe-only conservation tripwire: reject a status=0
+        # solve whose residual |E_res| exceeds this fraction of the enthalpy
+        # the step moved. K=1e-9 sits about 7 orders above the ~2e-18 healthy
+        # floor, so it never rejects a healthy solve. Not a calibrated value.
+        E_res_tripwire_K = 1.0e-9
 
         # Capture IC for restoration on retry, and pre-call T_core for
         # the sanity check on retry success.
@@ -2033,15 +2046,36 @@ class AragogRunner:
         # Pre-rename helpfiles store this column as T_core; fall back so
         # resumed runs keep the jump guard on their first step.
         T_core_pre = float(hf_row.get('T_cmb', hf_row.get('T_core', 0.0)))
+        # Pre-solve frozen-mass mantle enthalpy, carried in the current row
+        # from the previous accepted step (mirrors T_core_pre). Denominator
+        # for the conservation tripwire; None or 0.0 disables it.
+        E_cons_pre = hf_row.get('E_state_cons_J', None)
 
         # Reset atol scale to 1.0 at the start of each coupling step
         # (cleared regardless of retry outcome at end of method)
         solver._atol_sf = 1.0
 
+        # Base CVODE controls captured before the first attempt and restored
+        # in the finally block. rtol is re-read inside solve() every call, so
+        # a per-attempt override on parameters.solver.rtol takes effect. The
+        # step budget is cached at solver construction and reset() does not
+        # re-read it, so the effective value is set on solver._max_steps
+        # directly. Caps bound how far the stiffness branch relaxes each.
+        base_rtol = float(solver.parameters.solver.rtol)
+        base_max_steps = int(getattr(solver, '_max_steps', solver.parameters.solver.max_steps))
+        # 10x rtol shifts Phi_global by ~3e-8 and T_core by 0 K on a recovered
+        # mush step and keeps |E_res/dE_cons| at ~2e-18, so the cap is tied to a
+        # measured accuracy impact, not a guess.
+        rtol_cap = 10.0 * base_rtol
+        max_steps_cap = 8 * base_max_steps
+
         out = None
         _diag_on = os.environ.get('PROTEUS_CI_NIGHTLY') == '1'
         try:
-            for attempt in range(1, max_attempts + 1):
+            # Range over the widest ladder. max_attempts holds the active
+            # budget (6, widened to max_attempts_stiff on a stiff failure)
+            # and drives the exhaustion check below.
+            for attempt in range(1, max_attempts_stiff + 1):
                 _t0 = time.perf_counter()
                 solver.solve()
                 _solve_wall = time.perf_counter() - _t0
@@ -2059,29 +2093,46 @@ class AragogRunner:
 
                 # Status check: did the solver accept the step?
                 if out.status == 0:
-                    # Sanity check: reject suspiciously large T_core jumps
-                    # that indicate the solver "succeeded" with garbage.
-                    # Applies on ALL attempts (not just retries):
-                    #   - chili_atolrelax showed atol_sf=125x corruption on
-                    #     a retry attempt
-                    #   - chili_n_maxsteps500k showed corruption on attempt 1
-                    #     when more step budget allowed CVODE to traverse a
-                    #     phase boundary in one shot
-                    # Either way, we want to reject the result and retry
-                    # with a smaller dt.
-                    T_core_post = float(out.T_core)
-                    # T_core_pre is 0 only on the very first solve, before any
-                    # converged core temperature exists to compare against, so
-                    # the jump guard is necessarily inactive on that one step.
-                    dT = abs(T_core_post - T_core_pre) if T_core_pre > 0 else 0.0
-                    if dT > sanity_dT_core:
+                    # Two orthogonal post-solve sanity guards. Both must pass
+                    # to accept the step; either trip falls through to the
+                    # retry ladder. sanity_reject_reason names the guard that
+                    # tripped for the exhaustion message.
+                    sanity_reject_reason = None
+
+                    # Guard 1: reject a status=0 solve whose CMB temperature
+                    # moved implausibly far. tcore_change_max is the intra-solve
+                    # maximum change, >= the endpoint change by construction;
+                    # fall back to the endpoint change on an older aragog.
+                    # Inactive whenever T_core_pre <= 0, which includes any row
+                    # missing both T_cmb and T_core, not only the first solve.
+                    tcore_change = getattr(out, 'tcore_change_max', None)
+                    if tcore_change is None:
+                        tcore_change = abs(float(out.T_core) - T_core_pre)
+                    tcore_change = float(tcore_change)
+                    dT = tcore_change if T_core_pre > 0 else 0.0
+                    # A relaxed rtol can return a non-finite T_core change, so
+                    # a non-finite dT fails the guard instead of passing.
+                    if not np.isfinite(dT) or dT > sanity_dT_core:
+                        sanity_reject_reason = (
+                            f'T_core changed by up to {dT:.1f} K '
+                            f'(>{sanity_dT_core:.0f} K sanity threshold)'
+                        )
+
+                    # Guard 2: coarse conservation tripwire on |E_res/dE_cons|.
+                    if sanity_reject_reason is None and self._conservation_tripwire_trips(
+                        out, E_cons_pre, E_res_tripwire_K
+                    ):
+                        sanity_reject_reason = (
+                            'the conservation residual exceeded the '
+                            f'{E_res_tripwire_K:.0e} tripwire'
+                        )
+
+                    if sanity_reject_reason is not None:
                         log.warning(
-                            'Aragog attempt %d returned status=0 but T_core '
-                            'jumped %.1f K (>%.0f K threshold). Treating as '
-                            'failure and continuing retry ladder.',
+                            'Aragog attempt %d returned status=0 but %s. '
+                            'Treating as failure and continuing retry ladder.',
                             attempt,
-                            dT,
-                            sanity_dT_core,
+                            sanity_reject_reason,
                         )
                         # Fall through to the retry/exhaustion branch below
                     else:
@@ -2097,18 +2148,30 @@ class AragogRunner:
                             )
                         return out
 
+                # Determine the failure mode from the raw CVODE flag. status
+                # stays scipy-compatible -1 for every CVODE failure, so it
+                # cannot separate a step-budget exhaustion (recover by more
+                # steps / looser rtol) from other failures (recover by a
+                # smaller dt). cvode_flag == -1 is the authoritative predicate;
+                # the name is the readable label. A status=0 result maps from
+                # cvode_flag in {0, 2} (ROOT_RETURN), so a guard trip routes to
+                # the dt-halving branch.
+                cvode_flag = int(getattr(out, 'cvode_flag', 0) or 0)
+                flag_name = str(getattr(out, 'cvode_flag_name', '') or '')
+                is_too_much_work = cvode_flag == -1 or flag_name == 'TOO_MUCH_WORK'
+                if is_too_much_work:
+                    max_attempts = max_attempts_stiff
+
                 if attempt >= max_attempts:
                     # status==0 here means the solver accepted every step but
-                    # each result was rejected for an over-threshold T_core
-                    # jump, so report that reason rather than the misleading
-                    # status=0.
+                    # a post-solve sanity guard rejected each result, so report
+                    # the guard that tripped rather than the misleading status=0.
                     if out.status == 0:
-                        reason = (
-                            'status=0 but the T_core jump exceeded the '
-                            f'{sanity_dT_core:.0f} K sanity threshold on every attempt'
-                        )
+                        reason = f'status=0 but {sanity_reject_reason} on every attempt'
                     else:
                         reason = f'{self._active_solver_name()} status={out.status}'
+                        if flag_name:
+                            reason += f' (cvode_flag={cvode_flag}, {flag_name})'
                     log.error(
                         'Aragog solver failed after %d attempts (%s). '
                         'Raising RuntimeError so wrapper can apply skip-step fallback.',
@@ -2120,24 +2183,66 @@ class AragogRunner:
                         f'after {attempt} attempts at t={hf_row.get("Time", 0.0):.3e} yr'
                     )
 
-                # Failure: halve dt AND relax atol (capped), restore state, retry.
-                # atol_sf increases linearly to atol_sf_max over attempts 2-3,
-                # then stays at the cap for further attempts. dt continues
-                # halving so additional attempts gain resolution, not looser
-                # tolerance.
-                dt_new = dt_requested * (0.5**attempt)
+                # atol_sf ramps to the cap over the early attempts and stays
+                # there; it runs in both branches. The failure mode picks the
+                # remaining levers. next_attempt is the attempt these settings
+                # configure.
                 atol_sf_new = min(atol_sf_max, 1.0 + (atol_sf_max - 1.0) * (attempt / 2.0))
-                log.warning(
-                    'Aragog solver failed at t=%.3e yr (status=%d, attempt %d/%d). '
-                    'Retrying with dt=%.3e yr, atol_sf=%.1fx (was dt=%.3e yr).',
-                    hf_row.get('Time', 0.0),
-                    out.status,
-                    attempt,
-                    max_attempts,
-                    dt_new,
-                    atol_sf_new,
-                    dt_requested,
-                )
+                next_attempt = attempt + 1
+                # dt of the attempt that just failed. A retry must never run
+                # coarser than it, so clamp the scheduled dt below.
+                dt_current = float(solver.parameters.solver.end_time) - t_start
+                if is_too_much_work:
+                    # Stiffness recovery. Raise the step budget first (wall-time
+                    # cost only, no accuracy loss), relax rtol second (bounded),
+                    # halve dt last. Attempts 2-4 hold dt and ramp max_steps and
+                    # rtol to their caps; attempts 5-8 hold the caps and halve dt.
+                    if next_attempt <= 4:
+                        ms_factor = 2 ** (next_attempt - 1)
+                        rtol_factor = {2: 2.0, 3: 5.0, 4: 10.0}[next_attempt]
+                        max_steps_new = min(max_steps_cap, base_max_steps * ms_factor)
+                        rtol_new = min(rtol_cap, base_rtol * rtol_factor)
+                        dt_new = dt_requested
+                    else:
+                        max_steps_new = max_steps_cap
+                        rtol_new = rtol_cap
+                        dt_new = dt_requested * (0.5 ** (next_attempt - 4))
+                    dt_new = min(dt_new, dt_current)
+                    if hasattr(solver, '_max_steps'):
+                        solver._max_steps = int(max_steps_new)
+                    solver.parameters.solver.rtol = rtol_new
+                    log.warning(
+                        'Aragog CV_TOO_MUCH_WORK at t=%.3e yr (attempt %d/%d). '
+                        'Retrying with max_steps=%d, rtol=%.2e, dt=%.3e yr, '
+                        'atol_sf=%.1fx (was dt=%.3e yr).',
+                        hf_row.get('Time', 0.0),
+                        attempt,
+                        max_attempts,
+                        int(max_steps_new),
+                        rtol_new,
+                        dt_new,
+                        atol_sf_new,
+                        dt_requested,
+                    )
+                else:
+                    # Other failure modes: halve dt so additional attempts gain
+                    # resolution, not looser tolerance. Restore base rtol and
+                    # step budget in case a prior attempt was the stiff branch.
+                    dt_new = min(dt_requested * (0.5**attempt), dt_current)
+                    solver.parameters.solver.rtol = base_rtol
+                    if hasattr(solver, '_max_steps'):
+                        solver._max_steps = base_max_steps
+                    log.warning(
+                        'Aragog solver failed at t=%.3e yr (status=%d, attempt %d/%d). '
+                        'Retrying with dt=%.3e yr, atol_sf=%.1fx (was dt=%.3e yr).',
+                        hf_row.get('Time', 0.0),
+                        out.status,
+                        attempt,
+                        max_attempts,
+                        dt_new,
+                        atol_sf_new,
+                        dt_requested,
+                    )
                 solver.parameters.solver.start_time = t_start
                 solver.parameters.solver.end_time = t_start + dt_new
                 solver._atol_sf = atol_sf_new
@@ -2154,6 +2259,12 @@ class AragogRunner:
         finally:
             # Always reset atol_sf so subsequent coupling steps start at 1.0x
             solver._atol_sf = 1.0
+            # Restore the base CVODE controls the stiffness branch may have
+            # raised, so the next coupling step starts from the configured
+            # rtol and step budget.
+            solver.parameters.solver.rtol = base_rtol
+            if hasattr(solver, '_max_steps'):
+                solver._max_steps = base_max_steps
             # Release the dSdr_cmb override so the NEXT coupling step's
             # set_initial_entropy can hot-start from its own _solution
             # (which, after a successful retry, holds the accepted
@@ -2166,6 +2277,55 @@ class AragogRunner:
                 solver._dSdr_cmb_init = None
 
         return out
+
+    @staticmethod
+    def _conservation_tripwire_trips(out: SolverOutput, E_cons_pre, K: float) -> bool:
+        """Test a status=0 solve against a coarse energy-conservation tripwire.
+
+        The tripwire is the dimensionless ratio ``|E_res / dE_cons|``, where
+        ``E_res`` is the solver self-consistency residual
+        (``step_solver_residual_J``) and ``dE_cons`` is the frozen-mass mantle
+        enthalpy the step moved (end ``E_state_cons`` minus the pre-solve value
+        carried in the helpfile row). A healthy solve sits at ~2e-18 for a tight
+        or a 10x-relaxed rtol alike, so K=1e-9 sits about 7 orders above that
+        floor. This catches only a gross conservation blow-up; it is not a
+        calibrated threshold. A calibration against a real-stall residual
+        distribution is a follow-up.
+
+        The test never rejects when it cannot form a valid ratio: a missing
+        residual, a missing or zero baseline enthalpy, or a zero or non-finite
+        step move all return False (skip). A non-finite ratio rejects, matching
+        the T_core guard: reject when ``not (ratio <= K)``.
+
+        Parameters
+        ----------
+        out : SolverOutput
+            The accepted (status=0) solver output under test.
+        E_cons_pre : float or None
+            Pre-solve frozen-mass mantle enthalpy [J]. None or 0.0 disables
+            the tripwire.
+        K : float
+            Dimensionless tripwire ceiling on ``|E_res / dE_cons|``.
+
+        Returns
+        -------
+        bool
+            True to reject the solve, False to skip the tripwire or pass it.
+        """
+        e_res = getattr(out, 'step_solver_residual_J', None)
+        e_cons_end = getattr(out, 'E_state_cons', None)
+        if e_res is None or e_cons_end is None or E_cons_pre is None:
+            return False
+        try:
+            e_res = float(e_res)
+            base = float(E_cons_pre)
+            dE_cons = float(e_cons_end) - base
+        except (TypeError, ValueError):
+            return False
+        if base == 0.0 or dE_cons == 0.0 or not np.isfinite(dE_cons):
+            return False
+        ratio = abs(e_res) / abs(dE_cons)
+        return not (ratio <= K)
 
     @staticmethod
     def _build_helpfile_output(

--- a/src/proteus/interior_energetics/aragog.py
+++ b/src/proteus/interior_energetics/aragog.py
@@ -1989,9 +1989,22 @@ class AragogRunner:
         -----
         The attempt budget is a monotonic ratchet: the first CV_TOO_MUCH_WORK
         failure widens max_attempts from six to eight for the rest of the call
-        and it never narrows. The stiffness ramp is indexed by stiff_seen, the
+        and it never narrows. A later non-stiff failure in the same call is
+        still part of the stiff recovery, so it keeps the wider budget rather
+        than reverting to six. The stiffness ramp is indexed by stiff_seen, the
         running count of CV_TOO_MUCH_WORK attempts, so a late or intermittent
-        stiff switch still climbs the ramp from its first rung.
+        stiff switch still climbs the ramp from its first rung; the non-stiff
+        ramp is indexed by the symmetric other_seen count.
+
+        Per attempt the guard checks only that T_core is finite and that its
+        jump is plausible. Energy conservation is recorded in the coupler-level
+        ``E_residual_cons_frac`` diagnostic column, which is not asserted per
+        run; the rtol relaxation was spot-checked once to move it from 1.46e-4
+        to 1.53e-4 at 10x rtol (about 65x below its ~1% scale), not verified
+        automatically every run. A field-level bounds check on the mush entropy
+        and melt fraction (melt fraction in [0, 1], T > 0) is a possible
+        follow-up; the relaxation is measured-safe on this recovery path and the
+        guard only fires on a stall.
         """
         solver = self.aragog_solver
         max_attempts = 6
@@ -2062,23 +2075,28 @@ class AragogRunner:
         # directly.
         base_rtol = float(solver.parameters.solver.rtol)
         base_max_steps = int(getattr(solver, '_max_steps', solver.parameters.solver.max_steps))
-        # Stiffness ramp schedule, indexed by stiff_seen (the running count of
-        # CV_TOO_MUCH_WORK attempts). Rungs 1-3 raise the step budget and relax
-        # rtol; rungs 4+ hold the ceiling and halve dt. The caps derive from the
-        # top rung, so the dt-halving rungs hold exactly there.
-        stiff_ms_factor = {1: 2, 2: 4, 3: 8}
-        stiff_rtol_factor = {1: 2.0, 2: 5.0, 3: 10.0}
-        max_steps_cap = base_max_steps * max(stiff_ms_factor.values())
-        # 10x rtol moves the coupler conservation metric E_residual_cons_frac
-        # from 1.46e-4 to 1.53e-4 on a recovered mush step (about 65x below its
-        # ~1% structural floor) and shifts Phi_global by ~3e-8 with T_core
-        # unchanged, so the top rung is a measured accuracy bound, not a guess.
-        rtol_cap = base_rtol * max(stiff_rtol_factor.values())
+        # Stiffness ramp rungs as (max_steps factor, rtol factor), ordered from
+        # rung 1. Rungs on the ramp raise the step budget and relax rtol; rungs
+        # past the last one hold the ceiling and halve dt. The caps and the rung
+        # count both derive from this tuple, so an added rung is picked up in
+        # every place and the schedule stays a single source of truth.
+        stiff_ramp = ((2, 2.0), (4, 5.0), (8, 10.0))
+        n_ramp_rungs = len(stiff_ramp)
+        max_steps_cap = base_max_steps * stiff_ramp[-1][0]
+        # A one-off spot-check: 10x rtol moves the coupler conservation metric
+        # E_residual_cons_frac from 1.46e-4 to 1.53e-4 on a recovered mush step
+        # (about 65x below its ~1% structural floor) and shifts Phi_global by
+        # ~3e-8 with T_core unchanged. It is not asserted per run; a
+        # docs/Validation/interior_energetics/aragog.md harness is a follow-up.
+        rtol_cap = base_rtol * stiff_ramp[-1][1]
 
         out = None
-        # Running count of CV_TOO_MUCH_WORK attempts, indexes the stiffness
-        # ramp so it climbs from rung 1 whenever stiffness first appears.
+        # Running counts of CV_TOO_MUCH_WORK and other-mode attempts. stiff_seen
+        # indexes the stiffness ramp so it climbs from rung 1 whenever stiffness
+        # first appears; other_seen indexes the non-stiff atol/dt ramp so a
+        # switch back to non-stiff does not jump straight to the atol cap.
         stiff_seen = 0
+        other_seen = 0
         _diag_on = os.environ.get('PROTEUS_CI_NIGHTLY') == '1'
         try:
             # Range over the widest ladder. max_attempts holds the active
@@ -2108,24 +2126,32 @@ class AragogRunner:
                     # exhaustion message.
                     sanity_reject_reason = None
 
-                    # Reject a status=0 solve whose CMB temperature moved
-                    # implausibly far. tcore_change_max is the intra-solve
-                    # maximum change, >= the endpoint change by construction;
-                    # fall back to the endpoint change on an older aragog.
-                    # Inactive whenever T_core_pre <= 0, which includes any row
-                    # missing both T_cmb and T_core, not only the first solve.
-                    tcore_change = getattr(out, 'tcore_change_max', None)
-                    if tcore_change is None:
-                        tcore_change = abs(float(out.T_core) - T_core_pre)
-                    tcore_change = float(tcore_change)
-                    dT = tcore_change if T_core_pre > 0 else 0.0
-                    # A relaxed rtol can return a non-finite T_core change, so
-                    # a non-finite dT fails the guard instead of passing.
-                    if not np.isfinite(dT) or dT > sanity_dT_core:
-                        sanity_reject_reason = (
-                            f'T_core changed by up to {dT:.1f} K '
-                            f'(>{sanity_dT_core:.0f} K sanity threshold)'
-                        )
+                    # Reject a status=0 solve with a non-finite or implausibly
+                    # large CMB temperature. The finiteness check always runs,
+                    # so a corrupted relaxed-rtol solve never passes even on the
+                    # first solve. The jump-magnitude check needs a pre-solve
+                    # reference, so it is inactive when T_core_pre <= 0 (a row
+                    # missing both T_cmb and T_core, which includes solve one).
+                    tcore_endpoint = float(out.T_core)
+                    # tcore_change_max is the intra-solve maximum change,
+                    # >= the endpoint change by construction; on an older
+                    # aragog it is absent and the endpoint change is used.
+                    tcore_change_max = getattr(out, 'tcore_change_max', None)
+                    finite_ok = np.isfinite(tcore_endpoint)
+                    if tcore_change_max is not None:
+                        finite_ok = finite_ok and np.isfinite(float(tcore_change_max))
+                    if not finite_ok:
+                        sanity_reject_reason = 'T_core is non-finite'
+                    elif T_core_pre > 0:
+                        if tcore_change_max is not None:
+                            dT = float(tcore_change_max)
+                        else:
+                            dT = abs(tcore_endpoint - T_core_pre)
+                        if dT > sanity_dT_core:
+                            sanity_reject_reason = (
+                                f'T_core changed by up to {dT:.1f} K '
+                                f'(>{sanity_dT_core:.0f} K sanity threshold)'
+                            )
 
                     if sanity_reject_reason is not None:
                         log.warning(
@@ -2162,6 +2188,8 @@ class AragogRunner:
                 if is_too_much_work:
                     max_attempts = max_attempts_stiff
                     stiff_seen += 1
+                else:
+                    other_seen += 1
 
                 if attempt >= max_attempts:
                     # status==0 here means the solver accepted every step but
@@ -2191,21 +2219,25 @@ class AragogRunner:
                     # Stiffness recovery, indexed by stiff_seen so it climbs
                     # from rung 1 whenever stiffness first appears. Raise the
                     # step budget first (wall-time cost only, no accuracy loss),
-                    # relax rtol second (bounded), halve dt last. Rungs 1-3 hold
-                    # dt and ramp max_steps and rtol to the ceiling; rungs 4+
-                    # hold the ceiling and halve dt. atol_sf stays at 1.0 so the
-                    # ramp relaxes rtol alone, the measured lever.
+                    # relax rtol second (bounded), halve dt last. Ramp rungs hold
+                    # dt and raise max_steps and rtol to the ceiling; rungs past
+                    # the ramp hold the ceiling and halve the just-failed dt.
+                    # atol_sf stays at 1.0 so the ramp relaxes rtol alone.
                     rung = stiff_seen
                     atol_sf_new = 1.0
-                    if rung <= 3:
-                        max_steps_new = base_max_steps * stiff_ms_factor[rung]
-                        rtol_new = base_rtol * stiff_rtol_factor[rung]
-                        dt_new = dt_requested
+                    if rung <= n_ramp_rungs:
+                        ms_factor, rtol_factor = stiff_ramp[rung - 1]
+                        max_steps_new = base_max_steps * ms_factor
+                        rtol_new = base_rtol * rtol_factor
+                        # Hold dt, but never run coarser than the failed attempt.
+                        dt_new = min(dt_requested, dt_current)
                     else:
                         max_steps_new = max_steps_cap
                         rtol_new = rtol_cap
-                        dt_new = dt_requested * (0.5 ** (rung - 3))
-                    dt_new = min(dt_new, dt_current)
+                        # Halve the just-failed dt so a stiff dt attempt is
+                        # always strictly smaller than the attempt it retries,
+                        # even after prior non-stiff dt shrinking.
+                        dt_new = dt_current * 0.5
                     if hasattr(solver, '_max_steps'):
                         solver._max_steps = int(max_steps_new)
                     solver.parameters.solver.rtol = rtol_new
@@ -2224,11 +2256,14 @@ class AragogRunner:
                     )
                 else:
                     # Other failure modes: halve dt so additional attempts gain
-                    # resolution, not looser tolerance. Ramp atol_sf here only.
-                    # Restore base rtol and step budget in case a prior attempt
-                    # was the stiff branch.
-                    atol_sf_new = min(atol_sf_max, 1.0 + (atol_sf_max - 1.0) * (attempt / 2.0))
-                    dt_new = min(dt_requested * (0.5**attempt), dt_current)
+                    # resolution, not looser tolerance. Ramp atol_sf here only,
+                    # indexed by other_seen so a switch back from the stiff
+                    # branch does not jump straight to the atol cap. Restore base
+                    # rtol and step budget in case a prior attempt was stiff.
+                    atol_sf_new = min(
+                        atol_sf_max, 1.0 + (atol_sf_max - 1.0) * (other_seen / 2.0)
+                    )
+                    dt_new = min(dt_requested * (0.5**other_seen), dt_current)
                     solver.parameters.solver.rtol = base_rtol
                     if hasattr(solver, '_max_steps'):
                         solver._max_steps = base_max_steps
@@ -2409,7 +2444,7 @@ class AragogRunner:
             # into the conservation residual (which uses the live-density
             # variants above); ``E_state_cons_J`` is likewise an enthalpy
             # diagnostic, not the conservation-grade quantity. Machine-precision
-            # conservation is carried by the solver-residual column below.
+            # conservation is tracked by the solver-residual column below.
             'step_dE_Q_radio_cons_J': out.step_dE_Q_radio_cons_J,
             'step_dE_Q_tidal_cons_J': out.step_dE_Q_tidal_cons_J,
             # Per-call entropy-equation self-consistency residual [J].
@@ -2417,7 +2452,8 @@ class AragogRunner:
             # The discrete flux divergence telescopes to the boundary
             # fluxes, so it is machine-zero by construction; a non-zero
             # value flags a divergence-assembly bug, not time-integration
-            # quality (that is carried by ``E_residual_cons_frac``).
+            # quality (that is recorded in ``E_residual_cons_frac``, a
+            # write-only diagnostic column that is not asserted per run).
             'step_solver_residual_J': out.step_solver_residual_J,
             # Per-call adiabatic compression work [J] from the structure
             # re-solve that preceded this step. Informational only: the

--- a/src/proteus/interior_energetics/aragog.py
+++ b/src/proteus/interior_energetics/aragog.py
@@ -1984,6 +1984,14 @@ class AragogRunner:
         SolverOutput
             Solver state from the first successful attempt, or from the
             last attempt if all failed.
+
+        Notes
+        -----
+        The attempt budget is a monotonic ratchet: the first CV_TOO_MUCH_WORK
+        failure widens max_attempts from six to eight for the rest of the call
+        and it never narrows. The stiffness ramp is indexed by stiff_seen, the
+        running count of CV_TOO_MUCH_WORK attempts, so a late or intermittent
+        stiff switch still climbs the ramp from its first rung.
         """
         solver = self.aragog_solver
         max_attempts = 6
@@ -2011,11 +2019,6 @@ class AragogRunner:
         sanity_dT_core = max(
             3000.0, 1500.0 * mass_tot
         )  # max plausible T_core change per retry [K]
-        # Coarse catastrophe-only conservation tripwire: reject a status=0
-        # solve whose residual |E_res| exceeds this fraction of the enthalpy
-        # the step moved. K=1e-9 sits about 7 orders above the ~2e-18 healthy
-        # floor, so it never rejects a healthy solve. Not a calibrated value.
-        E_res_tripwire_K = 1.0e-9
 
         # Capture IC for restoration on retry, and pre-call T_core for
         # the sanity check on retry success.
@@ -2046,10 +2049,6 @@ class AragogRunner:
         # Pre-rename helpfiles store this column as T_core; fall back so
         # resumed runs keep the jump guard on their first step.
         T_core_pre = float(hf_row.get('T_cmb', hf_row.get('T_core', 0.0)))
-        # Pre-solve frozen-mass mantle enthalpy, carried in the current row
-        # from the previous accepted step (mirrors T_core_pre). Denominator
-        # for the conservation tripwire; None or 0.0 disables it.
-        E_cons_pre = hf_row.get('E_state_cons_J', None)
 
         # Reset atol scale to 1.0 at the start of each coupling step
         # (cleared regardless of retry outcome at end of method)
@@ -2060,16 +2059,26 @@ class AragogRunner:
         # a per-attempt override on parameters.solver.rtol takes effect. The
         # step budget is cached at solver construction and reset() does not
         # re-read it, so the effective value is set on solver._max_steps
-        # directly. Caps bound how far the stiffness branch relaxes each.
+        # directly.
         base_rtol = float(solver.parameters.solver.rtol)
         base_max_steps = int(getattr(solver, '_max_steps', solver.parameters.solver.max_steps))
-        # 10x rtol shifts Phi_global by ~3e-8 and T_core by 0 K on a recovered
-        # mush step and keeps |E_res/dE_cons| at ~2e-18, so the cap is tied to a
-        # measured accuracy impact, not a guess.
-        rtol_cap = 10.0 * base_rtol
-        max_steps_cap = 8 * base_max_steps
+        # Stiffness ramp schedule, indexed by stiff_seen (the running count of
+        # CV_TOO_MUCH_WORK attempts). Rungs 1-3 raise the step budget and relax
+        # rtol; rungs 4+ hold the ceiling and halve dt. The caps derive from the
+        # top rung, so the dt-halving rungs hold exactly there.
+        stiff_ms_factor = {1: 2, 2: 4, 3: 8}
+        stiff_rtol_factor = {1: 2.0, 2: 5.0, 3: 10.0}
+        max_steps_cap = base_max_steps * max(stiff_ms_factor.values())
+        # 10x rtol moves the coupler conservation metric E_residual_cons_frac
+        # from 1.46e-4 to 1.53e-4 on a recovered mush step (about 65x below its
+        # ~1% structural floor) and shifts Phi_global by ~3e-8 with T_core
+        # unchanged, so the top rung is a measured accuracy bound, not a guess.
+        rtol_cap = base_rtol * max(stiff_rtol_factor.values())
 
         out = None
+        # Running count of CV_TOO_MUCH_WORK attempts, indexes the stiffness
+        # ramp so it climbs from rung 1 whenever stiffness first appears.
+        stiff_seen = 0
         _diag_on = os.environ.get('PROTEUS_CI_NIGHTLY') == '1'
         try:
             # Range over the widest ladder. max_attempts holds the active
@@ -2093,14 +2102,14 @@ class AragogRunner:
 
                 # Status check: did the solver accept the step?
                 if out.status == 0:
-                    # Two orthogonal post-solve sanity guards. Both must pass
-                    # to accept the step; either trip falls through to the
-                    # retry ladder. sanity_reject_reason names the guard that
-                    # tripped for the exhaustion message.
+                    # Post-solve sanity guard on the CMB temperature. It must
+                    # pass to accept the step; a trip falls through to the retry
+                    # ladder. sanity_reject_reason names the trip for the
+                    # exhaustion message.
                     sanity_reject_reason = None
 
-                    # Guard 1: reject a status=0 solve whose CMB temperature
-                    # moved implausibly far. tcore_change_max is the intra-solve
+                    # Reject a status=0 solve whose CMB temperature moved
+                    # implausibly far. tcore_change_max is the intra-solve
                     # maximum change, >= the endpoint change by construction;
                     # fall back to the endpoint change on an older aragog.
                     # Inactive whenever T_core_pre <= 0, which includes any row
@@ -2116,15 +2125,6 @@ class AragogRunner:
                         sanity_reject_reason = (
                             f'T_core changed by up to {dT:.1f} K '
                             f'(>{sanity_dT_core:.0f} K sanity threshold)'
-                        )
-
-                    # Guard 2: coarse conservation tripwire on |E_res/dE_cons|.
-                    if sanity_reject_reason is None and self._conservation_tripwire_trips(
-                        out, E_cons_pre, E_res_tripwire_K
-                    ):
-                        sanity_reject_reason = (
-                            'the conservation residual exceeded the '
-                            f'{E_res_tripwire_K:.0e} tripwire'
                         )
 
                     if sanity_reject_reason is not None:
@@ -2161,6 +2161,7 @@ class AragogRunner:
                 is_too_much_work = cvode_flag == -1 or flag_name == 'TOO_MUCH_WORK'
                 if is_too_much_work:
                     max_attempts = max_attempts_stiff
+                    stiff_seen += 1
 
                 if attempt >= max_attempts:
                     # status==0 here means the solver accepted every step but
@@ -2183,30 +2184,27 @@ class AragogRunner:
                         f'after {attempt} attempts at t={hf_row.get("Time", 0.0):.3e} yr'
                     )
 
-                # atol_sf ramps to the cap over the early attempts and stays
-                # there; it runs in both branches. The failure mode picks the
-                # remaining levers. next_attempt is the attempt these settings
-                # configure.
-                atol_sf_new = min(atol_sf_max, 1.0 + (atol_sf_max - 1.0) * (attempt / 2.0))
-                next_attempt = attempt + 1
                 # dt of the attempt that just failed. A retry must never run
                 # coarser than it, so clamp the scheduled dt below.
                 dt_current = float(solver.parameters.solver.end_time) - t_start
                 if is_too_much_work:
-                    # Stiffness recovery. Raise the step budget first (wall-time
-                    # cost only, no accuracy loss), relax rtol second (bounded),
-                    # halve dt last. Attempts 2-4 hold dt and ramp max_steps and
-                    # rtol to their caps; attempts 5-8 hold the caps and halve dt.
-                    if next_attempt <= 4:
-                        ms_factor = 2 ** (next_attempt - 1)
-                        rtol_factor = {2: 2.0, 3: 5.0, 4: 10.0}[next_attempt]
-                        max_steps_new = min(max_steps_cap, base_max_steps * ms_factor)
-                        rtol_new = min(rtol_cap, base_rtol * rtol_factor)
+                    # Stiffness recovery, indexed by stiff_seen so it climbs
+                    # from rung 1 whenever stiffness first appears. Raise the
+                    # step budget first (wall-time cost only, no accuracy loss),
+                    # relax rtol second (bounded), halve dt last. Rungs 1-3 hold
+                    # dt and ramp max_steps and rtol to the ceiling; rungs 4+
+                    # hold the ceiling and halve dt. atol_sf stays at 1.0 so the
+                    # ramp relaxes rtol alone, the measured lever.
+                    rung = stiff_seen
+                    atol_sf_new = 1.0
+                    if rung <= 3:
+                        max_steps_new = base_max_steps * stiff_ms_factor[rung]
+                        rtol_new = base_rtol * stiff_rtol_factor[rung]
                         dt_new = dt_requested
                     else:
                         max_steps_new = max_steps_cap
                         rtol_new = rtol_cap
-                        dt_new = dt_requested * (0.5 ** (next_attempt - 4))
+                        dt_new = dt_requested * (0.5 ** (rung - 3))
                     dt_new = min(dt_new, dt_current)
                     if hasattr(solver, '_max_steps'):
                         solver._max_steps = int(max_steps_new)
@@ -2226,8 +2224,10 @@ class AragogRunner:
                     )
                 else:
                     # Other failure modes: halve dt so additional attempts gain
-                    # resolution, not looser tolerance. Restore base rtol and
-                    # step budget in case a prior attempt was the stiff branch.
+                    # resolution, not looser tolerance. Ramp atol_sf here only.
+                    # Restore base rtol and step budget in case a prior attempt
+                    # was the stiff branch.
+                    atol_sf_new = min(atol_sf_max, 1.0 + (atol_sf_max - 1.0) * (attempt / 2.0))
                     dt_new = min(dt_requested * (0.5**attempt), dt_current)
                     solver.parameters.solver.rtol = base_rtol
                     if hasattr(solver, '_max_steps'):
@@ -2277,55 +2277,6 @@ class AragogRunner:
                 solver._dSdr_cmb_init = None
 
         return out
-
-    @staticmethod
-    def _conservation_tripwire_trips(out: SolverOutput, E_cons_pre, K: float) -> bool:
-        """Test a status=0 solve against a coarse energy-conservation tripwire.
-
-        The tripwire is the dimensionless ratio ``|E_res / dE_cons|``, where
-        ``E_res`` is the solver self-consistency residual
-        (``step_solver_residual_J``) and ``dE_cons`` is the frozen-mass mantle
-        enthalpy the step moved (end ``E_state_cons`` minus the pre-solve value
-        carried in the helpfile row). A healthy solve sits at ~2e-18 for a tight
-        or a 10x-relaxed rtol alike, so K=1e-9 sits about 7 orders above that
-        floor. This catches only a gross conservation blow-up; it is not a
-        calibrated threshold. A calibration against a real-stall residual
-        distribution is a follow-up.
-
-        The test never rejects when it cannot form a valid ratio: a missing
-        residual, a missing or zero baseline enthalpy, or a zero or non-finite
-        step move all return False (skip). A non-finite ratio rejects, matching
-        the T_core guard: reject when ``not (ratio <= K)``.
-
-        Parameters
-        ----------
-        out : SolverOutput
-            The accepted (status=0) solver output under test.
-        E_cons_pre : float or None
-            Pre-solve frozen-mass mantle enthalpy [J]. None or 0.0 disables
-            the tripwire.
-        K : float
-            Dimensionless tripwire ceiling on ``|E_res / dE_cons|``.
-
-        Returns
-        -------
-        bool
-            True to reject the solve, False to skip the tripwire or pass it.
-        """
-        e_res = getattr(out, 'step_solver_residual_J', None)
-        e_cons_end = getattr(out, 'E_state_cons', None)
-        if e_res is None or e_cons_end is None or E_cons_pre is None:
-            return False
-        try:
-            e_res = float(e_res)
-            base = float(E_cons_pre)
-            dE_cons = float(e_cons_end) - base
-        except (TypeError, ValueError):
-            return False
-        if base == 0.0 or dE_cons == 0.0 or not np.isfinite(dE_cons):
-            return False
-        ratio = abs(e_res) / abs(dE_cons)
-        return not (ratio <= K)
 
     @staticmethod
     def _build_helpfile_output(

--- a/tests/interior_energetics/test_aragog.py
+++ b/tests/interior_energetics/test_aragog.py
@@ -1372,6 +1372,12 @@ def test_solve_with_retry_restores_base_tolerance_on_reverse_switch(monkeypatch)
         )
         assert calls[k]['max_steps'] == _RETRY_BASE_MAX_STEPS, f'attempt {k + 1} max_steps'
 
+    # The non-stiff branch indexes atol/dt on other_seen, not the global
+    # attempt, so the first non-stiff retry after three stalls enters at
+    # other_seen=1 (dt halved once, atol 3x). Indexing on attempt fails here.
+    np.testing.assert_allclose(calls[4]['dt'], 50.0, err_msg='reverse-switch dt')
+    np.testing.assert_allclose(calls[4]['atol_sf'], 3.0, err_msg='reverse-switch atol_sf')
+
 
 @pytest.mark.unit
 def test_solve_with_retry_late_stiff_switch_enters_ramp_at_first_rung(monkeypatch):

--- a/tests/interior_energetics/test_aragog.py
+++ b/tests/interior_energetics/test_aragog.py
@@ -1074,6 +1074,9 @@ def test_solve_with_retry_stiff_mode_ramps_maxsteps_and_rtol_then_halves_dt(monk
         np.testing.assert_allclose(calls[k]['dt'], dt, err_msg=f'attempt {k + 1} dt')
         assert calls[k]['max_steps'] == ms, f'attempt {k + 1} max_steps'
         np.testing.assert_allclose(calls[k]['rtol'], rtol, err_msg=f'attempt {k + 1} rtol')
+        # The stiff branch relaxes rtol alone; atol stays at base across every
+        # attempt. A mutant that ramps atol_sf in the stiff branch fails here.
+        np.testing.assert_allclose(calls[k]['atol_sf'], 1.0, err_msg=f'attempt {k + 1} atol_sf')
 
     # finally restores the base controls on the raising path.
     np.testing.assert_allclose(solver.parameters.solver.rtol, _RETRY_BASE_RTOL)
@@ -1251,14 +1254,14 @@ def test_solve_with_retry_rejects_non_finite_tcore_change(monkeypatch):
     intra = [_retry_out(0, cvode_flag=0, T_core=2000.0, tcore_change_max=nan)] * 8
     solver, _ = _retry_solver(intra)
     runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
-    with pytest.raises(RuntimeError, match='sanity threshold'):
+    with pytest.raises(RuntimeError, match='non-finite'):
         runner._solve_with_retry(hf_row, interior_o)
     assert solver.solve.call_count == 6
 
     endpoint = [_retry_out(0, cvode_flag=0, T_core=nan, has_tcore_change=False)] * 8
     solver2, _ = _retry_solver(endpoint)
     runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
-    with pytest.raises(RuntimeError, match='sanity threshold'):
+    with pytest.raises(RuntimeError, match='non-finite'):
         runner2._solve_with_retry(hf_row2, interior2)
     assert solver2.solve.call_count == 6
 
@@ -1368,3 +1371,51 @@ def test_solve_with_retry_restores_base_tolerance_on_reverse_switch(monkeypatch)
             calls[k]['rtol'], _RETRY_BASE_RTOL, err_msg=f'attempt {k + 1} rtol'
         )
         assert calls[k]['max_steps'] == _RETRY_BASE_MAX_STEPS, f'attempt {k + 1} max_steps'
+
+
+@pytest.mark.unit
+def test_solve_with_retry_late_stiff_switch_enters_ramp_at_first_rung(monkeypatch):
+    """A stall that appears after non-stiff failures enters the ramp at rung 1.
+
+    The stiffness ramp is indexed by stiff_seen, the running count of
+    CV_TOO_MUCH_WORK attempts, not the global attempt number. So the first stall
+    after several non-stiff failures must start the ramp at its first rung
+    (max_steps 2x, rtol 2x), not jump deep into the ramp or to the cap. This
+    scripts three non-stiff failures then stalls: the first stiff retry is
+    attempt five, and it must run at max_steps=2000, rtol=2e-6. A mutant that
+    indexes the ramp on the global attempt puts attempt four's rung at four,
+    past the ramp, so the first stiff retry lands on the cap and fails here.
+    """
+    scripted = [_retry_out(-1, cvode_flag=0, cvode_flag_name='')] * 3 + [
+        _retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')
+    ] * 5
+    solver, calls = _retry_solver(scripted)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+    with pytest.raises(RuntimeError, match='TOO_MUCH_WORK'):
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 8
+    # attempt 5 (index 4) is the first stiff retry: rung 1, not the cap.
+    assert calls[4]['max_steps'] == 2000, f'first stiff retry max_steps: {calls[4]}'
+    np.testing.assert_allclose(calls[4]['rtol'], 2.0e-6, err_msg='first stiff retry rtol')
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_solve_with_retry_first_solve_rejects_non_finite_tcore(monkeypatch):
+    """A non-finite T_core on the first solve is rejected, not accepted.
+
+    On the first solve no pre-solve reference is available (T_core_pre <= 0), so
+    the jump-magnitude check is inactive. The finiteness check must still run: a
+    NaN core temperature must be rejected rather than accepted because no
+    reference exists. This is the relaxed-rtol recovery path where a corrupted
+    solve is most likely. A mutant that skips the finiteness check when
+    T_core_pre <= 0 accepts the NaN solve on attempt one and fails here.
+    """
+    nan = float('nan')
+    scripted = [_retry_out(0, cvode_flag=0, T_core=nan, has_tcore_change=False)] * 8
+    solver, _ = _retry_solver(scripted)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=0.0)
+    with pytest.raises(RuntimeError, match='non-finite'):
+        runner._solve_with_retry(hf_row, interior_o)
+    assert solver.solve.call_count == 6

--- a/tests/interior_energetics/test_aragog.py
+++ b/tests/interior_energetics/test_aragog.py
@@ -972,15 +972,8 @@ def _retry_out(
     T_core=2000.0,
     has_tcore_change=True,
     tcore_change_max=0.0,
-    e_res=None,
-    e_state_cons=None,
 ):
-    """Build one scripted SolverOutput stand-in with explicit mode fields.
-
-    Pass e_res and e_state_cons to drive the conservation tripwire; both set
-    the numeric residual fields explicitly, since an unset MagicMock child
-    coerces to 1.0 and would not represent a real value.
-    """
+    """Build one scripted SolverOutput stand-in with explicit mode fields."""
     out = MagicMock()
     out.status = status
     out.T_core = T_core
@@ -991,10 +984,6 @@ def _retry_out(
     else:
         # Older aragog returns no such attribute: force the getattr fallback.
         del out.tcore_change_max
-    if e_res is not None:
-        out.step_solver_residual_J = e_res
-    if e_state_cons is not None:
-        out.E_state_cons = e_state_cons
     return out
 
 
@@ -1055,7 +1044,7 @@ def test_solve_with_retry_stiff_mode_ramps_maxsteps_and_rtol_then_halves_dt(monk
     and ramp max_steps to 2x/4x/8x(cap) and rtol to 2x/5x/10x(cap), attempts 5-8
     hold both caps and halve dt (0.5/0.25/0.125/0.0625). This pins the whole
     schedule, so a mutant that drops the rtol/max_steps ramp, off-by-ones the
-    next_attempt index, freezes the range at six, or falls through the loop
+    stiff_seen rung index, freezes the range at six, or falls through the loop
     returning a failed SolverOutput instead of raising fails here. It also
     confirms the finally block restores the base rtol and step budget on the
     raising exit path, so a later coupling step never inherits a relaxed rtol.
@@ -1150,6 +1139,7 @@ def test_solve_with_retry_stiff_success_returns_state_and_restores_controls(monk
 
 
 @pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_solve_with_retry_tcore_guard_trips_and_routes_to_dt_halving(monkeypatch):
     """A status=0 solve with an implausible T_core change is rejected as failure.
 
@@ -1173,6 +1163,7 @@ def test_solve_with_retry_tcore_guard_trips_and_routes_to_dt_halving(monkeypatch
 
 
 @pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_solve_with_retry_tcore_guard_inactive_on_first_solve(monkeypatch):
     """The T_core-jump guard is inactive on the first solve (no prior T_core).
 
@@ -1193,6 +1184,7 @@ def test_solve_with_retry_tcore_guard_inactive_on_first_solve(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_solve_with_retry_tcore_guard_falls_back_to_endpoint_change(monkeypatch):
     """Without tcore_change_max the guard uses the endpoint change instead.
 
@@ -1243,6 +1235,7 @@ def test_solve_with_retry_restores_rtol_when_solver_has_no_cached_step_budget(mo
 
 
 @pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_solve_with_retry_rejects_non_finite_tcore_change(monkeypatch):
     """A status=0 solve with a non-finite T_core change fails the sanity guard.
 
@@ -1262,53 +1255,6 @@ def test_solve_with_retry_rejects_non_finite_tcore_change(monkeypatch):
         runner._solve_with_retry(hf_row, interior_o)
     assert solver.solve.call_count == 6
 
-
-@pytest.mark.unit
-def test_solve_with_retry_conservation_tripwire(monkeypatch):
-    """A status=0 solve that breaks energy conservation grossly is rejected.
-
-    The coarse tripwire rejects a solve whose residual |E_res/dE_cons| exceeds
-    K=1e-9, where dE_cons is the enthalpy the step moved (end E_state_cons minus
-    the pre-solve value carried in the helpfile row). This pins three cases: a
-    gross ratio (1e-5) is rejected and, carrying cvode_flag == 0, routes to the
-    six-attempt dt-halving branch with a conservation reason; a healthy ~2e-18
-    ratio passes and returns on attempt 1; a NaN ratio is rejected, matching the
-    T_core guard inversion 'not (ratio <= K)'. A mutant that drops the tripwire,
-    or uses 'ratio > K' and so passes a NaN, fails here.
-    """
-    e_cons_pre = 1.0e30
-    e_cons_end = 6.0e29  # dE_cons = -4.0e29 J, the enthalpy the step moved
-
-    gross = [
-        _retry_out(0, cvode_flag=0, e_res=1.0e25, e_state_cons=e_cons_end)
-    ] * 8  # |E_res/dE_cons| = 2.5e-5 >> K
-    solver, _ = _retry_solver(gross)
-    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
-    hf_row['E_state_cons_J'] = e_cons_pre
-    with pytest.raises(RuntimeError, match='conservation residual') as info:
-        runner._solve_with_retry(hf_row, interior_o)
-    assert solver.solve.call_count == 6
-    assert 'status=0' in str(info.value)
-
-    healthy = [
-        _retry_out(0, e_res=-8.0e11, e_state_cons=e_cons_end)
-    ]  # |E_res/dE_cons| = 2.0e-18 << K
-    solver2, _ = _retry_solver(healthy)
-    runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
-    hf_row2['E_state_cons_J'] = e_cons_pre
-    out = runner2._solve_with_retry(hf_row2, interior2)
-    assert out is not None
-    assert solver2.solve.call_count == 1
-
-    nan = float('nan')
-    corrupt = [_retry_out(0, cvode_flag=0, e_res=nan, e_state_cons=e_cons_end)] * 8
-    solver3, _ = _retry_solver(corrupt)
-    runner3, interior3, hf_row3 = _retry_runner(solver3, monkeypatch, T_core_pre=2000.0)
-    hf_row3['E_state_cons_J'] = e_cons_pre
-    with pytest.raises(RuntimeError, match='conservation residual'):
-        runner3._solve_with_retry(hf_row3, interior3)
-    assert solver3.solve.call_count == 6
-
     endpoint = [_retry_out(0, cvode_flag=0, T_core=nan, has_tcore_change=False)] * 8
     solver2, _ = _retry_solver(endpoint)
     runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
@@ -1318,16 +1264,65 @@ def test_solve_with_retry_conservation_tripwire(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.physics_invariant
+def test_solve_with_retry_tcore_guard_boundary_is_inclusive(monkeypatch):
+    """The T_core-jump guard accepts dT exactly at the threshold, rejects above.
+
+    The guard trips on 'dT > sanity_dT_core', so a change exactly at the
+    threshold (3000 K at 1 M_Earth) must pass and a change just above it must
+    fail. This pins the boundary against a '>='/'>' flip: a mutant that rejects
+    at exactly the threshold fails the accept case, and a mutant that only
+    rejects far above it fails the reject case.
+    """
+    at = [_retry_out(0, cvode_flag=0, T_core=5000.0, tcore_change_max=3000.0)]
+    solver, _ = _retry_solver(at)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
+    out = runner._solve_with_retry(hf_row, interior_o)
+    assert out is not None
+    assert solver.solve.call_count == 1
+
+    above = [_retry_out(0, cvode_flag=0, T_core=5000.0, tcore_change_max=3000.001)] * 8
+    solver2, _ = _retry_solver(above)
+    runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
+    with pytest.raises(RuntimeError, match='sanity threshold'):
+        runner2._solve_with_retry(hf_row2, interior2)
+    assert solver2.solve.call_count == 6
+
+
+@pytest.mark.unit
+def test_solve_with_retry_stiff_detected_by_flag_name_alone(monkeypatch):
+    """The flag-name half of the stiff predicate widens the ladder on its own.
+
+    The stiff mode is 'cvode_flag == -1 or cvode_flag_name == TOO_MUCH_WORK', so
+    a failure whose numeric flag is not -1 but whose readable name is
+    TOO_MUCH_WORK must still take the stiff branch: eight attempts, and the step
+    budget and rtol ramp rather than a bare dt-halving. A mutant that keys the
+    mode on the numeric flag alone caps at six here and never ramps max_steps.
+    """
+    named = [_retry_out(-1, cvode_flag=0, cvode_flag_name='TOO_MUCH_WORK')] * 10
+    solver, calls = _retry_solver(named)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+
+    with pytest.raises(RuntimeError, match='TOO_MUCH_WORK'):
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 8
+    assert calls[1]['max_steps'] == 2000
+    np.testing.assert_allclose(calls[1]['rtol'], 2.0e-6)
+
+
+@pytest.mark.unit
+@pytest.mark.physics_invariant
 def test_solve_with_retry_dt_never_increases_on_late_stiff_switch(monkeypatch):
     """A late switch to the stiff branch never retries at a coarser dt.
 
     When the first failures are non-stiff and a CV_TOO_MUCH_WORK stall appears
-    only after dt has already shrunk, the stiff schedule (anchored to the
-    absolute attempt index) would otherwise set a larger dt than the attempt
-    that just failed. A retry must never run coarser than the step it retries,
-    so the stiff dt is clamped to the failed dt. This scripts five non-stiff
-    failures then a stall and asserts the dt sequence never increases; a mutant
-    that drops the clamp jumps dt up at the switch and fails here.
+    only after dt has already shrunk, the stiff branch enters at rung 1, which
+    holds dt at the requested value and so would set a larger dt than the
+    attempt that just failed. A retry must never run coarser than the step it
+    retries, so the stiff dt is clamped to the failed dt. This scripts five
+    non-stiff failures then a stall and asserts the dt sequence never increases;
+    a mutant that drops the clamp jumps dt up at the switch and fails here.
     """
     scripted = [_retry_out(-1, cvode_flag=0, cvode_flag_name='')] * 5 + [
         _retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')

--- a/tests/interior_energetics/test_aragog.py
+++ b/tests/interior_energetics/test_aragog.py
@@ -943,3 +943,433 @@ def test_retry_exhaustion_labels_unknown_when_cvode_probe_fails(monkeypatch):
     # The label is built only on the exhaustion branch, so confirm the ladder
     # ran the full six attempts rather than raising early.
     assert runner.aragog_solver.solve.call_count == 6
+
+
+# --- Failure-mode-branched retry ladder ------------------------------------
+#
+# _solve_with_retry branches its recovery on the CVODE failure mode. A
+# CV_TOO_MUCH_WORK stall (cvode_flag == -1) raises the step budget, then relaxes
+# rtol (both bounded by caps), and only then halves dt, over eight attempts.
+# Every other failure keeps the six-attempt dt-halving ladder. The helpers below
+# script the solver so each solve() records the controls it ran under, which lets
+# a test assert the exact per-attempt schedule and the finally-block restore.
+#
+# A MagicMock coerces int()/float()/str() of an auto-child to 1/1.0/a repr, so
+# the mode-branch fields (cvode_flag, cvode_flag_name, tcore_change_max) and
+# _max_steps must be set on each mock explicitly; attribute absence (an older
+# aragog, or a solver without a cached step budget) is forced with del.
+
+_RETRY_BASE_RTOL = 1.0e-6
+_RETRY_BASE_MAX_STEPS = 1000
+_RETRY_DT0 = 100.0
+
+
+def _retry_out(
+    status,
+    *,
+    cvode_flag=0,
+    cvode_flag_name='',
+    T_core=2000.0,
+    has_tcore_change=True,
+    tcore_change_max=0.0,
+    e_res=None,
+    e_state_cons=None,
+):
+    """Build one scripted SolverOutput stand-in with explicit mode fields.
+
+    Pass e_res and e_state_cons to drive the conservation tripwire; both set
+    the numeric residual fields explicitly, since an unset MagicMock child
+    coerces to 1.0 and would not represent a real value.
+    """
+    out = MagicMock()
+    out.status = status
+    out.T_core = T_core
+    out.cvode_flag = cvode_flag
+    out.cvode_flag_name = cvode_flag_name
+    if has_tcore_change:
+        out.tcore_change_max = tcore_change_max
+    else:
+        # Older aragog returns no such attribute: force the getattr fallback.
+        del out.tcore_change_max
+    if e_res is not None:
+        out.step_solver_residual_J = e_res
+    if e_state_cons is not None:
+        out.E_state_cons = e_state_cons
+    return out
+
+
+def _retry_solver(scripted_outs, *, with_max_steps=True):
+    """Build a scripted solver mock that records the controls of each solve()."""
+    calls = []
+    solver = MagicMock()
+    solver.parameters.solver.start_time = 0.0
+    solver.parameters.solver.end_time = _RETRY_DT0
+    solver.parameters.solver.rtol = _RETRY_BASE_RTOL
+    solver.parameters.solver.max_steps = _RETRY_BASE_MAX_STEPS
+    if with_max_steps:
+        solver._max_steps = _RETRY_BASE_MAX_STEPS
+    else:
+        del solver._max_steps
+    solver._atol_sf = 1.0
+    solver.get_current_dSdr_cmb.return_value = None
+    solver._dSdr_cmb_init = None
+
+    def _record():
+        s = solver.parameters.solver
+        calls.append(
+            {
+                'dt': s.end_time - s.start_time,
+                'rtol': s.rtol,
+                'max_steps': getattr(solver, '_max_steps', None),
+                'atol_sf': solver._atol_sf,
+            }
+        )
+
+    solver.solve.side_effect = _record
+    solver.get_state.side_effect = list(scripted_outs)
+    return solver, calls
+
+
+def _retry_runner(solver, monkeypatch, *, T_core_pre=2000.0, mass_tot=1.0):
+    """Bind the scripted solver to an AragogRunner and return (runner, hf_row)."""
+    from proteus.interior_energetics.aragog import AragogRunner
+
+    monkeypatch.setattr('aragog.solver.entropy_solver._CVODE_AVAILABLE', True)
+    runner = AragogRunner.__new__(AragogRunner)
+    runner._config = MagicMock()
+    runner._config.interior_energetics.aragog.solver_method = 'cvode'
+    runner._config.planet.mass_tot = mass_tot
+    runner.aragog_solver = solver
+    interior_o = MagicMock()
+    interior_o._last_entropy = None
+    hf_row = {'Time': 1.0e6, 'T_cmb': T_core_pre}
+    return runner, interior_o, hf_row
+
+
+@pytest.mark.unit
+def test_solve_with_retry_stiff_mode_ramps_maxsteps_and_rtol_then_halves_dt(monkeypatch):
+    """A CV_TOO_MUCH_WORK stall relaxes step budget and rtol before halving dt.
+
+    A stiffness stall is a step-budget problem, so halving dt alone wastes the
+    ladder. The stiff branch instead runs eight attempts: attempts 2-4 hold dt
+    and ramp max_steps to 2x/4x/8x(cap) and rtol to 2x/5x/10x(cap), attempts 5-8
+    hold both caps and halve dt (0.5/0.25/0.125/0.0625). This pins the whole
+    schedule, so a mutant that drops the rtol/max_steps ramp, off-by-ones the
+    next_attempt index, freezes the range at six, or falls through the loop
+    returning a failed SolverOutput instead of raising fails here. It also
+    confirms the finally block restores the base rtol and step budget on the
+    raising exit path, so a later coupling step never inherits a relaxed rtol.
+    """
+    stiff = [_retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')] * 10
+    solver, calls = _retry_solver(stiff)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+
+    with pytest.raises(RuntimeError, match='TOO_MUCH_WORK') as info:
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 8
+    assert 'cvode_flag=-1' in str(info.value)
+
+    expected = [
+        (100.0, 1000, 1.0e-6),
+        (100.0, 2000, 2.0e-6),
+        (100.0, 4000, 5.0e-6),
+        (100.0, 8000, 1.0e-5),
+        (50.0, 8000, 1.0e-5),
+        (25.0, 8000, 1.0e-5),
+        (12.5, 8000, 1.0e-5),
+        (6.25, 8000, 1.0e-5),
+    ]
+    assert len(calls) == 8
+    for k, (dt, ms, rtol) in enumerate(expected):
+        np.testing.assert_allclose(calls[k]['dt'], dt, err_msg=f'attempt {k + 1} dt')
+        assert calls[k]['max_steps'] == ms, f'attempt {k + 1} max_steps'
+        np.testing.assert_allclose(calls[k]['rtol'], rtol, err_msg=f'attempt {k + 1} rtol')
+
+    # finally restores the base controls on the raising path.
+    np.testing.assert_allclose(solver.parameters.solver.rtol, _RETRY_BASE_RTOL)
+    assert solver._max_steps == _RETRY_BASE_MAX_STEPS
+
+
+@pytest.mark.unit
+def test_solve_with_retry_other_mode_caps_at_six_and_only_halves_dt(monkeypatch):
+    """A non-stiff CVODE failure keeps the six-attempt dt-halving ladder.
+
+    Any failure that is not CV_TOO_MUCH_WORK (cvode_flag != -1) must not widen
+    the ladder to eight or touch rtol/max_steps: those levers belong to the
+    stiff branch only. This confirms the exhaustion check reads the active
+    six-attempt budget for the other mode, the dt halves each attempt
+    (100/50/25/12.5/6.25/3.125), rtol and the step budget stay at their base
+    values throughout, and the exhaustion message names the solver status
+    without a stiff-mode flag suffix. A mutant that shares the stiff schedule
+    across modes or miscounts the other-mode budget fails here.
+    """
+    other = [_retry_out(-1, cvode_flag=0, cvode_flag_name='')] * 8
+    solver, calls = _retry_solver(other)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+
+    with pytest.raises(RuntimeError, match='status=-1') as info:
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 6
+    assert 'TOO_MUCH_WORK' not in str(info.value)
+
+    expected_dt = [100.0, 50.0, 25.0, 12.5, 6.25, 3.125]
+    assert len(calls) == 6
+    for k, dt in enumerate(expected_dt):
+        np.testing.assert_allclose(calls[k]['dt'], dt, err_msg=f'attempt {k + 1} dt')
+        assert calls[k]['max_steps'] == _RETRY_BASE_MAX_STEPS, f'attempt {k + 1} max_steps'
+        np.testing.assert_allclose(
+            calls[k]['rtol'], _RETRY_BASE_RTOL, err_msg=f'attempt {k + 1} rtol'
+        )
+
+
+@pytest.mark.unit
+def test_solve_with_retry_stiff_success_returns_state_and_restores_controls(monkeypatch):
+    """A stiff retry that succeeds returns the state and restores base controls.
+
+    After four CV_TOO_MUCH_WORK failures the fifth attempt succeeds with a small
+    CMB-temperature change, so the method must return that SolverOutput rather
+    than raise, and the finally block must still restore the base rtol and step
+    budget on the returning path. A mutant that restores only on the exception
+    path, or continues past a success, fails here.
+    """
+    scripted = [_retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')] * 4 + [
+        _retry_out(0, T_core=2010.0, tcore_change_max=10.0)
+    ]
+    solver, calls = _retry_solver(scripted)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+
+    out = runner._solve_with_retry(hf_row, interior_o)
+
+    assert out is not None
+    assert out.status == 0
+    assert solver.solve.call_count == 5
+    np.testing.assert_allclose(solver.parameters.solver.rtol, _RETRY_BASE_RTOL)
+    assert solver._max_steps == _RETRY_BASE_MAX_STEPS
+
+
+@pytest.mark.unit
+def test_solve_with_retry_tcore_guard_trips_and_routes_to_dt_halving(monkeypatch):
+    """A status=0 solve with an implausible T_core change is rejected as failure.
+
+    tcore_change_max above the mass-scaled sanity threshold (3000 K at 1
+    M_Earth) means the solver 'succeeded' with garbage, so the guard rejects it
+    and continues the ladder. A guard trip carries cvode_flag == 0, so it must
+    route to the six-attempt dt-halving branch, not the stiff branch, and the
+    exhaustion message must name the T_core-jump reason rather than the
+    misleading status=0. A mutant that treats a guard trip as stiff (eight
+    attempts) or reports a bare status=0 fails here.
+    """
+    guard = [_retry_out(0, cvode_flag=0, T_core=9000.0, tcore_change_max=9000.0)] * 8
+    solver, calls = _retry_solver(guard)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
+
+    with pytest.raises(RuntimeError, match='sanity threshold') as info:
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 6
+    assert 'status=0' in str(info.value)
+
+
+@pytest.mark.unit
+def test_solve_with_retry_tcore_guard_inactive_on_first_solve(monkeypatch):
+    """The T_core-jump guard is inactive on the first solve (no prior T_core).
+
+    On the very first coupling solve T_core_pre is 0, so no converged core
+    temperature exists to compare against and the guard must be forced off even
+    for a large tcore_change_max. The method must accept and return the solve on
+    attempt 1. A mutant that keeps the guard active with T_core_pre == 0 would
+    reject a legitimate first solve and fails here.
+    """
+    first = [_retry_out(0, T_core=9000.0, tcore_change_max=9000.0)] * 3
+    solver, calls = _retry_solver(first)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=0.0)
+
+    out = runner._solve_with_retry(hf_row, interior_o)
+
+    assert out is not None
+    assert solver.solve.call_count == 1
+
+
+@pytest.mark.unit
+def test_solve_with_retry_tcore_guard_falls_back_to_endpoint_change(monkeypatch):
+    """Without tcore_change_max the guard uses the endpoint change instead.
+
+    An older aragog returns no tcore_change_max attribute, so the guard must
+    fall back to the endpoint change abs(T_core - T_core_pre). A 7000 K endpoint
+    jump (9000 from 2000) trips the 3000 K threshold and exhausts the ladder; a
+    100 K jump (2100 from 2000) passes and returns on attempt 1. A mutant that
+    drops the fallback (crashing on the missing attribute, or never checking)
+    fails one of the two directions here.
+    """
+    tripping = [_retry_out(0, cvode_flag=0, T_core=9000.0, has_tcore_change=False)] * 8
+    solver, calls = _retry_solver(tripping)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
+    with pytest.raises(RuntimeError, match='sanity threshold'):
+        runner._solve_with_retry(hf_row, interior_o)
+    assert solver.solve.call_count == 6
+
+    passing = [_retry_out(0, T_core=2100.0, has_tcore_change=False)]
+    solver2, _ = _retry_solver(passing)
+    runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
+    out = runner2._solve_with_retry(hf_row2, interior2)
+    assert out is not None
+    assert solver2.solve.call_count == 1
+
+
+@pytest.mark.unit
+def test_solve_with_retry_restores_rtol_when_solver_has_no_cached_step_budget(monkeypatch):
+    """A solver without a cached _max_steps still relaxes rtol and restores it.
+
+    When the solver exposes no _max_steps attribute the base step budget comes
+    from parameters.solver.max_steps and the stiff branch skips every _max_steps
+    write, so no such attribute is ever created. The ladder must still run its
+    eight stiff attempts, and the finally block must restore the base rtol
+    without touching the absent step budget. A mutant that assumes _max_steps
+    exists (crashing on capture or restore) fails here.
+    """
+    stiff = [_retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')] * 10
+    solver, calls = _retry_solver(stiff, with_max_steps=False)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+
+    with pytest.raises(RuntimeError, match='TOO_MUCH_WORK'):
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 8
+    assert not hasattr(solver, '_max_steps')
+    np.testing.assert_allclose(solver.parameters.solver.rtol, _RETRY_BASE_RTOL)
+    assert all(c['max_steps'] is None for c in calls)
+
+
+@pytest.mark.unit
+def test_solve_with_retry_rejects_non_finite_tcore_change(monkeypatch):
+    """A status=0 solve with a non-finite T_core change fails the sanity guard.
+
+    A relaxed rtol can let CVODE return status=0 with a NaN core temperature or
+    a NaN tcore_change_max. A bare 'dT > threshold' test passes such a solve,
+    because 'NaN > 3000' is False, so the run would accept a corrupt state. The
+    guard must reject a non-finite dT instead. This pins both the intra-solve
+    path (tcore_change_max = NaN) and the endpoint fallback (T_core = NaN, no
+    tcore_change_max); a mutant that drops the np.isfinite clause returns the
+    NaN solve and fails here.
+    """
+    nan = float('nan')
+    intra = [_retry_out(0, cvode_flag=0, T_core=2000.0, tcore_change_max=nan)] * 8
+    solver, _ = _retry_solver(intra)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
+    with pytest.raises(RuntimeError, match='sanity threshold'):
+        runner._solve_with_retry(hf_row, interior_o)
+    assert solver.solve.call_count == 6
+
+
+@pytest.mark.unit
+def test_solve_with_retry_conservation_tripwire(monkeypatch):
+    """A status=0 solve that breaks energy conservation grossly is rejected.
+
+    The coarse tripwire rejects a solve whose residual |E_res/dE_cons| exceeds
+    K=1e-9, where dE_cons is the enthalpy the step moved (end E_state_cons minus
+    the pre-solve value carried in the helpfile row). This pins three cases: a
+    gross ratio (1e-5) is rejected and, carrying cvode_flag == 0, routes to the
+    six-attempt dt-halving branch with a conservation reason; a healthy ~2e-18
+    ratio passes and returns on attempt 1; a NaN ratio is rejected, matching the
+    T_core guard inversion 'not (ratio <= K)'. A mutant that drops the tripwire,
+    or uses 'ratio > K' and so passes a NaN, fails here.
+    """
+    e_cons_pre = 1.0e30
+    e_cons_end = 6.0e29  # dE_cons = -4.0e29 J, the enthalpy the step moved
+
+    gross = [
+        _retry_out(0, cvode_flag=0, e_res=1.0e25, e_state_cons=e_cons_end)
+    ] * 8  # |E_res/dE_cons| = 2.5e-5 >> K
+    solver, _ = _retry_solver(gross)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch, T_core_pre=2000.0)
+    hf_row['E_state_cons_J'] = e_cons_pre
+    with pytest.raises(RuntimeError, match='conservation residual') as info:
+        runner._solve_with_retry(hf_row, interior_o)
+    assert solver.solve.call_count == 6
+    assert 'status=0' in str(info.value)
+
+    healthy = [
+        _retry_out(0, e_res=-8.0e11, e_state_cons=e_cons_end)
+    ]  # |E_res/dE_cons| = 2.0e-18 << K
+    solver2, _ = _retry_solver(healthy)
+    runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
+    hf_row2['E_state_cons_J'] = e_cons_pre
+    out = runner2._solve_with_retry(hf_row2, interior2)
+    assert out is not None
+    assert solver2.solve.call_count == 1
+
+    nan = float('nan')
+    corrupt = [_retry_out(0, cvode_flag=0, e_res=nan, e_state_cons=e_cons_end)] * 8
+    solver3, _ = _retry_solver(corrupt)
+    runner3, interior3, hf_row3 = _retry_runner(solver3, monkeypatch, T_core_pre=2000.0)
+    hf_row3['E_state_cons_J'] = e_cons_pre
+    with pytest.raises(RuntimeError, match='conservation residual'):
+        runner3._solve_with_retry(hf_row3, interior3)
+    assert solver3.solve.call_count == 6
+
+    endpoint = [_retry_out(0, cvode_flag=0, T_core=nan, has_tcore_change=False)] * 8
+    solver2, _ = _retry_solver(endpoint)
+    runner2, interior2, hf_row2 = _retry_runner(solver2, monkeypatch, T_core_pre=2000.0)
+    with pytest.raises(RuntimeError, match='sanity threshold'):
+        runner2._solve_with_retry(hf_row2, interior2)
+    assert solver2.solve.call_count == 6
+
+
+@pytest.mark.unit
+def test_solve_with_retry_dt_never_increases_on_late_stiff_switch(monkeypatch):
+    """A late switch to the stiff branch never retries at a coarser dt.
+
+    When the first failures are non-stiff and a CV_TOO_MUCH_WORK stall appears
+    only after dt has already shrunk, the stiff schedule (anchored to the
+    absolute attempt index) would otherwise set a larger dt than the attempt
+    that just failed. A retry must never run coarser than the step it retries,
+    so the stiff dt is clamped to the failed dt. This scripts five non-stiff
+    failures then a stall and asserts the dt sequence never increases; a mutant
+    that drops the clamp jumps dt up at the switch and fails here.
+    """
+    scripted = [_retry_out(-1, cvode_flag=0, cvode_flag_name='')] * 5 + [
+        _retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')
+    ] * 5
+    solver, calls = _retry_solver(scripted)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+    with pytest.raises(RuntimeError, match='TOO_MUCH_WORK'):
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 8
+    dts = [c['dt'] for c in calls]
+    assert all(dts[k + 1] <= dts[k] + 1e-12 for k in range(len(dts) - 1)), (
+        f'dt not monotone non-increasing: {dts}'
+    )
+    # the switch is at attempt 6 -> 7: the stiff retry holds dt, never raises it.
+    assert calls[6]['dt'] <= calls[5]['dt']
+
+
+@pytest.mark.unit
+def test_solve_with_retry_restores_base_tolerance_on_reverse_switch(monkeypatch):
+    """A switch from the stiff branch back to a non-stiff failure runs at base.
+
+    If a CV_TOO_MUCH_WORK stall relaxes rtol and the step budget and then a
+    later attempt fails for a different reason, the non-stiff branch must run at
+    base tolerance, not inherit the stiff relaxation; its own purpose is more
+    resolution, not looser tolerance. This scripts three stalls then non-stiff
+    failures. Attempt 4 still runs the relaxation set by attempt 3's stall,
+    because the switch is only seen when attempt 4 fails, so attempts 5-8 must
+    be back at base rtol and base max_steps. A mutant that omits the base
+    restore on the non-stiff branch leaves those attempts relaxed and fails here.
+    """
+    scripted = [_retry_out(-1, cvode_flag=-1, cvode_flag_name='TOO_MUCH_WORK')] * 3 + [
+        _retry_out(-1, cvode_flag=0, cvode_flag_name='')
+    ] * 6
+    solver, calls = _retry_solver(scripted)
+    runner, interior_o, hf_row = _retry_runner(solver, monkeypatch)
+    with pytest.raises(RuntimeError):
+        runner._solve_with_retry(hf_row, interior_o)
+
+    assert solver.solve.call_count == 8
+    for k in range(4, 8):
+        np.testing.assert_allclose(
+            calls[k]['rtol'], _RETRY_BASE_RTOL, err_msg=f'attempt {k + 1} rtol'
+        )
+        assert calls[k]['max_steps'] == _RETRY_BASE_MAX_STEPS, f'attempt {k + 1} max_steps'


### PR DESCRIPTION
## Description

The Aragog entropy solver now recovers from a CVODE `CV_TOO_MUCH_WORK` return by relaxing `rtol` and raising the step budget, rather than only halving the timestep. The 3.02 Mearth mush stall came from the solver exhausting its step budget on a stiff mush transient, and timestep halving alone did not clear it. This builds on the aragog #27 enablers (the per-step `out.cvode_flag` and the step-budget controls) now in fwl-aragog.

How it works:

- On `CV_TOO_MUCH_WORK` specifically, the retry relaxes `rtol` and raises `max_steps` along a bounded ramp; other CVODE failure modes keep timestep halving as before.
- The ramp has a stiff branch (timestep halving, indexed on the number of stiff attempts) and a non-stiff branch (`atol_sf`/timestep ramp, indexed on the number of non-stiff attempts). The caps and the rung count come from one ordered source, so adding a rung cannot silently skip a cap.
- Every accepted attempt passes a sanity guard: a solve whose `T_core` jump exceeds a mass-scaled bound is rejected, and a non-finite `T_core` is rejected unconditionally, including on the first solve where no jump reference exists.

The per-attempt guard checks `T_core`-jump plausibility only. Energy conservation is recorded in the coupler-level `E_residual_cons_frac` diagnostic column, which is not asserted per run.

Three follow-ups are noted in the code and left for later: a per-attempt bounds check on the spatially resolved mush state (melt fraction, temperature); a reproducing test and a `docs/Validation` note for the `rtol` cap; and the rationale for keeping the widened step budget after a later non-stiff failure.

## Validation of changes

macOS, Python 3.12 (conda). `tests/interior_energetics/test_aragog.py` 33/33 and `test_timestep*.py` 49/49 pass; the full unit tier runs 3129 passed, 11 skipped. `ruff check` and `ruff format --check` are clean. The new tests cover the stiff and non-stiff ramp schedules, the atol freeze on the stiff branch, and the non-finite `T_core` rejection on the first solve.

The `rtol` relaxation was spot-checked on the conservation diagnostic: at 10x `rtol` it moves `E_residual_cons_frac` from 1.46e-4 to 1.53e-4, about 65x below its roughly 1% scale.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
