### PR TITLE
Take netcdf-fortran from conda in the Kapteyn guide

### DIFF
--- a/docs/How-to/kapteyn_cluster_guide.md
+++ b/docs/How-to/kapteyn_cluster_guide.md
@@ -61,13 +61,16 @@ Follow the instructions at [VS Code Instructions Kapteyn Cluster](https://docs.g
     source "$HOME/.bashrc"
     ```
 
-5. You can now follow the usual installation steps [here](installation.md), but, since your home folder is capped
-   at 9GB, you need to install Julia and miniconda or conda-forge in "/dataserver/users/formingworlds/<username>".
+5. Install conda and create the PROTEUS environment, by following the
+   [installation steps](installation.md) up to and including
+   `conda activate proteus`. Since your home folder is capped at 9GB, install
+   Julia and miniconda or conda-forge in "/dataserver/users/formingworlds/<username>"
+   rather than in the default location. See [Julia considerations](#julia-considerations)
+   and [Miniconda and conda-forge considerations](#miniconda-and-conda-forge-considerations)
+   below.
 
-    The Kapteyn module system does not provide NetCDF-Fortran, which SOCRATES
-    needs both to build and to run, so take it from conda-forge instead. Run
-    these commands once the conda environment exists, and before you build
-    SOCRATES:
+6. Install NetCDF-Fortran into that environment. The Kapteyn module system
+   does not provide it, and SOCRATES needs it both to build and to run:
     ```console
     conda install -c conda-forge netcdf-fortran
     conda env config vars set LD_LIBRARY_PATH="$CONDA_PREFIX/lib"
@@ -79,6 +82,9 @@ Follow the instructions at [VS Code Instructions Kapteyn Cluster](https://docs.g
     of its own. Without the variable SOCRATES still compiles, and the binaries
     it produces then fail with `libnetcdff.so.7: cannot open shared object
     file`.
+
+7. You can now run the installer and complete the remaining
+   [installation steps](installation.md).
 
 ### Julia considerations
 If you have already installed Julia in your home folder, you could remove that through `rm -rf ~/.julia`.

--- a/docs/How-to/kapteyn_cluster_guide.md
+++ b/docs/How-to/kapteyn_cluster_guide.md
@@ -51,15 +51,7 @@ Follow the instructions at [VS Code Instructions Kapteyn Cluster](https://docs.g
     cd /dataserver/users/formingworlds/<username>
     ```
 
-4. Configure the system environment. The Kapteyn cluster provides NetCDF
-   and other libraries via the module system. Add the following to your
-   `~/.bashrc` so the correct modules are loaded on every login:
-    ```console
-    echo "module purge" >> "$HOME/.bashrc"
-    echo "module load netcdf-fortran" >> "$HOME/.bashrc"
-    ```
-
-5. To avoid the cluster terminating PROTEUS jobs, increase the temporary file limit:
+4. To avoid the cluster terminating PROTEUS jobs, increase the temporary file limit:
     ```console
     echo "ulimit -Sn 4000000" >> "$HOME/.bashrc"
     echo "ulimit -Hn 5000000" >> "$HOME/.bashrc"
@@ -69,8 +61,24 @@ Follow the instructions at [VS Code Instructions Kapteyn Cluster](https://docs.g
     source "$HOME/.bashrc"
     ```
 
-6. You can now follow the usual installation steps [here](installation.md), but, since your home folder is capped
+5. You can now follow the usual installation steps [here](installation.md), but, since your home folder is capped
    at 9GB, you need to install Julia and miniconda or conda-forge in "/dataserver/users/formingworlds/<username>".
+
+    The Kapteyn module system does not provide NetCDF-Fortran, which SOCRATES
+    needs both to build and to run, so take it from conda-forge instead. Run
+    these commands once the conda environment exists, and before you build
+    SOCRATES:
+    ```console
+    conda install -c conda-forge netcdf-fortran
+    conda env config vars set LD_LIBRARY_PATH="$CONDA_PREFIX/lib"
+    conda activate proteus
+    ```
+    The last command reactivates the environment so that the variable takes
+    effect. Setting `LD_LIBRARY_PATH` is necessary because SOCRATES links
+    against the absolute path that `nf-config` reports but records no run path
+    of its own. Without the variable SOCRATES still compiles, and the binaries
+    it produces then fail with `libnetcdff.so.7: cannot open shared object
+    file`.
 
 ### Julia considerations
 If you have already installed Julia in your home folder, you could remove that through `rm -rf ~/.julia`.
@@ -226,16 +234,33 @@ This displays the jobs currently running on Condormaster, including both your jo
 
 ### NetCDF Error
 
-SOCRATES is using the NetCDF version installed by Python in your PROTEUS environment instead of the NetCDF version installed on the Kapteyn cluster system.
+Either the SOCRATES build stops with `ERROR: NetCDF-Fortran library is not
+installed`, or a run fails with `libnetcdff.so.7: cannot open shared object
+file`.
 
-To resolve this issue:
+The cluster provides no NetCDF-Fortran of its own, so both the library and the
+path to it come from your conda environment. Check that the environment is
+active and that it supplies them:
 
-1. Deactivate all conda environments.
-2. Go to the PROTEUS folder : `cd PROTEUS/`
-3. Delete the `socrates/` directory using `rm -r socrates/`
-4. Run the `./tools/get_socrates.sh` command to download SOCRATES again, ensuring this is done OUTSIDE of any conda environment.
-5. Execute the `cat socrates/set_rad_env` command to verify that SOCRATES is pointing to the correct NetCDF version (i.e. the NetCDF version installed on the Kapteyn cluster system).
-6. Finally, run a PROTEUS simulation using the `dummy.toml` configuration file to confirm it is working correctly.
+```console
+conda activate proteus
+nf-config --flibs
+echo $LD_LIBRARY_PATH
+```
+
+`nf-config` should report a `-L` path inside your conda environment, and
+`LD_LIBRARY_PATH` should contain that same environment's `lib` directory. If
+either is missing, apply the NetCDF-Fortran installation step from the
+[installation section](#installation) above and reactivate the environment.
+
+To check that an existing SOCRATES build can find the library at run time:
+
+```console
+ldd $RAD_DIR/bin/l_run_cdf | grep netcdff
+```
+
+A working installation prints a path to `libnetcdff.so`; a broken one prints
+`not found`.
 
 ### Error reporting
 

--- a/install.sh
+++ b/install.sh
@@ -504,9 +504,12 @@ if ! command_exists unzip; then
     missing_deps+=("unzip")
 fi
 
-# NetCDF (needed for SOCRATES)
-if ! command_exists nc-config && ! command_exists nf-config; then
+# NetCDF (needed for SOCRATES, which uses the C and the Fortran interface)
+if ! command_exists nc-config; then
     missing_deps+=("netcdf-dev")
+fi
+if ! command_exists nf-config; then
+    missing_deps+=("netcdf-fortran-dev")
 fi
 
 if [ ${#missing_deps[@]} -gt 0 ]; then

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 from helpers import PROTEUS_ROOT
@@ -93,6 +94,45 @@ class TestInstallerArgParsing:
         assert 'Unknown argument' in bogus.stdout + bogus.stderr
 
 
+def _bin_dir_without(tmp_path, omitted: set[str]) -> Path:
+    """Mirror every executable on PATH into a fresh directory, minus `omitted`.
+
+    Lets a test run the installer as if the host lacked one specific tool,
+    without disturbing anything else the pre-flight checks need.
+    """
+    bindir = tmp_path / 'bin'
+    bindir.mkdir()
+    for entry in os.environ['PATH'].split(os.pathsep):
+        source = Path(entry)
+        if not source.is_dir():
+            continue
+        for exe in source.iterdir():
+            if exe.name in omitted or (bindir / exe.name).exists():
+                continue
+            try:
+                if exe.is_file() and os.access(exe, os.X_OK):
+                    (bindir / exe.name).symlink_to(exe)
+            except OSError:
+                continue
+    return bindir
+
+
+def _run_preflight(bindir: Path) -> str:
+    """Run install.sh with PATH restricted to `bindir`; return its combined output."""
+    env = os.environ.copy()
+    env['PATH'] = str(bindir)
+    env.setdefault('CONDA_DEFAULT_ENV', 'proteus')
+    result = subprocess.run(
+        ['bash', str(INSTALL_SH)],
+        capture_output=True,
+        text=True,
+        timeout=25,
+        env=env,
+        cwd=str(PROTEUS_ROOT),
+    )
+    return result.stdout + result.stderr
+
+
 class TestPreflightChecks:
     """Verify pre-flight check failure modes."""
 
@@ -138,6 +178,32 @@ class TestPreflightChecks:
         assert result.returncode != 0
         output = result.stdout + result.stderr
         assert 'pyproject.toml' in output or 'repository root' in output.lower()
+
+    def test_netcdf_fortran_required_even_when_c_interface_present(self, tmp_path):
+        """A host with nc-config but no nf-config is rejected at pre-flight.
+
+        SOCRATES needs the Fortran interface, so the C interface alone is not
+        enough. Discrimination: the check previously accepted either tool, so
+        on such a host it reported nothing missing and the build failed many
+        phases later with a far less obvious message. Requiring the Fortran
+        package to be named, and the C package not to be, fails against that
+        earlier logic rather than merely restating it.
+        """
+        output = _run_preflight(_bin_dir_without(tmp_path, {'nf-config'}))
+        assert 'Missing system packages' in output
+        assert 'netcdf-fortran-dev' in output
+        assert 'netcdf-dev' not in output
+
+    def test_both_netcdf_interfaces_named_when_both_absent(self, tmp_path):
+        """With neither tool present, both packages are named.
+
+        The opposite boundary from the test above. Reporting only one would
+        send a user who installs it round the same failure a second time.
+        """
+        output = _run_preflight(_bin_dir_without(tmp_path, {'nc-config', 'nf-config'}))
+        assert 'Missing system packages' in output
+        assert 'netcdf-dev' in output
+        assert 'netcdf-fortran-dev' in output
 
 
 def _echo_e_lines(content: str) -> list[int]:


### PR DESCRIPTION
## Description

The Kapteyn module system no longer provides NetCDF-Fortran. `module load netcdf-fortran` fails with `Unable to locate a modulefile`, no modulefile matches `netcdf` or `hdf`, and there is no `nf-config` on `PATH`. PROTEUS therefore cannot be installed by following the guide.

Take the library from conda-forge instead, and set `LD_LIBRARY_PATH` on the conda environment. Both steps are needed: SOCRATES builds against the absolute path `nf-config` reports, but records no run path, so its binaries fail at run time without the variable.

The `NetCDF Error` troubleshooting entry told the reader to rebuild SOCRATES outside conda against the system NetCDF. That now deletes a working checkout and cannot rebuild it, so it is replaced with conda-based checks.

Also fixes the installer pre-flight check, which accepted either `nc-config` or `nf-config` where SOCRATES needs both. On a host carrying only the C interface it reported `System dependencies: OK` and then failed in Phase 4 with `ERROR: NetCDF-Fortran library is not installed`. Kapteyn is such a host.

Habrok and Snellius are untouched.

## Validation of changes

Clean clone of `main` at `ecdfed28` on eddington (Rocky Linux 9.8, x86_64, gfortran 11.5.0, Julia 1.11.9), fresh conda environment created as the guide now describes.

- `bash install.sh --no-data` completes, all 8 phases
- `ldd socrates/bin/l_run_cdf`: `libnetcdff.so.7 => not found` without the variable, resolves to the environment's `lib` with it
- `proteus doctor`: `All checks passed`, reports `SOCRATES: 2603.10 (c3296586)`
- `pytest -m "unit and not skip and not slow and not integration" --ignore=tests/examples`: 3001 passed, 41 skipped
- `PROTEUS_CI_NIGHTLY=1 pytest tests/integration/test_integration_agni_transparent_limit.py tests/integration/test_integration_agni_greygas_interior.py`: 4 passed, including the banded case, which is the only one that runs the SOCRATES binaries

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

Two tests cover the pre-flight fix: one host with `nc-config` but no `nf-config`, one with neither. Both fail against the previous logic.
