### PR TITLE
Demote interior init-condition info logs to debug

### DIFF
--- a/src/proteus/interior_energetics/spider.py
+++ b/src/proteus/interior_energetics/spider.py
@@ -870,7 +870,7 @@ def _try_spider(
     # then FWL_DATA, then SPIDER local as final fallback.
     if dirs.get('spider_eos_dir') and os.path.isdir(dirs['spider_eos_dir']):
         eos_dir = dirs['spider_eos_dir']
-        log.info('Using Zalmoxis-generated SPIDER EOS tables from %s', eos_dir)
+        log.debug('Using Zalmoxis-generated SPIDER EOS tables from %s', eos_dir)
     else:
         if config.interior_struct.eos_dir is None:
             raise FileNotFoundError(

--- a/src/proteus/interior_energetics/wrapper.py
+++ b/src/proteus/interior_energetics/wrapper.py
@@ -1883,7 +1883,7 @@ def run_interior(
 
     # Use the appropriate interior model
     if verbose:
-        log.info('Evolve interior...')
+        log.debug('Evolve interior...')
     log.debug('Using %s module to evolve interior' % config.interior_energetics.module)
 
     # Write tidal heating file

--- a/tests/interior_energetics/test_spider.py
+++ b/tests/interior_energetics/test_spider.py
@@ -1149,6 +1149,50 @@ def test_try_spider_rho_core_from_zalmoxis(tmp_path):
 
 
 @pytest.mark.unit
+def test_try_spider_zalmoxis_eos_dir_logs_at_debug(tmp_path, caplog):
+    """_try_spider logs the Zalmoxis-generated EOS table path at debug level.
+
+    This line fires on every timestep when Zalmoxis provides a per-run EOS
+    directory, so it must stay off the default INFO output (#839).
+    """
+    from proteus.interior_energetics.spider import _try_spider
+
+    dirs, config, hf_row, eos_base, mc_base, mesh_path = _setup_spider_env(
+        tmp_path, with_mesh=True
+    )
+    dirs['spider_eos_dir'] = os.path.join(eos_base, 'WolfBower2018_MgSiO3', 'P-S')
+
+    with (
+        patch('proteus.interior_energetics.spider.EOS_DYNAMIC_DIR', eos_base),
+        patch('proteus.interior_energetics.spider.MELTING_CURVES_DIR', mc_base),
+        patch('proteus.interior_energetics.spider.sp.run') as mock_run,
+        patch(
+            'proteus.interior_energetics.common.compute_initial_entropy',
+            return_value=3000.0,
+        ),
+        caplog.at_level('DEBUG', logger='fwl.proteus.interior_energetics.spider'),
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        _try_spider(
+            dirs,
+            config,
+            IC_INTERIOR=1,
+            hf_all=None,
+            hf_row=hf_row,
+            step_sf=1.0,
+            atol_sf=1.0,
+            dT_max=1000.0,
+            mesh_file=mesh_path,
+        )
+
+    zalmoxis_records = [
+        r for r in caplog.records if 'Zalmoxis-generated SPIDER EOS tables' in r.message
+    ]
+    assert len(zalmoxis_records) == 1
+    assert zalmoxis_records[0].levelname == 'DEBUG'
+
+
+@pytest.mark.unit
 def test_try_spider_init_aw(tmp_path):
     """_try_spider with IC_INTERIOR=1, no mesh file (Adams-Williamson mode).
 

--- a/tests/interior_energetics/test_wrapper.py
+++ b/tests/interior_energetics/test_wrapper.py
@@ -2252,6 +2252,44 @@ def test_run_interior_non_boundary_module_shares_dT_delta_between_caps():
     assert hf_row['T_surf'] == pytest.approx(2820.0)
 
 
+@pytest.mark.unit
+def test_run_interior_evolve_message_is_debug_not_info(caplog):
+    """The per-step 'Evolve interior...' announcement stays off the default
+    INFO output: it fires on every timestep, so it belongs at debug (#839)."""
+    from proteus.interior_energetics.wrapper import run_interior
+
+    config = _make_run_interior_config(prevent_warming=False, module='dummy')
+    hf_all, hf_row = _make_run_interior_state(prev_f_int=0.2)
+    hf_row['RF_depth'] = 0.5
+    out = {
+        'T_magma': 3005.0,
+        'T_surf': 2805.0,
+        'Phi_global': 0.7,
+        'F_int': 0.15,
+        'M_mantle': 4.0e24,
+        'M_mantle_liquid': 1.0e24,
+        'M_mantle_solid': 3.0e24,
+        'M_core': 2.0e24,
+    }
+    interior_o = MagicMock(spec=Interior_t)
+    interior_o.ic = 2
+    atmos_o = MagicMock()
+
+    with (
+        patch(
+            'proteus.interior_energetics.dummy.run_dummy_int',
+            return_value=(110.0, out),
+        ),
+        patch('proteus.interior_energetics.wrapper.update_planet_mass'),
+        caplog.at_level(logging.DEBUG, logger='fwl.proteus.interior_energetics.wrapper'),
+    ):
+        run_interior({}, config, hf_all, hf_row, interior_o, atmos_o, verbose=True)
+
+    evolve_records = [r for r in caplog.records if 'Evolve interior' in r.getMessage()]
+    assert len(evolve_records) == 1
+    assert evolve_records[0].levelname == 'DEBUG'
+
+
 # ============================================================================
 # determine_interior_radius: tolerance_struct + maxiter + initial bracket
 # ============================================================================


### PR DESCRIPTION
## Description
The interior evolve-step announcement and the Zalmoxis EOS-table source line both fire on every timestep, so they belong at debug level rather than info. This demotes both lines.

Closes #839

## Validation of changes
Added a unit test for each line confirming it now logs at debug level. I reverted each line to info, confirmed both tests fail with an assertion on the log level, then restored the fix and reran to confirm they pass. Ran the full interior_energetics test suite: 187 passed, 7 skipped (pre-existing, unrelated).

Test configuration: macOS, Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
