### PR TITLE
Require aragog 26.09.10 for the refined entropy solve

### DIFF
--- a/docs/Reference/module_versions.md
+++ b/docs/Reference/module_versions.md
@@ -22,7 +22,7 @@ in `[project] dependencies`. Click a badge to view the pinned release.
 | fwl-mors | Stellar evolution | [![fwl-mors](https://img.shields.io/badge/fwl--mors-%3E%3D26.01.02-blue)](https://pypi.org/project/fwl-mors/26.01.02/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/MORS/) |
 | fwl-calliope | Volatile outgassing | [![fwl-calliope](https://img.shields.io/badge/fwl--calliope-%3E%3D26.06.01-blue)](https://pypi.org/project/fwl-calliope/26.06.01/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/CALLIOPE/) |
 | fwl-zephyrus | Atmospheric escape | [![fwl-zephyrus](https://img.shields.io/badge/fwl--zephyrus-%3E%3D25.03.11-blue)](https://pypi.org/project/fwl-zephyrus/25.03.11/){target="_blank" rel="noopener"} | [GitHub](https://github.com/FormingWorlds/ZEPHYRUS) |
-| fwl-aragog | Interior thermal evolution | [![fwl-aragog](https://img.shields.io/badge/fwl--aragog-%3E%3D26.09.09-blue)](https://pypi.org/project/fwl-aragog/26.09.09/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/aragog/) |
+| fwl-aragog | Interior thermal evolution | [![fwl-aragog](https://img.shields.io/badge/fwl--aragog-%3E%3D26.09.10-blue)](https://pypi.org/project/fwl-aragog/26.09.10/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/aragog/) |
 | fwl-zalmoxis | Interior structure | [![fwl-zalmoxis](https://img.shields.io/badge/fwl--zalmoxis-%3E%3D26.07.17-blue)](https://pypi.org/project/fwl-zalmoxis/26.07.17/){target="_blank" rel="noopener"} | [Docs](https://proteus-framework.org/Zalmoxis/) |
 <!-- END PYPI_TABLE -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "fwl-mors>=26.01.02",
     "fwl-calliope>=26.06.01",
     "fwl-zephyrus>=25.03.11",
-    "fwl-aragog>=26.09.09",
+    "fwl-aragog>=26.09.10",
     # 26.07.17 reads the liquid EOS table for fully molten entropy
     # lookups, which the super-liquidus interior initial condition
     # requires (Zalmoxis #79), on top of the JAX structure path for


### PR DESCRIPTION
## Description

Raise the minimum `fwl-aragog` version from `26.09.09` to `26.09.10`.

Aragog 26.09.10 refines the entropy solve: it flags entropy that leaves the pressure-entropy table instead of silently clamping it, and it reports mantle mass split into melt and solid against the total. Raising the floor makes every environment and CI run pick up this behaviour, so results stay reproducible.

## Validation of changes

I installed `fwl-aragog` 26.9.10 and ran `proteus start` on three configurations. All three completed with converged Zalmoxis interior solves and no new errors from the entropy-range check.

Test configuration: macOS, Python 3.12, aragog 26.9.10.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required
